### PR TITLE
Fixes target overlay border cutting through hand

### DIFF
--- a/client/js/views/GameView.vue
+++ b/client/js/views/GameView.vue
@@ -232,6 +232,7 @@
           </span>
         </h3>
         <div
+          v-if="!targeting"
           id="player-hand-cards"
           class="user-cards-grid-container"
           :class="{ 'my-turn': isPlayersTurn }"
@@ -244,7 +245,6 @@
           />
           <div class="player-cards-container">
             <transition-group
-              v-if="!targeting"
               tag="div"
               name="slide-above"
               class="d-flex justify-center align-start"


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
* Choose an action that will display the target overlay
* The target overlay should display as it did before without being pushed down

<img width="1322" alt="Screen Shot 2022-07-18 at 7 39 23 PM" src="https://user-images.githubusercontent.com/35972440/179635024-72f8fb43-a355-42e4-810b-5d38ddc84cef.png">

