### PR TITLE
fix: disable blueprint routes in production

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -60,6 +60,11 @@ module.exports = {
       'https://beta.cuttle.cards',
     ],
   },
+
+  blueprints: {
+    rest: false,
+    shortcuts: false,
+  },
   /***************************************************************************
    * Set the log level in production environment to "silent"                 *
    ***************************************************************************/


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
This PR fixes a security flaw where sails [blueprint routes](https://sailsjs.com/documentation/concepts/blueprints) are exposed in production. Thankfully security policies on the user controller made this not as heinous as it could have been, but it facilitates cheating as well as scraping. For (horrifying) reference, check out: https://www.cuttle.cards/game

