### PR TITLE
Fix username flashing on hover and opponent's username position

### DIFF
--- a/client/js/components/GameView/UsernameToolTip.vue
+++ b/client/js/components/GameView/UsernameToolTip.vue
@@ -34,7 +34,6 @@ export default {
   /* Change this to see truncation */
   background-color: transparent;
   padding: 1em;
-  transition: 0.25s all ease-in-out;
   white-space: nowrap;
 
   &__outer {
@@ -49,10 +48,6 @@ export default {
     text-overflow: ellipsis;
     width: 100%;
     transition: 0.25s all ease-in-out;
-
-    .username:hover & {
-      width: fit-content;
-    }
   }
 
   &:hover {

--- a/client/js/components/GameView/UsernameToolTip.vue
+++ b/client/js/components/GameView/UsernameToolTip.vue
@@ -47,7 +47,6 @@ export default {
     white-space: nowrap;
     text-overflow: ellipsis;
     width: 100%;
-    transition: 0.25s all ease-in-out;
   }
 
   &:hover {

--- a/client/js/views/GameView.vue
+++ b/client/js/views/GameView.vue
@@ -1204,6 +1204,7 @@ export default {
 .user-cards-grid-container {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
+  width: 100%;
 }
 #player-username-container {
   grid-column-end: span 2;


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
* Open up a game
* Hover over a username - the username's background should longer flash to a bigger size when you hover away
* The opponent's username should remain in the upper left corner as their hand changes size

![username-flash](https://user-images.githubusercontent.com/35972440/182905711-8b1b4401-9026-4a0a-b05d-ff2b7ecfacb3.gif)

