### PR TITLE
Display players lost to in Stats Leaderboard

### DIFF
--- a/client/js/components/StatsLeaderboardCell.vue
+++ b/client/js/components/StatsLeaderboardCell.vue
@@ -16,10 +16,15 @@
       </v-chip>
     </template>
     <v-card :data-players-beaten="`${username}-week-${week}`">
-      <v-card-title>Players Beaten</v-card-title>
+      <v-card-title>Results</v-card-title>
       <v-card-text>
+        <h3>Wins</h3>
         <v-list>
           {{ playersBeaten }}
+        </v-list>
+        <h3>Losses</h3>
+        <v-list>
+          {{ playersLostTo }}
         </v-list>
       </v-card-text>
       <v-card-actions class="d-flex justify-end">
@@ -51,6 +56,10 @@ export default {
       required: true,
     },
     playersBeaten: {
+      type: String,
+      default: '',
+    },
+    playersLostTo: {
       type: String,
       default: '',
     },

--- a/client/js/components/StatsLeaderboardCell.vue
+++ b/client/js/components/StatsLeaderboardCell.vue
@@ -15,20 +15,20 @@
         {{ chipText }}
       </v-chip>
     </template>
-    <v-card :data-players-beaten="`${username}-week-${week}`">
+    <v-card :data-player-results="`${username}-week-${week}`">
       <v-card-title>Results</v-card-title>
       <v-card-text>
         <h3>Wins</h3>
-        <v-list>
+        <v-list :data-players-beaten="`${username}-week-${week}`">
           {{ playersBeaten }}
         </v-list>
         <h3>Losses</h3>
-        <v-list>
+        <v-list :data-players-lost-to="`${username}-week-${week}`">
           {{ playersLostTo }}
         </v-list>
       </v-card-text>
       <v-card-actions class="d-flex justify-end">
-        <v-btn data-cy="close-players-beaten" outlined color="primary" @click="showMenu = false">
+        <v-btn data-cy="close-player-results" outlined color="primary" @click="showMenu = false">
           Close
         </v-btn>
       </v-card-actions>

--- a/tests/e2e/specs/out-of-game/stats.spec.js
+++ b/tests/e2e/specs/out-of-game/stats.spec.js
@@ -95,13 +95,32 @@ describe('Stats Page', () => {
     cy.get('[data-week-total=Player2]').contains('W: 7, P: 9');
     cy.get("[data-week-1='Player5']").contains('W: 1, P: 3');
     cy.get('tr.active-user-stats').contains(playerOne.username);
-    // Players Beaten menus
+    // Player result menus (Week without losses)
     cy.get("[data-week-1='Player1']").click();
-    cy.get('[data-players-beaten=Player1-week-1]')
-      .should('contain', 'Player2, Player3, Player4')
-      .find('[data-cy=close-players-beaten]')
-      .click();
+    cy.get('[data-players-beaten=Player1-week-1]').should('contain', 'Player2, Player3, Player4');
+    cy.get('[data-players-lost-to=Player1-week-1]').should('not.contain', 'Player');
+    cy.get('[data-player-results=Player1-week-1]').find('[data-cy=close-player-results]').click();
     cy.get('[data-players-beaten=Player1-week-1').should('not.be.visible');
+    cy.get('[data-players-lost-to=Player1-week-1').should('not.be.visible');
+    // Player result menus (Week with losses)
+    cy.get("[data-week-1='Player2']").click();
+    cy.get('[data-players-beaten=Player2-week-1]').should('contain', 'Player3, Player4');
+    cy.get('[data-players-lost-to=Player2-week-1]').should('contain', 'Player1');
+    cy.get('[data-player-results=Player2-week-1]').find('[data-cy=close-player-results]').click();
+    cy.get('[data-players-beaten=Player2-week-1').should('not.be.visible');
+    cy.get('[data-players-lost-to=Player2-week-1').should('not.be.visible');
+    // Player result menus (Total)
+    cy.get("[data-week-total='Player3']").click();
+    cy.get('[data-players-beaten=Player3-week-total]').should('contain', 'Player5 (1)');
+    cy.get('[data-players-lost-to=Player3-week-total]').should(
+      'contain',
+      'Player1 (2), Player2 (2), Player4 (2), Player5 (1)'
+    );
+    cy.get('[data-player-results=Player3-week-total]')
+      .find('[data-cy=close-player-results]')
+      .click();
+    cy.get('[data-players-beaten=Player3-week-total').should('not.be.visible');
+    cy.get('[data-players-lost-to=Player3-week-total').should('not.be.visible');
   });
 
   it('Filters table to display wins, points, or both', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [x] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
As requested in #182 , this adapts the "Players Beaten" dialog to include a list of **Losses** in addition to the list of **Wins**.

In the "Total" column, a counter is also shown next to the player's name, depicting the number of times each player appeared in winning/losing matches over the weeks.

![Screenshot from 2022-10-28 23-53-11](https://user-images.githubusercontent.com/15658199/198799374-b54be9a8-87fb-4b60-b703-9d05dbcd51b4.png)

All feedback is appreciated! :)