### PR TITLE
Add visual indicator to frozen card

### DIFF
--- a/client/js/components/GameView/Card.vue
+++ b/client/js/components/GameView/Card.vue
@@ -1,10 +1,18 @@
 <template>
   <v-card
     class="mx-1 player-card"
-    :class="{ selected: isSelected, glasses: isGlasses, jack: isJack }"
+    :class="{
+      selected: isSelected,
+      glasses: isGlasses,
+      jack: isJack,
+      frozen: isFrozen,
+    }"
     :elevation="elevation"
     @click="$emit('click')"
   >
+    <v-icon v-if="isFrozen" class="player-card-icon mr-1 mt-1" color="#00a5ff">
+      mdi-snowflake
+    </v-icon>
     <v-overlay
       v-ripple
       :value="isValidTarget"
@@ -53,6 +61,10 @@ export default {
     jacks: {
       type: Array,
       default: null,
+    },
+    isFrozen: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {
@@ -130,6 +142,13 @@ export default {
     height: calc(20vh / 1.45);
   }
 }
+.player-card-icon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+}
+
 .selected {
   // transform: scale(1.23);
   img {
@@ -155,5 +174,24 @@ export default {
 }
 .target-overlay {
   cursor: pointer;
+}
+
+.frozen {
+  &:after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(#00a5ff, 0.25);
+    opacity: 1;
+    transition: all 0.3s linear;
+  }
+
+  &:hover:after {
+    opacity: 0;
+  }
 }
 </style>

--- a/client/js/components/GameView/GameOverlays.vue
+++ b/client/js/components/GameView/GameOverlays.vue
@@ -69,16 +69,10 @@ export default {
     selectedCard: {
       type: Object,
       default: null,
-      validator: (value) => {
-        return typeof value === Object || value === null;
-      },
     },
     cardSelectedFromDeck: {
       type: Object,
       default: null,
-      validator: (value) => {
-        return typeof value === Object || value === null;
-      },
     },
   },
   computed: {

--- a/client/js/views/GameView.vue
+++ b/client/js/views/GameView.vue
@@ -256,6 +256,7 @@
                 :suit="card.suit"
                 :rank="card.rank"
                 :is-selected="selectedCard && card.id === selectedCard.id"
+                :is-frozen="player.frozenId === card.id"
                 class="mt-8 transition-all"
                 :data-player-hand-card="`${card.rank}-${card.suit}`"
                 @click="selectCard(index)"

--- a/tests/e2e/specs/in-game/oneOffs.spec.js
+++ b/tests/e2e/specs/in-game/oneOffs.spec.js
@@ -1137,6 +1137,9 @@ describe('Playing NINES', () => {
         scrap: [Card.NINE_OF_CLUBS],
       });
 
+      // Card should have the frozen state shown visually
+      cy.get('[data-player-hand-card=11-0]').should('have.class', 'frozen');
+
       // Player attempts plays the returned jack immediately
       cy.get('[data-player-hand-card=11-0]').click();
       cy.get('[data-move-choice=jack]').click();


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [x] ~Has the documentation been updated accordingly?~

## Please describe additional details for testing this change

Verify the modified test passes and bask in the satisfaction of knowing when a card is frozen.

![cuttle-frozen-card](https://user-images.githubusercontent.com/414475/189138729-7aa22812-5008-45b7-9ad8-08351d1e2ca9.gif)
