### PR TITLE
Feat/request stalemate

### DIFF
--- a/api/controllers/game/stalemate-reject.js
+++ b/api/controllers/game/stalemate-reject.js
@@ -1,0 +1,30 @@
+module.exports = async function (req, res) {
+  try {
+    const game = await Game.findOne({ id: req.session.game }).populate('players');
+    let gameUpdates = {
+      turnStalemateWasRequestedByP0: -1,
+      turnStalemateWasRequestedByP1: -1,
+    };
+
+    const victory = {
+      gameOver: false,
+      winner: null,
+      conceded: false,
+    };
+
+    await Game.updateOne({ id: game.id }).set(gameUpdates);
+
+    Game.publish([game.id], {
+      verb: 'updated',
+      data: {
+        change: 'rejectStalemate',
+        game,
+        victory,
+        requestedByPNum: req.session.pNum,
+      },
+    });
+    return res.ok();
+  } catch (err) {
+    return res.badRequest(err);
+  }
+};

--- a/api/controllers/game/stalemate.js
+++ b/api/controllers/game/stalemate.js
@@ -46,6 +46,7 @@ module.exports = async function (req, res) {
         change: 'requestStalemate',
         game,
         victory,
+        requestedByPNum: req.session.pNum,
       },
     });
     return res.ok();

--- a/api/controllers/game/stalemate.js
+++ b/api/controllers/game/stalemate.js
@@ -1,35 +1,46 @@
 module.exports = async function (req, res) {
   try {
     const game = await Game.findOne({ id: req.session.game }).populate('players');
+    let gameUpdates = {};
+    const updatePromises = [];
+
     switch (req.session.pNum) {
-      case 0:
-        game.turnStalemateWasRequestedByP0 = game.turnStalemateWasRequestedByP0 ? game.turn : null;
+      case 0: {
+        const newVal = game.turnStalemateWasRequestedByP0 ? game.turn : null;
+        gameUpdates.turnStalemateWasRequestedByP0 = newVal;
+        game.turnStalemateWasRequestedByP0 = newVal;
         break;
-      case 1:
-        game.turnStalemateWasRequestedByP1 = game.turnStalemateWasRequestedByP1 ? game.turn : null;
+      }
+      case 1: {
+        const newVal = game.turnStalemateWasRequestedByP1 ? game.turn : null;
+        gameUpdates.turnStalemateWasRequestedByP1 = newVal;
+        game.turnStalemateWasRequestedByP1 = newVal;
+        break;
+      }
     }
     const victory = {
       gameOver: false,
       winner: null,
       conceded: false,
     };
+
     // End in stalemate if both players requested stalemate this turn
     if (
       game.turnStalemateWasRequestedByP0 === game.turnStalemateWasRequestedByP1 &&
       game.turnStalemateWasRequestedByP0 === game.turn
     ) {
       victory.gameOver = true;
-      const gameUpdates = {
+      gameUpdates = {
+        ...gameUpdates,
         p0: game.players[0].id,
         p1: game.players[1].id,
         result: gameService.GameResult.STALEMATE,
       };
-      await Promise.all([
-        Game.updateOne({ id: game.id }).set(gameUpdates),
-        gameService.clearGame({ userId: req.session.usr }),
-      ]);
+      updatePromises.push(gameService.clearGame({ userId: req.session.usr }));
     }
-    await Game.publish([game.id], {
+    updatePromises.push(Game.updateOne({ id: game.id }).set(gameUpdates));
+    await Promise.all(updatePromises);
+    Game.publish([game.id], {
       verb: 'updated',
       data: {
         change: 'requestStalemate',

--- a/api/controllers/game/stalemate.js
+++ b/api/controllers/game/stalemate.js
@@ -16,7 +16,7 @@ module.exports = async function (req, res) {
     // End in stalemate if both players requested stalemate this turn
     if (
       game.turnStalemateWasRequestedByP0 === game.turnStalemateWasRequestedByP1 &&
-      game.TurnStalemateWasRequestedByP0 === game.turn
+      game.turnStalemateWasRequestedByP0 === game.turn
     ) {
       victory.gameOver = true;
       const gameUpdates = {

--- a/api/controllers/game/stalemate.js
+++ b/api/controllers/game/stalemate.js
@@ -1,0 +1,44 @@
+module.exports = async function (req, res) {
+  try {
+    const game = await Game.findOne({ id: req.session.game }).populate('players');
+    switch (req.session.pNum) {
+      case 0:
+        game.turnStalemateWasRequestedByP0 = game.turnStalemateWasRequestedByP0 ? game.turn : null;
+        break;
+      case 1:
+        game.turnStalemateWasRequestedByP1 = game.turnStalemateWasRequestedByP1 ? game.turn : null;
+    }
+    const victory = {
+      gameOver: false,
+      winner: null,
+      conceded: false,
+    };
+    // End in stalemate if both players requested stalemate this turn
+    if (
+      game.turnStalemateWasRequestedByP0 === game.turnStalemateWasRequestedByP1 &&
+      game.TurnStalemateWasRequestedByP0 === game.turn
+    ) {
+      victory.gameOver = true;
+      const gameUpdates = {
+        p0: game.players[0].id,
+        p1: game.players[1].id,
+        result: gameService.GameResult.STALEMATE,
+      };
+      await Promise.all([
+        Game.updateOne({ id: game.id }).set(gameUpdates),
+        gameService.clearGame({ userId: req.session.usr }),
+      ]);
+    }
+    await Game.publish([game.id], {
+      verb: 'updated',
+      data: {
+        change: 'requestStalemate',
+        game,
+        victory,
+      },
+    });
+    return res.ok();
+  } catch (err) {
+    return res.badRequest(err);
+  }
+};

--- a/api/models/Game.js
+++ b/api/models/Game.js
@@ -76,7 +76,14 @@ module.exports = {
       columnType: 'text[]',
       defaultsTo: [],
     },
-
+    turnStalemateWasRequestedByP0: {
+      type: 'number',
+      defaultsTo: -1,
+    },
+    turnStalemateWasRequestedByP1: {
+      type: 'number',
+      defaultsTo: -1,
+    },
     chat: {
       type: 'ref',
       columnType: 'text[]',

--- a/client/js/components/GameView/GameDialogs.vue
+++ b/client/js/components/GameView/GameDialogs.vue
@@ -127,8 +127,13 @@ export default {
     stalemate() {
       return this.$store.state.game.gameIsOver && this.$store.state.game.winnerPNum === null;
     },
-    consideringOpponentStalemateRequest() {
-      return this.$store.state.game.consideringOpponentStalemateRequest;
+    consideringOpponentStalemateRequest: {
+      get() {
+        return this.$store.state.game.consideringOpponentStalemateRequest;
+      },
+      set(val) {
+        this.$store.commit('setConsideringOpponentStalemateRequest', val);
+      },
     },
     topCard() {
       return this.$store.state.game.topCard;

--- a/client/js/components/GameView/GameDialogs.vue
+++ b/client/js/components/GameView/GameDialogs.vue
@@ -33,6 +33,7 @@
     />
     <game-over-dialog v-model="gameIsOver" :player-wins="playerWins" :stalemate="stalemate" />
     <reauthenticate-dialog v-model="mustReauthenticate" />
+    <opponent-requested-stalemate-dialog v-model="consideringOpponentStalemateRequest" />
   </div>
 </template>
 
@@ -46,6 +47,7 @@ import GameOverDialog from '@/components/GameView/GameOverDialog.vue';
 import ReauthenticateDialog from '@/components/GameView/ReauthenticateDialog.vue';
 import SevenDoubleJacksDialog from '@/components/GameView/SevenDoubleJacksDialog.vue';
 import ThreeDialog from '@/components/GameView/ThreeDialog.vue';
+import OpponentRequestedStalemateDialog from './OpponentRequestedStalemateDialog.vue';
 
 export default {
   name: 'GameDialogs',
@@ -57,6 +59,7 @@ export default {
     ReauthenticateDialog,
     SevenDoubleJacksDialog,
     ThreeDialog,
+    OpponentRequestedStalemateDialog,
   },
   computed: {
     ...mapGetters([
@@ -123,6 +126,9 @@ export default {
     },
     stalemate() {
       return this.$store.state.game.gameIsOver && this.$store.state.game.winnerPNum === null;
+    },
+    consideringOpponentStalemateRequest() {
+      return this.$store.state.game.consideringOpponentStalemateRequest;
     },
     topCard() {
       return this.$store.state.game.topCard;

--- a/client/js/components/GameView/GameMenu.vue
+++ b/client/js/components/GameView/GameMenu.vue
@@ -115,7 +115,13 @@ export default {
     },
     async requestStalemate() {
       this.loading = true;
-      await this.$store.dispatch('requestStalemate');
+      try {
+        await this.$store.dispatch('requestStalemate');
+        this.$store.commit('setWaitingForOpponentToStalemate', true);
+      } catch (e) {
+        debugger;
+        this.$store.commit('setWaitingForOpponentToStalemate', false);
+      }
       this.showStalemateDialog = false;
     },
   },

--- a/client/js/components/GameView/GameMenu.vue
+++ b/client/js/components/GameView/GameMenu.vue
@@ -119,7 +119,6 @@ export default {
         await this.$store.dispatch('requestStalemate');
         this.$store.commit('setWaitingForOpponentToStalemate', true);
       } catch (e) {
-        debugger;
         this.$store.commit('setWaitingForOpponentToStalemate', false);
       }
       this.showStalemateDialog = false;

--- a/client/js/components/GameView/GameMenu.vue
+++ b/client/js/components/GameView/GameMenu.vue
@@ -121,6 +121,7 @@ export default {
       } catch (e) {
         this.$store.commit('setWaitingForOpponentToStalemate', false);
       }
+      this.loading = false;
       this.showStalemateDialog = false;
     },
   },

--- a/client/js/components/GameView/GameOverlays.vue
+++ b/client/js/components/GameView/GameOverlays.vue
@@ -28,6 +28,13 @@
     >
       <h1>Opponent Playing from Deck</h1>
     </v-overlay>
+    <v-overlay
+      id="waiting-for-opponent-stalemate-scrim"
+      v-model="waitingForOpponentToStalemate"
+      opacity=".6"
+    >
+      <h1>Opponent Considering Stalemate Request</h1>
+    </v-overlay>
     <move-choice-overlay
       :value="!targeting && (!!selectedCard || !!cardSelectedFromDeck)"
       :selected-card="selectedCard || cardSelectedFromDeck"
@@ -82,6 +89,7 @@ export default {
       waitingForOpponentToDiscard: ({ game }) => game.waitingForOpponentToDiscard,
       waitingForOpponentToPickFromScrap: ({ game }) => game.waitingForOpponentToPickFromScrap,
       waitingForOpponentToPlayFromDeck: ({ game }) => game.waitingForOpponentToPlayFromDeck,
+      waitingForOpponentToStalemate: ({ game }) => game.waitingForOpponentToStalemate,
     }),
     ...mapGetters([
       'isPlayersTurn',

--- a/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
+++ b/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-dialog v-model="show" persistent>
+    <v-card id="opponent-requested-stalemate-dialog">
+      <v-card-title>Accept Stalemate?</v-card-title>
+      <v-card-text>
+        <p>Your opponent has requested a stalemate. If you accept, the game will end in a tie.</p>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  name: 'OpponentRequestedStalemateDialog',
+  props: {
+    value: Boolean,
+  },
+  computed: {
+    show: {
+      get() {
+        return this.value;
+      },
+      set(value) {
+        this.$emit('input', value);
+      },
+    },
+  },
+};
+</script>

--- a/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
+++ b/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
@@ -11,7 +11,9 @@
       </v-card-text>
       <v-card-actions class="d-flex justify-end">
         <v-btn outlined color="primary" class="mr-4">Reject Request</v-btn>
-        <v-btn color="error" depressed>Accept Stalemate</v-btn>
+        <v-btn color="error" depressed data-cy="accept-stalemate" @click="acceptStalemate">
+          Accept Stalemate
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -31,6 +33,11 @@ export default {
       set(value) {
         this.$emit('input', value);
       },
+    },
+  },
+  methods: {
+    async acceptStalemate() {
+      await this.$store.dispatch('requestStalemate');
     },
   },
 };

--- a/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
+++ b/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
@@ -4,7 +4,15 @@
       <v-card-title>Accept Stalemate?</v-card-title>
       <v-card-text>
         <p>Your opponent has requested a stalemate. If you accept, the game will end in a tie.</p>
+        <div class="d-flex justify-center">
+          <v-icon class="mr-8" size="80px">mdi-offer</v-icon>
+          <v-icon size="80px">mdi-help-circle</v-icon>
+        </div>
       </v-card-text>
+      <v-card-actions class="d-flex justify-end">
+        <v-btn outlined color="primary" class="mr-4">Reject Request</v-btn>
+        <v-btn color="error" depressed>Accept Stalemate</v-btn>
+      </v-card-actions>
     </v-card>
   </v-dialog>
 </template>

--- a/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
+++ b/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
@@ -10,7 +10,16 @@
         </div>
       </v-card-text>
       <v-card-actions class="d-flex justify-end">
-        <v-btn outlined color="primary" class="mr-4" :diabled="loading">Reject Request</v-btn>
+        <v-btn
+          outlined
+          color="primary"
+          class="mr-4"
+          :diabled="loading"
+          data-cy="reject-stalemate"
+          @click="rejectStalemate"
+        >
+          Reject Request
+        </v-btn>
         <v-btn
           color="error"
           depressed
@@ -51,6 +60,15 @@ export default {
       this.loading = true;
       try {
         await this.$store.dispatch('requestStalemate');
+      } finally {
+        this.loading = false;
+        this.show = false;
+      }
+    },
+    async rejectStalemate() {
+      this.loading = true;
+      try {
+        await this.$store.dispatch('rejectStalemate');
       } finally {
         this.loading = false;
         this.show = false;

--- a/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
+++ b/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
@@ -14,7 +14,8 @@
           outlined
           color="primary"
           class="mr-4"
-          :diabled="loading"
+          :diabled="loadingAccept"
+          :loading="loadingReject"
           data-cy="reject-stalemate"
           @click="rejectStalemate"
         >
@@ -24,7 +25,8 @@
           color="error"
           depressed
           data-cy="accept-stalemate"
-          :loading="loading"
+          :loading="loadingAccept"
+          :disabled="loadingReject"
           @click="acceptStalemate"
         >
           Accept Stalemate
@@ -42,7 +44,8 @@ export default {
   },
   data() {
     return {
-      loading: false,
+      loadingAccept: false,
+      loadingReject: false,
     };
   },
   computed: {
@@ -57,20 +60,20 @@ export default {
   },
   methods: {
     async acceptStalemate() {
-      this.loading = true;
+      this.loadingAccept = true;
       try {
         await this.$store.dispatch('requestStalemate');
       } finally {
-        this.loading = false;
+        this.loadingAccept = false;
         this.show = false;
       }
     },
     async rejectStalemate() {
-      this.loading = true;
+      this.loadingReject = true;
       try {
         await this.$store.dispatch('rejectStalemate');
       } finally {
-        this.loading = false;
+        this.loadingReject = false;
         this.show = false;
       }
     },

--- a/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
+++ b/client/js/components/GameView/OpponentRequestedStalemateDialog.vue
@@ -10,8 +10,14 @@
         </div>
       </v-card-text>
       <v-card-actions class="d-flex justify-end">
-        <v-btn outlined color="primary" class="mr-4">Reject Request</v-btn>
-        <v-btn color="error" depressed data-cy="accept-stalemate" @click="acceptStalemate">
+        <v-btn outlined color="primary" class="mr-4" :diabled="loading">Reject Request</v-btn>
+        <v-btn
+          color="error"
+          depressed
+          data-cy="accept-stalemate"
+          :loading="loading"
+          @click="acceptStalemate"
+        >
           Accept Stalemate
         </v-btn>
       </v-card-actions>
@@ -25,6 +31,11 @@ export default {
   props: {
     value: Boolean,
   },
+  data() {
+    return {
+      loading: false,
+    };
+  },
   computed: {
     show: {
       get() {
@@ -37,7 +48,13 @@ export default {
   },
   methods: {
     async acceptStalemate() {
-      await this.$store.dispatch('requestStalemate');
+      this.loading = true;
+      try {
+        await this.$store.dispatch('requestStalemate');
+      } finally {
+        this.loading = false;
+        this.show = false;
+      }
     },
   },
 };

--- a/client/js/plugins/sails.js
+++ b/client/js/plugins/sails.js
@@ -120,6 +120,10 @@ io.socket.on('game', function (evData) {
             store.commit('setConsideringOpponentStalemateRequest', true);
           }
           break;
+        case 'rejectStalemate':
+          store.commit('setConsideringOpponentStalemateRequest', false);
+          store.commit('setWaitingForOpponentToStalemate', false);
+          break;
       }
   }
 });

--- a/client/js/plugins/sails.js
+++ b/client/js/plugins/sails.js
@@ -17,6 +17,7 @@ io.socket.on('game', function (evData) {
     case 'updated':
       // Handle GameOver
       if (evData.data.victory && evData.data.victory.gameOver) {
+        debugger;
         setTimeout(() => {
           store.commit('setGameOver', evData.data.victory);
         }, 1000);

--- a/client/js/plugins/sails.js
+++ b/client/js/plugins/sails.js
@@ -17,7 +17,6 @@ io.socket.on('game', function (evData) {
     case 'updated':
       // Handle GameOver
       if (evData.data.victory && evData.data.victory.gameOver) {
-        debugger;
         setTimeout(() => {
           store.commit('setGameOver', evData.data.victory);
         }, 1000);
@@ -115,6 +114,11 @@ io.socket.on('game', function (evData) {
           break;
         case 'reLogin':
           store.dispatch('updateGameThenResetPNumIfNull', evData.data.game);
+          break;
+        case 'requestStalemate':
+          if (evData.data.requestedByPNum !== store.state.game.myPNum) {
+            store.commit('setConsideringOpponentStalemateRequest', true);
+          }
           break;
       }
   }

--- a/client/js/store/modules/game.js
+++ b/client/js/store/modules/game.js
@@ -40,6 +40,7 @@ function resetState() {
     winnerPNum: null,
     conceded: false,
     waitingForOpponentToStalemate: false,
+    consideringOpponentStalemateRequest: false,
   };
 }
 
@@ -243,6 +244,9 @@ export default {
     },
     setWaitingForOpponentToStalemate(state, value) {
       state.waitingForOpponentToStalemate = value;
+    },
+    setConsideringOpponentStalemateRequest(state, value) {
+      state.consideringOpponentStalemateRequest = value;
     },
   },
   actions: {

--- a/client/js/store/modules/game.js
+++ b/client/js/store/modules/game.js
@@ -639,6 +639,13 @@ export default {
         });
       });
     },
+    async rejectStalemate(context) {
+      return new Promise((resolve, reject) => {
+        io.socket.get('/game/reject-stalemate', function handleResponse(res, jwres) {
+          return handleGameResponse(context, jwres, resolve, reject);
+        });
+      });
+    },
     async requestUnsubscribeFromGame(context) {
       return new Promise((resolve, reject) => {
         io.socket.get('/game/over', function handleResponse(res, jwres) {

--- a/client/js/store/modules/game.js
+++ b/client/js/store/modules/game.js
@@ -50,6 +50,7 @@ function handleGameResponse(context, jwres, resolve, reject) {
       context.commit('setMustReauthenticate', true, { root: true });
       return reject(jwres.body.message);
     default:
+      debugger;
       return reject(jwres.body.message);
   }
 }
@@ -619,6 +620,13 @@ export default {
     async requestConcede(context) {
       return new Promise((resolve, reject) => {
         io.socket.get('/game/concede', function handleResponse(res, jwres) {
+          return handleGameResponse(context, jwres, resolve, reject);
+        });
+      });
+    },
+    async requestStalemate(context) {
+      return new Promise((resolve, reject) => {
+        io.socket.get('/game/stalemate', function handleResponse(res, jwres) {
           return handleGameResponse(context, jwres, resolve, reject);
         });
       });

--- a/client/js/store/modules/game.js
+++ b/client/js/store/modules/game.js
@@ -39,6 +39,7 @@ function resetState() {
     gameIsOver: false,
     winnerPNum: null,
     conceded: false,
+    waitingForOpponentToStalemate: false,
   };
 }
 
@@ -50,7 +51,6 @@ function handleGameResponse(context, jwres, resolve, reject) {
       context.commit('setMustReauthenticate', true, { root: true });
       return reject(jwres.body.message);
     default:
-      debugger;
       return reject(jwres.body.message);
   }
 }
@@ -153,6 +153,7 @@ export default {
           state.lastEventTargetType = null;
         }
       }
+      state.waitingForOpponentToStalemate = false;
       if (Object.hasOwnProperty.call(newGame, 'id')) state.id = newGame.id;
       if (Object.hasOwnProperty.call(newGame, 'turn')) state.turn = newGame.turn;
       if (Object.hasOwnProperty.call(newGame, 'chat')) state.chat = _.cloneDeep(newGame.chat);
@@ -239,6 +240,9 @@ export default {
       state.gameIsOver = gameOver;
       state.conceded = conceded;
       state.winnerPNum = winner;
+    },
+    setWaitingForOpponentToStalemate(state, value) {
+      state.waitingForOpponentToStalemate = value;
     },
   },
   actions: {

--- a/config/policies.js
+++ b/config/policies.js
@@ -57,6 +57,7 @@ module.exports.policies = {
   'game/resolve-three': ['isLoggedIn', 'isInGame', 'hasCardId'],
   'game/concede': ['isLoggedIn', 'isInGame'],
   'game/stalemate': ['isLoggedIn', 'isInGame'],
+  'game/reject-stalemate': ['isLoggedIn', 'isInGame'],
   'game/game-over': ['isLoggedIn', 'isInGame'],
   'game/chat': ['isLoggedIn', 'isInGame'],
   'game/game-data': ['isLoggedIn', 'isInGame'],

--- a/config/policies.js
+++ b/config/policies.js
@@ -56,6 +56,7 @@ module.exports.policies = {
   'game/resolve-four': ['isLoggedIn', 'isInGame', 'hasCardIdOne'],
   'game/resolve-three': ['isLoggedIn', 'isInGame', 'hasCardId'],
   'game/concede': ['isLoggedIn', 'isInGame'],
+  'game/stalemate': ['isLoggedIn', 'isInGame'],
   'game/game-over': ['isLoggedIn', 'isInGame'],
   'game/chat': ['isLoggedIn', 'isInGame'],
   'game/game-data': ['isLoggedIn', 'isInGame'],

--- a/config/routes.js
+++ b/config/routes.js
@@ -80,6 +80,7 @@ module.exports.routes = {
   '/game/seven/targetedOneOff': 'game/seven/targeted-one-off',
   '/game/over': 'game/game-over',
   '/game/concede': 'game/concede',
+  '/game/stalemate': 'game/stalemate',
   '/game/chat': 'game/chat',
   '/game/gameData': 'game/game-data',
   '/game/lobbyData': 'game/lobby-data',

--- a/config/routes.js
+++ b/config/routes.js
@@ -81,6 +81,7 @@ module.exports.routes = {
   '/game/over': 'game/game-over',
   '/game/concede': 'game/concede',
   '/game/stalemate': 'game/stalemate',
+  '/game/reject-stalemate': 'game/stalemate-reject',
   '/game/chat': 'game/chat',
   '/game/gameData': 'game/game-data',
   '/game/lobbyData': 'game/lobby-data',

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -264,6 +264,9 @@ describe('Stalemates', () => {
         .click();
 
       cy.get('#waiting-for-opponent-stalemate-scrim').should('be.visible');
+
+      cy.stalemateOpponent();
+      assertStalemate();
     });
   });
 });

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -286,7 +286,7 @@ describe('Stalemates', () => {
       assertStalemate();
     });
 
-    it.only('Cancels the stalemate when player requests a stalemate and opponent rejects', () => {
+    it('Cancels the stalemate when player requests a stalemate and opponent rejects', () => {
       setupGameAsP0();
       cy.get('[data-player-hand-card]').should('have.length', 5);
       cy.log('Game loaded');
@@ -318,6 +318,21 @@ describe('Stalemates', () => {
       cy.get('#waiting-for-opponent-stalemate-scrim').should('not.be.visible');
     });
 
-    it('Cancels the stalemate when opponent requests and player rejects', () => {});
+    it.only('Cancels the stalemate when opponent requests and player rejects', () => {
+      setupGameAsP1();
+      cy.get('[data-player-hand-card]').should('have.length', 6);
+      cy.log('Game loaded');
+
+      // Opponent requests stalemate
+      cy.stalemateOpponent();
+
+      // Player accepts stalemate
+      cy.get('#opponent-requested-stalemate-dialog')
+        .should('be.visible')
+        .find('[data-cy=reject-stalemate]')
+        .click();
+
+      cy.get('#opponent-requested-stalemate-dialog').should('not.be.visible');
+    });
   });
 });

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -269,7 +269,7 @@ describe('Stalemates', () => {
       assertStalemate();
     });
 
-    it.only('Ends in a stalemate when opponent requests a stalemate and player agrees', () => {
+    it('Ends in a stalemate when opponent requests a stalemate and player agrees', () => {
       setupGameAsP1();
       cy.get('[data-player-hand-card]').should('have.length', 6);
       cy.log('Game loaded');
@@ -285,5 +285,39 @@ describe('Stalemates', () => {
 
       assertStalemate();
     });
+
+    it.only('Cancels the stalemate when player requests a stalemate and opponent rejects', () => {
+      setupGameAsP0();
+      cy.get('[data-player-hand-card]').should('have.length', 5);
+      cy.log('Game loaded');
+
+      // Request Stalemate
+      cy.get('#game-menu-activator').click();
+      cy.get('#game-menu').should('be.visible').get('[data-cy=stalemate-initiate]').click();
+      cy.get('#request-gameover-dialog')
+        .should('be.visible')
+        .get('[data-cy=request-gameover-confirm]')
+        .click();
+      cy.get('#waiting-for-opponent-stalemate-scrim').should('be.visible');
+
+      // Opponent rejects stalemate
+      cy.rejectStalemateOpponent();
+      cy.get('#waiting-for-opponent-stalemate-scrim').should('not.be.visible');
+
+      // Player requests stalemate again -- process starts over
+      cy.get('#game-menu-activator').click();
+      cy.get('#game-menu').should('be.visible').get('[data-cy=stalemate-initiate]').click();
+      cy.get('#request-gameover-dialog')
+        .should('be.visible')
+        .get('[data-cy=request-gameover-confirm]')
+        .click();
+      cy.get('#waiting-for-opponent-stalemate-scrim').should('be.visible');
+
+      // Opponent rejects stalemate
+      cy.rejectStalemateOpponent();
+      cy.get('#waiting-for-opponent-stalemate-scrim').should('not.be.visible');
+    });
+
+    it('Cancels the stalemate when opponent requests and player rejects', () => {});
   });
 });

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -278,7 +278,12 @@ describe('Stalemates', () => {
       cy.stalemateOpponent();
 
       // Player accepts stalemate
-      cy.get('#opponent-requested-stalemate-dialog').should('be.visible');
+      cy.get('#opponent-requested-stalemate-dialog')
+        .should('be.visible')
+        .find('[data-cy=accept-stalemate]')
+        .click();
+
+      assertStalemate();
     });
   });
 });

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -147,7 +147,7 @@ describe('Losing the game', () => {
     goHomeJoinNewGame();
   });
 
-  it('Loses by conceding', () => {
+  it.only('Loses by conceding', () => {
     cy.loadGameFixture({
       p0Hand: [Card.SEVEN_OF_CLUBS],
       p0Points: [Card.SEVEN_OF_DIAMONDS, Card.SEVEN_OF_HEARTS],
@@ -161,13 +161,20 @@ describe('Losing the game', () => {
 
     cy.get('#game-menu-activator').click();
     cy.get('#game-menu').should('be.visible').get('[data-cy=concede-initiate]').click();
+
     // Cancel Concede
-    cy.get('#concede-menu').should('be.visible').get('[data-cy=concede-cancel]').click();
-    cy.get('#concede-menu').should('not.be.visible');
+    cy.get('#request-gameover-dialog')
+      .should('be.visible')
+      .get('[data-cy=request-gameover-cancel]')
+      .click();
+    cy.get('#request-gameover-dialog').should('not.be.visible');
     // Re-open concede menu and confirm concession
     cy.get('#game-menu-activator').click();
     cy.get('#game-menu').should('be.visible').get('[data-cy=concede-initiate]').click();
-    cy.get('#concede-menu').should('be.visible').get('[data-cy=concede-confirm]').click();
+    cy.get('#request-gameover-dialog')
+      .should('be.visible')
+      .get('[data-cy=request-gameover-confirm]')
+      .click();
     assertLoss();
     goHomeJoinNewGame();
   });
@@ -239,7 +246,7 @@ describe('Stalemates', () => {
     goHomeJoinNewGame();
   });
 
-  describe.only('Requesting a stalemate', () => {
+  describe('Requesting a stalemate', () => {
     it('Ends in stalemate when player requests stalemate and opponent agrees', () => {
       setupGameAsP0();
       cy.get('[data-player-hand-card]').should('have.length', 5);
@@ -354,7 +361,7 @@ describe('Stalemates', () => {
         .click();
     });
 
-    it.only('Cancels stalemate after an additional turn passes', () => {
+    it('Cancels stalemate after an additional turn passes', () => {
       setupGameAsP1();
       cy.get('[data-player-hand-card]').should('have.length', 6);
       cy.log('Game loaded');

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -147,7 +147,7 @@ describe('Losing the game', () => {
     goHomeJoinNewGame();
   });
 
-  it.only('Loses by conceding', () => {
+  it('Loses by conceding', () => {
     cy.loadGameFixture({
       p0Hand: [Card.SEVEN_OF_CLUBS],
       p0Points: [Card.SEVEN_OF_DIAMONDS, Card.SEVEN_OF_HEARTS],

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -240,7 +240,7 @@ describe('Stalemates', () => {
   });
 
   describe('Requesting a stalemate', () => {
-    it.only('Ends in stalemate when player requests stalemate and opponent agrees', () => {
+    it('Ends in stalemate when player requests stalemate and opponent agrees', () => {
       setupGameAsP0();
       cy.get('[data-player-hand-card]').should('have.length', 5);
       cy.log('Game loaded');
@@ -267,6 +267,18 @@ describe('Stalemates', () => {
 
       cy.stalemateOpponent();
       assertStalemate();
+    });
+
+    it.only('Ends in a stalemate when opponent requests a stalemate and player agrees', () => {
+      setupGameAsP1();
+      cy.get('[data-player-hand-card]').should('have.length', 6);
+      cy.log('Game loaded');
+
+      // Opponent requests stalemate
+      cy.stalemateOpponent();
+
+      // Player accepts stalemate
+      cy.get('#opponent-requested-stalemate-dialog').should('be.visible');
     });
   });
 });

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -239,7 +239,7 @@ describe('Stalemates', () => {
     goHomeJoinNewGame();
   });
 
-  describe('Requesting a stalemate', () => {
+  describe.only('Requesting a stalemate', () => {
     it('Ends in stalemate when player requests stalemate and opponent agrees', () => {
       setupGameAsP0();
       cy.get('[data-player-hand-card]').should('have.length', 5);
@@ -316,9 +316,19 @@ describe('Stalemates', () => {
       // Opponent rejects stalemate
       cy.rejectStalemateOpponent();
       cy.get('#waiting-for-opponent-stalemate-scrim').should('not.be.visible');
+
+      // Opponent requests stalemate - Does not immediately stalemate
+      cy.stalemateOpponent();
+      // Player accepts stalemate
+      cy.get('#opponent-requested-stalemate-dialog')
+        .should('be.visible')
+        .find('[data-cy=accept-stalemate]')
+        .click();
+
+      assertStalemate();
     });
 
-    it.only('Cancels the stalemate when opponent requests and player rejects', () => {
+    it('Cancels the stalemate when opponent requests and player rejects', () => {
       setupGameAsP1();
       cy.get('[data-player-hand-card]').should('have.length', 6);
       cy.log('Game loaded');
@@ -326,13 +336,22 @@ describe('Stalemates', () => {
       // Opponent requests stalemate
       cy.stalemateOpponent();
 
-      // Player accepts stalemate
+      // Player rejects stalemate
       cy.get('#opponent-requested-stalemate-dialog')
         .should('be.visible')
         .find('[data-cy=reject-stalemate]')
         .click();
 
       cy.get('#opponent-requested-stalemate-dialog').should('not.be.visible');
+
+      // Opponent requests stalemate again
+      cy.stalemateOpponent();
+
+      // Player rejects stalemate
+      cy.get('#opponent-requested-stalemate-dialog')
+        .should('be.visible')
+        .find('[data-cy=reject-stalemate]')
+        .click();
     });
   });
 });

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -353,5 +353,31 @@ describe('Stalemates', () => {
         .find('[data-cy=reject-stalemate]')
         .click();
     });
+
+    it.only('Cancels stalemate after an additional turn passes', () => {
+      setupGameAsP1();
+      cy.get('[data-player-hand-card]').should('have.length', 6);
+      cy.log('Game loaded');
+
+      // Request Stalemate
+      cy.get('#game-menu-activator').click();
+      cy.get('#game-menu').should('be.visible').get('[data-cy=stalemate-initiate]').click();
+      cy.get('#request-gameover-dialog')
+        .should('be.visible')
+        .get('[data-cy=request-gameover-confirm]')
+        .click();
+      cy.get('#waiting-for-opponent-stalemate-scrim').should('be.visible');
+
+      cy.drawCardOpponent();
+      cy.get('#waiting-for-opponent-stalemate-scrim').should('not.be.visible');
+
+      // Opponent requests stalemate
+      cy.stalemateOpponent();
+      // Player rejects stalemate
+      cy.get('#opponent-requested-stalemate-dialog')
+        .should('be.visible')
+        .find('[data-cy=reject-stalemate]')
+        .click();
+    });
   });
 });

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -263,7 +263,7 @@ describe('Stalemates', () => {
         .get('[data-cy=request-gameover-confirm]')
         .click();
 
-      cy.get('#waiting-opponent-stalemate-overlay').should('be.visible');
+      cy.get('#waiting-for-opponent-stalemate-scrim').should('be.visible');
     });
   });
 });

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -238,4 +238,32 @@ describe('Stalemates', () => {
     assertStalemate();
     goHomeJoinNewGame();
   });
+
+  describe('Requesting a stalemate', () => {
+    it.only('Ends in stalemate when player requests stalemate and opponent agrees', () => {
+      setupGameAsP0();
+      cy.get('[data-player-hand-card]').should('have.length', 5);
+      cy.log('Game loaded');
+
+      cy.get('#game-menu-activator').click();
+      cy.get('#game-menu').should('be.visible').get('[data-cy=stalemate-initiate]').click();
+      // Cancel Stalemate
+      cy.get('#request-gameover-dialog')
+        .should('be.visible')
+        .get('[data-cy=request-gameover-cancel]')
+        .click();
+
+      cy.get('#request-gameover-dialog').should('not.be.visible');
+
+      cy.get('#game-menu-activator').click();
+      cy.get('#game-menu').should('be.visible').get('[data-cy=stalemate-initiate]').click();
+      // Request Stalemate
+      cy.get('#request-gameover-dialog')
+        .should('be.visible')
+        .get('[data-cy=request-gameover-confirm]')
+        .click();
+
+      cy.get('#waiting-opponent-stalemate-overlay').should('be.visible');
+    });
+  });
 });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -936,6 +936,16 @@ Cypress.Commands.add('stalemateOpponent', () => {
   });
 });
 
+Cypress.Commands.add('rejectStalemateOpponent', () => {
+  cy.log('Opponent rejects stalemate request');
+  io.socket.get('/game/reject-stalemate', function handleResponse(res, jwres) {
+    if (jwres.statusCode !== 200) {
+      throw new Error(jwres.body.message);
+    }
+    return jwres;
+  });
+});
+
 Cypress.Commands.add('reconnectOpponent', (username, password) => {
   cy.log('Opponent Reconnects');
   io.socket.get(

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -926,6 +926,17 @@ Cypress.Commands.add('concedeOpponent', () => {
   });
 });
 
+Cypress.Commands.add('stalemateOpponent', () => {
+  cy.log('Opponent requests/accepts stalemate');
+  io.socket.get('/game/stalemate', function handleResponse(res, jwres) {
+    debugger;
+    if (jwres.statusCode !== 200) {
+      throw new Error(jwres.body.message);
+    }
+    return jwres;
+  });
+});
+
 Cypress.Commands.add('reconnectOpponent', (username, password) => {
   cy.log('Opponent Reconnects');
   io.socket.get(

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -929,7 +929,6 @@ Cypress.Commands.add('concedeOpponent', () => {
 Cypress.Commands.add('stalemateOpponent', () => {
   cy.log('Opponent requests/accepts stalemate');
   io.socket.get('/game/stalemate', function handleResponse(res, jwres) {
-    debugger;
     if (jwres.statusCode !== 200) {
       throw new Error(jwres.body.message);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
**REQUIRES DATABASE UPDATE:** (adds two columns to game table)
Allows players to request a stalemate from their opponent which can be accepted or rejected. Stalemates must be accepted on the turn that they are requested or else the request is considered invalid.


