### PR TITLE
Feature/adds win rate on player menu stats

### DIFF
--- a/client/js/components/StatsLeaderboard.vue
+++ b/client/js/components/StatsLeaderboard.vue
@@ -102,8 +102,11 @@ export default {
       return this.season.rankings.map((playerStats, index) => {
         const playerWins = this.playerWins[index];
         const playerScores = this.playerScores[index];
+        const playerMatchesCount = Object.values(playerStats.matches)
+          .reduce((totalCount, weekMatches) => totalCount += weekMatches.length, 0)
         const res = {
           username: playerStats.username,
+          week_total_count: playerMatchesCount,
           week_total_wins: playerWins.total,
           week_total_points: playerScores.total,
           week_total: playerScores.total,
@@ -111,6 +114,7 @@ export default {
         };
         for (const weekNum in playerStats.matches) {
           res[`week_${weekNum}`] = playerScores[weekNum];
+          res[`week_${weekNum}_count`] = playerStats.matches[weekNum].length;
           res[`week_${weekNum}_wins`] = playerWins[weekNum];
           res[`week_${weekNum}_points`] = playerScores[weekNum];
         }

--- a/client/js/components/StatsLeaderboard.vue
+++ b/client/js/components/StatsLeaderboard.vue
@@ -102,8 +102,14 @@ export default {
       return this.season.rankings.map((playerStats, index) => {
         const playerWins = this.playerWins[index];
         const playerScores = this.playerScores[index];
-        const playerMatchesCount = Object.values(playerStats.matches)
-          .reduce((totalCount, weekMatches) => totalCount += weekMatches.length, 0)
+        // Count matches completed per week and in total
+        const playerMatchesCount = Object.values(playerStats.matches).reduce(
+          (totalCount, weekMatches) =>
+            (totalCount += weekMatches.filter((match) =>
+              [Result.WON, Result.LOST].includes(match.result)
+            ).length),
+          0
+        );
         const res = {
           username: playerStats.username,
           week_total_count: playerMatchesCount,

--- a/client/js/components/StatsLeaderboardCell.vue
+++ b/client/js/components/StatsLeaderboardCell.vue
@@ -16,7 +16,7 @@
       </v-chip>
     </template>
     <v-card :data-player-results="`${username}-week-${week}`">
-      <v-card-title>{{ username }} Week {{ week}} Results</v-card-title>
+      <v-card-title>{{ username }} Week {{ week }} Results</v-card-title>
       <v-card-text>
         <h3>Wins</h3>
         <v-list :data-players-beaten="`${username}-week-${week}`">
@@ -151,7 +151,7 @@ export default {
       return res;
     },
     winRatePercentage() {
-      const winRate = Math.floor((this.wins / this.weekCount) * 100)
+      const winRate = Math.floor((this.wins / this.weekCount) * 100);
       return `${winRate}%`;
     },
   },

--- a/client/js/components/StatsLeaderboardCell.vue
+++ b/client/js/components/StatsLeaderboardCell.vue
@@ -16,7 +16,7 @@
       </v-chip>
     </template>
     <v-card :data-player-results="`${username}-week-${week}`">
-      <v-card-title>Results</v-card-title>
+      <v-card-title>{{ username }} Week {{ week}} Results</v-card-title>
       <v-card-text>
         <h3>Wins</h3>
         <v-list :data-players-beaten="`${username}-week-${week}`">
@@ -25,6 +25,10 @@
         <h3>Losses</h3>
         <v-list :data-players-lost-to="`${username}-week-${week}`">
           {{ playersLostTo }}
+        </v-list>
+        <h3>Win Rate</h3>
+        <v-list :data-win-rate="`${username}-week-${week}`">
+          {{ winRatePercentage }}
         </v-list>
       </v-card-text>
       <v-card-actions class="d-flex justify-end">
@@ -86,6 +90,9 @@ export default {
     points() {
       return this.playerRow[`week_${this.week}_points`];
     },
+    weekCount() {
+      return this.playerRow[`week_${this.week}_count`];
+    },
     chipText() {
       switch (this.selectedMetric) {
         case Metrics.POINTS_AND_WINS:
@@ -142,6 +149,10 @@ export default {
       const attributeName = `data-week-${this.week}`;
       res[attributeName] = this.username;
       return res;
+    },
+    winRatePercentage() {
+      const winRate = Math.floor((this.wins / this.weekCount) * 100)
+      return `${winRate}%`;
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "description": "The deepest card game under the sea",
   "scripts": {

--- a/tests/e2e/specs/out-of-game/stats.spec.js
+++ b/tests/e2e/specs/out-of-game/stats.spec.js
@@ -102,6 +102,7 @@ describe('Stats Page', () => {
     cy.get('[data-player-results=Player1-week-1]').find('[data-cy=close-player-results]').click();
     cy.get('[data-players-beaten=Player1-week-1').should('not.be.visible');
     cy.get('[data-players-lost-to=Player1-week-1').should('not.be.visible');
+    cy.get('[data-win-rate=Player1-week-1]').should('contain', '100%');
     // Player result menus (Week with losses)
     cy.get("[data-week-1='Player2']").click();
     cy.get('[data-players-beaten=Player2-week-1]').should('contain', 'Player3, Player4');
@@ -109,6 +110,7 @@ describe('Stats Page', () => {
     cy.get('[data-player-results=Player2-week-1]').find('[data-cy=close-player-results]').click();
     cy.get('[data-players-beaten=Player2-week-1').should('not.be.visible');
     cy.get('[data-players-lost-to=Player2-week-1').should('not.be.visible');
+    cy.get('[data-win-rate=Player2-week-1]').should('contain', '66%');
     // Player result menus (Total)
     cy.get("[data-week-total='Player3']").click();
     cy.get('[data-players-beaten=Player3-week-total]').should('contain', 'Player5 (1)');
@@ -121,6 +123,7 @@ describe('Stats Page', () => {
       .click();
     cy.get('[data-players-beaten=Player3-week-total').should('not.be.visible');
     cy.get('[data-players-lost-to=Player3-week-total').should('not.be.visible');
+    cy.get('[data-win-rate=Player3-week-total]').should('contain', '12%');
   });
 
   it('Filters table to display wins, points, or both', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [x] Has the documentation been updated accordingly?
 
## Please describe additional details for testing this change
Resolves #201 

- Adds win rate section on player stats menu
- Renames stats menu title to  “[username] Week [week_number] Results”

![image](https://user-images.githubusercontent.com/15387723/198919729-1bb27d48-99a0-4594-b00f-abdabdfc20f0.png)
