### PR TITLE
Add rate-limit middleware

### DIFF
--- a/config/http.js
+++ b/config/http.js
@@ -20,6 +20,25 @@ module.exports.http = {
    ****************************************************************************/
 
   middleware: {
+    order: [
+      'cookieParser',
+      'session',
+      'bodyParser',
+      'compress',
+      'poweredBy',
+      'rateLimit',
+      'router',
+      'www',
+      'favicon',
+    ],
+    rateLimit: (function () {
+      const { isProd } = require('../utils/config-utils');
+      const erl = require('express-rate-limit');
+      return erl({
+        windowMs: 1 * 60 * 1000, // 1 minute
+        max: isProd ? 30 : 1000, // limit each IP to 30 requests per windowMs
+      });
+    })(),
     /***************************************************************************
      *                                                                          *
      * The order in which middleware should be run for HTTP requests.           *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17343,6 +17343,11 @@
           "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
         }
       }
+    },
+    "express-rate-limit": {
+      "version": "6.6.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/express-rate-limit/-/express-rate-limit-6.6.0.tgz",
+      "integrity": "sha512-HFN2+4ZGdkQOS8Qli4z6knmJFnw6lZed67o6b7RGplWeb1Z0s8VXaj3dUgPIdm9hrhZXTRpCTHXA0/2Eqex0vA=="
     },
     "express-session": {
       "version": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",
+    "express-rate-limit": "^6.6.0",
     "lodash": "4.17.21",
     "machinepack-passwords": "2.3.0",
     "sails": "1.4.3",


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

We briefly talked about rate-limits for the API in another issue that could impact the db, and the solution seemed relatively plug and play. I'm doing that here. I realized if we override the "order" array we need to keep the default values in place (these are pointed out in the existing comments of the file).

I'm checking the `isProd` variable to tell the limit of requests per minute, for the test env is 1000 and for prod is 30. I'm not sure how many request a single IP makes per minute but this can be tweaked. I originally put 200 for test but then realized locally it would return 429 errors fast.

I've not added tests but I'm thinking we could somehow set the env variable to be "prod" and burst more than 30 requests and expect a 429 at some point. Have you done a test like this in the past, where you change the prod variable before lifting the sails networking stack?
