### PR TITLE
Add player usernames to GameView

### DIFF
--- a/client/js/components/GameView/UsernameToolTip.vue
+++ b/client/js/components/GameView/UsernameToolTip.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <div class="username-container__outer" :class="{ 'username-container__outer--rtl': !isPlayer }">
-      <div class="username-container">
-        <h4 class="truncate" :data-cy="dataCyProp">{{ username }}</h4>
+    <div class="username__outer" :class="{ 'username__outer--rtl': !isPlayer }">
+      <div class="username">
+        <h4 class="username__text" :data-cy="dataCyProp">{{ username }}</h4>
       </div>
     </div>
   </div>
@@ -30,7 +30,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.username-container {
+.username {
   /* Change this to see truncation */
   background-color: transparent;
   padding: 1em;
@@ -39,27 +39,28 @@ export default {
 
   &__outer {
     width: auto;
+
+    &--rtl {
+      direction: rtl;
+    }
   }
 
-  &__outer--rtl {
-    direction: rtl;
+  &__text {
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    width: 100%;
+    transition: 0.25s all ease-in-out;
+
+    .username:hover & {
+      width: fit-content;
+    }
   }
 
   &:hover {
     background-color: rgba(0, 0, 0, 0.75);
-    width: fit-content;
-  }
-}
-.truncate {
-  margin: 0;
-  padding: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  width: 100%;
-  transition: 0.25s all ease-in-out;
-
-  .username-container:hover & {
     width: fit-content;
   }
 }

--- a/client/js/components/GameView/UsernameToolTip.vue
+++ b/client/js/components/GameView/UsernameToolTip.vue
@@ -40,9 +40,6 @@ export default {
   &__outer {
     width: auto;
 
-    &--rtl {
-      direction: rtl;
-    }
   }
 
   &__text {

--- a/client/js/components/GameView/UsernameToolTip.vue
+++ b/client/js/components/GameView/UsernameToolTip.vue
@@ -39,7 +39,6 @@ export default {
 
   &__outer {
     width: auto;
-
   }
 
   &__text {

--- a/client/js/components/GameView/UsernameToolTip.vue
+++ b/client/js/components/GameView/UsernameToolTip.vue
@@ -1,11 +1,10 @@
 <template>
   <div>
-    <v-tooltip :top="isPlayer" :bottom="!isPlayer">
-      <template #activator="{ on, attrs }">
-        <h4 :data-cy="dataCyProp" v-bind="attrs" v-on="on">{{ formattedUsername }}</h4>
-      </template>
-      <span>{{ username }}</span>
-    </v-tooltip>
+    <div class="username-container__outer" :class="{ 'username-container__outer--rtl': !isPlayer }">
+      <div class="username-container">
+        <h4 class="truncate" :data-cy="dataCyProp">{{ username }}</h4>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -26,11 +25,42 @@ export default {
     dataCyProp() {
       return this.isPlayer ? 'player-username' : 'opponent-username';
     },
-    formattedUsername() {
-      return this.username.length < 13 ? this.username : `${this.username.slice(0, 12)}...`;
-    },
   },
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.username-container {
+  /* Change this to see truncation */
+  background-color: transparent;
+  padding: 1em;
+  transition: 0.25s all ease-in-out;
+  white-space: nowrap;
+
+  &__outer {
+    width: auto;
+  }
+
+  &__outer--rtl {
+    direction: rtl;
+  }
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.75);
+    width: fit-content;
+  }
+}
+.truncate {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 100%;
+  transition: 0.25s all ease-in-out;
+
+  .username-container:hover & {
+    width: fit-content;
+  }
+}
+</style>

--- a/client/js/components/GameView/UsernameToolTip.vue
+++ b/client/js/components/GameView/UsernameToolTip.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="username__outer" :class="{ 'username__outer--rtl': !isPlayer }">
+    <div class="username__outer">
       <div class="username">
         <h4 class="username__text" :data-cy="dataCyProp">{{ username }}</h4>
       </div>

--- a/client/js/components/GameView/UsernameToolTip.vue
+++ b/client/js/components/GameView/UsernameToolTip.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <v-tooltip :top="isPlayer" :bottom="!isPlayer">
+      <template #activator="{ on, attrs }">
+        <h4 :data-cy="dataCyProp" v-bind="attrs" v-on="on">{{ formattedUsername }}</h4>
+      </template>
+      <span>{{ username }}</span>
+    </v-tooltip>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UsernameToolTip',
+  props: {
+    username: {
+      required: true,
+      type: String,
+    },
+    isPlayer: {
+      default: false,
+      type: Boolean,
+    },
+  },
+  computed: {
+    dataCyProp() {
+      return this.isPlayer ? 'player-username' : 'opponent-username';
+    },
+    formattedUsername() {
+      return this.username.length < 13 ? this.username : `${this.username.slice(0, 12)}...`;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/client/js/views/GameView.vue
+++ b/client/js/views/GameView.vue
@@ -16,6 +16,7 @@
         class="d-flex flex-column justify-start align-center px-2 pb-2 mx-auto"
       >
         <div class="user-cards-grid-container">
+          <username-tool-tip id="opponent-username-container" :username="opponentUsername" />
           <div class="opponent-cards-container">
             <div id="opponent-hand-cards" class="d-flex justify-center align-start">
               <transition name="slide-below" mode="out-in">
@@ -56,7 +57,6 @@
               </transition>
             </div>
           </div>
-          <username-tool-tip id="opponent-username-container" :username="opponentUsername" />
         </div>
         <h3 id="opponent-score">
           <span>POINTS: {{ opponentPointTotal }}</span>
@@ -1215,6 +1215,8 @@ export default {
 #game-menu-wrapper {
   position: absolute;
   display: inline-block;
+  right: 0;
+  margin: 10px;
 }
 
 .valid-move {

--- a/client/js/views/GameView.vue
+++ b/client/js/views/GameView.vue
@@ -9,6 +9,9 @@
       <div id="game-menu-wrapper">
         <game-menu />
       </div>
+
+      <username-tool-tip id="opponent-username-container" :username="opponentUsername" />
+
       <!-- Opponent Hand -->
       <div
         id="opponent-hand"
@@ -60,7 +63,6 @@
             :is-player="false"
           />
         </h3>
-        <h4 data-cy="opponent-username">{{ opponentUsername }}</h4>
       </div>
       <!-- Field -->
       <div id="field" class="d-flex justify-center align-center p-2 mx-auto">
@@ -210,7 +212,6 @@
       </div>
       <!-- Player Hand -->
       <div id="player-hand" class="d-flex flex-column justify-end align-center px-2 pt-2 mx-auto">
-        <h4 data-cy="player-username">{{ playerUsername }}</h4>
         <h3 id="player-score">
           <span>POINTS: {{ playerPointTotal }}</span>
           <score-goal-tool-tip
@@ -255,6 +256,11 @@
           :is-players-turn="isPlayersTurn"
           :move-display-name="targetingMoveDisplayName"
           @cancel="clearSelection"
+        />
+        <username-tool-tip
+          id="player-username-container"
+          :username="playerUsername"
+          :is-player="true"
         />
       </div>
       <v-snackbar
@@ -360,6 +366,7 @@ import SevenDoubleJacksDialog from '@/components/GameView/SevenDoubleJacksDialog
 import MoveChoiceOverlay from '@/components/GameView/MoveChoiceOverlay.vue';
 import TargetSelectionOverlay from '@/components/GameView/TargetSelectionOverlay.vue';
 import ScrapDialog from '@/components/GameView/ScrapDialog';
+import UsernameToolTip from '@/components/GameView/UsernameToolTip';
 
 export default {
   name: 'GameView',
@@ -377,6 +384,7 @@ export default {
     MoveChoiceOverlay,
     TargetSelectionOverlay,
     ScrapDialog,
+    UsernameToolTip,
   },
   data() {
     return {
@@ -1379,5 +1387,17 @@ export default {
       border: 4px solid transparent;
     }
   }
+}
+
+#opponent-username-container {
+  position: absolute;
+  margin: 8px;
+  right: 0px;
+}
+
+#player-username-container {
+  position: absolute;
+  margin: 10px 18px;
+  left: 0px;
 }
 </style>

--- a/client/js/views/GameView.vue
+++ b/client/js/views/GameView.vue
@@ -60,6 +60,7 @@
             :is-player="false"
           />
         </h3>
+        <h4 data-cy="opponent-username">{{ opponentUsername }}</h4>
       </div>
       <!-- Field -->
       <div id="field" class="d-flex justify-center align-center p-2 mx-auto">
@@ -209,6 +210,7 @@
       </div>
       <!-- Player Hand -->
       <div id="player-hand" class="d-flex flex-column justify-end align-center px-2 pt-2 mx-auto">
+        <h4 data-cy="player-username">{{ playerUsername }}</h4>
         <h3 id="player-score">
           <span>POINTS: {{ playerPointTotal }}</span>
           <score-goal-tool-tip
@@ -449,6 +451,12 @@ export default {
     },
     opponent() {
       return this.$store.getters.opponent;
+    },
+    opponentUsername() {
+      return this.opponent.username;
+    },
+    playerUsername() {
+      return this.player.username;
     },
     //////////////////
     // Point Totals //

--- a/client/js/views/GameView.vue
+++ b/client/js/views/GameView.vue
@@ -10,52 +10,55 @@
         <game-menu />
       </div>
 
-      <username-tool-tip id="opponent-username-container" :username="opponentUsername" />
-
       <!-- Opponent Hand -->
       <div
         id="opponent-hand"
         class="d-flex flex-column justify-start align-center px-2 pb-2 mx-auto"
       >
-        <div id="opponent-hand-cards" class="d-flex justify-center align-start">
-          <transition name="slide-below" mode="out-in">
-            <transition-group
-              v-if="hasGlassesEight"
-              id="opponent-hand-glasses"
-              key="opponent-hand-glasses"
-              class="opponent-hand-wrapper transition-all"
-              tag="div"
-              name="slide-below"
-            >
-              <card
-                v-for="card in opponent.hand"
-                :key="card.id"
-                :suit="card.suit"
-                :rank="card.rank"
-                :data-opponent-hand-card="`${card.rank}-${card.suit}`"
-                class="transition-all opponent-hand-card-revealed"
-              />
-            </transition-group>
-            <transition-group
-              v-else
-              key="opponent-hand"
-              tag="div"
-              name="slide-below"
-              class="opponent-hand-wrapper transition-all"
-            >
-              <div
-                v-for="(card, index) in opponent.hand"
-                :key="index + 0"
-                class="transition-all opponent-card-back-wrapper opponent-hand-card mx-2"
-              >
-                <v-card class="opponent-card-back" data-opponent-hand-card>
-                  <v-img :src="require('../img/logo_head.svg')" contain />
-                </v-card>
-              </div>
-            </transition-group>
-          </transition>
+        <div class="user-cards-grid-container">
+          <div class="opponent-cards-container">
+            <div id="opponent-hand-cards" class="d-flex justify-center align-start">
+              <transition name="slide-below" mode="out-in">
+                <transition-group
+                  v-if="hasGlassesEight"
+                  id="opponent-hand-glasses"
+                  key="opponent-hand-glasses"
+                  class="opponent-hand-wrapper transition-all"
+                  tag="div"
+                  name="slide-below"
+                >
+                  <card
+                    v-for="card in opponent.hand"
+                    :key="card.id"
+                    :suit="card.suit"
+                    :rank="card.rank"
+                    :data-opponent-hand-card="`${card.rank}-${card.suit}`"
+                    class="transition-all opponent-hand-card-revealed"
+                  />
+                </transition-group>
+                <transition-group
+                  v-else
+                  key="opponent-hand"
+                  tag="div"
+                  name="slide-below"
+                  class="opponent-hand-wrapper transition-all"
+                >
+                  <div
+                    v-for="(card, index) in opponent.hand"
+                    :key="index + 0"
+                    class="transition-all opponent-card-back-wrapper opponent-hand-card mx-2"
+                  >
+                    <v-card class="opponent-card-back" data-opponent-hand-card>
+                      <v-img :src="require('../img/logo_head.svg')" contain />
+                    </v-card>
+                  </div>
+                </transition-group>
+              </transition>
+            </div>
+          </div>
+          <username-tool-tip id="opponent-username-container" :username="opponentUsername" />
         </div>
-        <h3 id="opponent-score" class="mt-2">
+        <h3 id="opponent-score">
           <span>POINTS: {{ opponentPointTotal }}</span>
           <score-goal-tool-tip
             :king-count="opponentKingCount"
@@ -210,6 +213,7 @@
           </div>
         </div>
       </div>
+
       <!-- Player Hand -->
       <div id="player-hand" class="d-flex flex-column justify-end align-center px-2 pt-2 mx-auto">
         <h3 id="player-score">
@@ -227,26 +231,38 @@
             {{ turnText }}
           </span>
         </h3>
-
-        <transition-group
-          v-if="!targeting"
+        <div
           id="player-hand-cards"
-          tag="div"
-          name="slide-above"
-          class="d-flex justify-center align-start"
+          class="user-cards-grid-container"
           :class="{ 'my-turn': isPlayersTurn }"
         >
-          <card
-            v-for="(card, index) in player.hand"
-            :key="card.id"
-            :suit="card.suit"
-            :rank="card.rank"
-            :is-selected="selectedCard && card.id === selectedCard.id"
-            class="mt-8 transition-all"
-            :data-player-hand-card="`${card.rank}-${card.suit}`"
-            @click="selectCard(index)"
+          <username-tool-tip
+            id="player-username-container"
+            key="player-username"
+            :username="playerUsername"
+            :is-player="true"
           />
-        </transition-group>
+          <div class="player-cards-container">
+            <transition-group
+              v-if="!targeting"
+              tag="div"
+              name="slide-above"
+              class="d-flex justify-center align-start"
+              :class="{ 'my-turn': isPlayersTurn }"
+            >
+              <card
+                v-for="(card, index) in player.hand"
+                :key="card.id"
+                :suit="card.suit"
+                :rank="card.rank"
+                :is-selected="selectedCard && card.id === selectedCard.id"
+                class="mt-8 transition-all"
+                :data-player-hand-card="`${card.rank}-${card.suit}`"
+                @click="selectCard(index)"
+              />
+            </transition-group>
+          </div>
+        </div>
         <target-selection-overlay
           v-if="targeting && (selectedCard || cardSelectedFromDeck)"
           id="player-hand-targeting"
@@ -257,12 +273,8 @@
           :move-display-name="targetingMoveDisplayName"
           @cancel="clearSelection"
         />
-        <username-tool-tip
-          id="player-username-container"
-          :username="playerUsername"
-          :is-player="true"
-        />
       </div>
+
       <v-snackbar
         v-model="showSnack"
         :color="snackColor"
@@ -1389,15 +1401,34 @@ export default {
   }
 }
 
-#opponent-username-container {
-  position: absolute;
-  margin: 8px;
-  right: 0px;
+.user-cards-grid-container {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+}
+#player-username-container {
+  grid-column-end: span 2;
+  align-self: end;
+  margin-bottom: 15%;
+
+  &:hover {
+    z-index: 1;
+  }
 }
 
-#player-username-container {
-  position: absolute;
-  margin: 10px 18px;
-  left: 0px;
+.player-cards-container {
+  grid-column-start: 3;
+  grid-column-end: span 8;
+}
+
+#opponent-username-container {
+  grid-column-end: span 2;
+
+  &:hover {
+    z-index: 1;
+  }
+}
+.opponent-cards-container {
+  grid-column-start: 3;
+  grid-column-end: span 8;
 }
 </style>

--- a/tests/e2e/specs/in-game/layout.spec.js
+++ b/tests/e2e/specs/in-game/layout.spec.js
@@ -17,9 +17,9 @@ describe('Game View Layout', () => {
     cy.get('[data-cy=nav-drawer]').should('not.be.visible');
   });
 
-  it.only('Should display usernames of player and opponent', () => {
+  it('Should display usernames of player and opponent', () => {
     cy.get('[data-cy=opponent-username]').should('be.visible');
-    cy.get('[data-cy=username]').should('be.visible');
+    cy.get('[data-cy=player-username]').should('be.visible');
   });
 
   it('Many cards on field', () => {

--- a/tests/e2e/specs/in-game/layout.spec.js
+++ b/tests/e2e/specs/in-game/layout.spec.js
@@ -22,10 +22,6 @@ describe('Game View Layout', () => {
     cy.get('[data-cy=player-username]').should('be.visible');
   });
 
-  it('Should truncate usernames > 12 characters', () => {
-    cy.get('[data-cy=opponent-username]').should('have.text', 'definitelyNo...');
-  });
-
   it('Many cards on field', () => {
     // Set Up
     cy.loadGameFixture({

--- a/tests/e2e/specs/in-game/layout.spec.js
+++ b/tests/e2e/specs/in-game/layout.spec.js
@@ -22,6 +22,10 @@ describe('Game View Layout', () => {
     cy.get('[data-cy=player-username]').should('be.visible');
   });
 
+  it('Should truncate usernames > 12 characters', () => {
+    cy.get('[data-cy=opponent-username]').should('have.text', 'definitelyNo...');
+  });
+
   it('Many cards on field', () => {
     // Set Up
     cy.loadGameFixture({

--- a/tests/e2e/specs/in-game/layout.spec.js
+++ b/tests/e2e/specs/in-game/layout.spec.js
@@ -17,6 +17,11 @@ describe('Game View Layout', () => {
     cy.get('[data-cy=nav-drawer]').should('not.be.visible');
   });
 
+  it.only('Should display usernames of player and opponent', () => {
+    cy.get('[data-cy=opponent-username]').should('be.visible');
+    cy.get('[data-cy=username]').should('be.visible');
+  });
+
   it('Many cards on field', () => {
     // Set Up
     cy.loadGameFixture({


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
This PR adds player usernames to the game view - the opponent's username should display below their score, and the player's username should display above their score.

**Test Steps**
* Add `.only` to the test statement added below in `layout.spec.js`
* Start cypress with `npm run e2e:gui`
* Select `layout.spec.js`
* When the test starts, you should see the two player usernames display
