### PR TITLE
Enhancement: move logout button to the bottom for mobiles (closes #135)

### DIFF
--- a/client/js/components/NavigationDrawer.vue
+++ b/client/js/components/NavigationDrawer.vue
@@ -25,12 +25,7 @@
     <!-- Bottom section (logout, expand/collapse) -->
     <template #append>
       <v-list v-if="isSmallDevice">
-        <v-list-item
-          link
-          exact
-          :to="{ name: 'Logout' }"
-          data-nav="Logout"
-        >
+        <v-list-item link exact :to="{ name: 'Logout' }" data-nav="Logout">
           <v-icon class="mr-2">mdi-logout</v-icon>
           <template v-if="!isCollapsed">Logout</template>
         </v-list-item>
@@ -69,13 +64,13 @@ export default {
 
       if (!this.authenticated) {
         return [
-            {
-              text: 'Login',
-              icon: 'login',
-              page: { name: 'Login' },
-            },
-            ...rules,
-          ];
+          {
+            text: 'Login',
+            icon: 'login',
+            page: { name: 'Login' },
+          },
+          ...rules,
+        ];
       }
 
       return this.isSmallDevice

--- a/client/js/components/NavigationDrawer.vue
+++ b/client/js/components/NavigationDrawer.vue
@@ -22,9 +22,20 @@
         {{ text }}
       </v-list-item>
     </v-list>
-    <!-- Expand/Collapse -->
+    <!-- Bottom section (logout, expand/collapse) -->
     <template #append>
-      <v-list v-if="!isSmallDevice">
+      <v-list v-if="isSmallDevice">
+        <v-list-item
+          link
+          exact
+          :to="{ name: 'Logout' }"
+          data-nav="Logout"
+        >
+          <v-icon class="mr-2">mdi-logout</v-icon>
+          <template v-if="!isCollapsed">Logout</template>
+        </v-list-item>
+      </v-list>
+      <v-list v-else>
         <v-list-item :data-cy="collapseMenuAttribute" @click="userHasCollapsed = !userHasCollapsed">
           <v-icon class="mr-2">{{ collapseMenuIcon }}</v-icon>
           <template v-if="!isCollapsed">Collapse Menu</template>
@@ -55,14 +66,23 @@ export default {
           page: { name: 'Rules' },
         },
       ];
-      return !this.authenticated
-        ? [
+
+      if (!this.authenticated) {
+        return [
             {
               text: 'Login',
               icon: 'login',
               page: { name: 'Login' },
             },
             ...rules,
+          ];
+      }
+
+      return this.isSmallDevice
+        ? [
+            ...rules,
+            { text: 'Play', icon: 'play', page: { name: 'Home' } },
+            { text: 'Stats', icon: 'chart-bar', page: { name: 'Stats' } },
           ]
         : [
             { text: 'Logout', icon: 'logout', page: { name: 'Logout' } },


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))

## Please describe additional details for testing this change
This is a tiny UI improvement that moves logout link from the very top to the bottom for mobile screens. (closes #135)
P.S. I decided to make things more simple and straightforward in terms of `pageLinks` generation depending on authentication status and screen size. If you want to keep thing as short as it possible we may use a rest spread operator approach of `...(cond ? {a: 1} : {}),` but I'm not sure it'll be readable then.