### PR TITLE
Fix typo in 'Two - Effect 2' move description (closes #127)

### DIFF
--- a/client/js/views/Rules.vue
+++ b/client/js/views/Rules.vue
@@ -379,7 +379,7 @@ export default {
           {
             title: 'Two - Effect 2',
             icon: 'delete',
-            description: 'Twos have two alternative one-off effects: Scrap target Royal',
+            description: 'Twos have two alternative one-off effects: Scrap target Royal or Glasses Eight',
             staticImg: 'cuttle_one_off_two.png',
             animatedImg:
               'https://github.com/cuttle-cards/cuttle-assets/blob/main/assets/two.gif?raw=true',


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))

## Please describe additional details for testing this change
Just a minor typo fix (updated description of "Two - Effect 2" move to be more precise).
Closes #127 

