### PR TITLE
Add class to fix card width for resolving seven

### DIFF
--- a/client/js/views/GameView.vue
+++ b/client/js/views/GameView.vue
@@ -150,7 +150,7 @@
                   :rank="topCard.rank"
                   :data-top-card="`${topCard.rank}-${topCard.suit}`"
                   :is-selected="topCardIsSelected"
-                  class="mb-4"
+                  class="mb-4 resolving-seven-size"
                   @click="selectTopCard"
                 />
                 <card
@@ -159,7 +159,7 @@
                   :rank="secondCard.rank"
                   :data-second-card="`${secondCard.rank}-${secondCard.suit}`"
                   :is-selected="secondCardIsSelected"
-                  class="mb-4"
+                  class="mb-4 resolving-seven-size"
                   @click="selectSecondCard"
                 />
               </div>
@@ -1189,6 +1189,10 @@ export default {
 
 .deck-container {
   grid-area: decks;
+}
+
+.resolving-seven-size {
+    width: 9.5rem;
 }
 
 #field-left {

--- a/client/js/views/GameView.vue
+++ b/client/js/views/GameView.vue
@@ -150,7 +150,7 @@
                   :rank="topCard.rank"
                   :data-top-card="`${topCard.rank}-${topCard.suit}`"
                   :is-selected="topCardIsSelected"
-                  class="mb-4 resolving-seven-size"
+                  class="mb-4 resolving-seven-card"
                   @click="selectTopCard"
                 />
                 <card
@@ -159,7 +159,7 @@
                   :rank="secondCard.rank"
                   :data-second-card="`${secondCard.rank}-${secondCard.suit}`"
                   :is-selected="secondCardIsSelected"
-                  class="mb-4 resolving-seven-size"
+                  class="mb-4 resolving-seven-card"
                   @click="selectSecondCard"
                 />
               </div>
@@ -1191,10 +1191,6 @@ export default {
   grid-area: decks;
 }
 
-.resolving-seven-size {
-    width: 9.5rem;
-}
-
 #field-left {
   & #deck {
     cursor: pointer;
@@ -1202,6 +1198,9 @@ export default {
     &.reveal-top-two {
       height: auto;
       align-self: start;
+        & .resolving-seven-card {
+            width: 9.5rem;
+        }
     }
     & #empty-deck-text {
       background-color: rgba(0, 0, 0, 0.8);

--- a/client/js/views/GameView.vue
+++ b/client/js/views/GameView.vue
@@ -1198,9 +1198,9 @@ export default {
     &.reveal-top-two {
       height: auto;
       align-self: start;
-        & .resolving-seven-card {
-            width: 9.5rem;
-        }
+      & .resolving-seven-card {
+        width: 9.5rem;
+      }
     }
     & #empty-deck-text {
       background-color: rgba(0, 0, 0, 0.8);


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

Adds class to fix card width when resolving seven. Fixes #179 