### PR TITLE
Add form element to ReauthenticateDialog.vue

### DIFF
--- a/client/js/components/GameView/ReauthenticateDialog.vue
+++ b/client/js/components/GameView/ReauthenticateDialog.vue
@@ -2,31 +2,33 @@
   <v-dialog v-model="show" persistent max-width="650">
     <v-card id="reauthenticate-dialog">
       <v-card-title>Reconnect to Game</v-card-title>
-      <v-card-text>
-        <p>You have disconnected due to inactivity. Log in again to resume your session</p>
-        <!-- Login Form -->
-        <v-text-field
-          v-model="username"
-          outlined
-          :dense="$vuetify.breakpoint.mdAndDown"
-          label="Username"
-          data-cy="username"
-          @keyup.enter="login"
-        />
-        <v-text-field
-          v-model="password"
-          outlined
-          label="Password"
-          :dense="$vuetify.breakpoint.mdAndDown"
-          type="password"
-          data-cy="password"
-          @keyup.enter="login"
-        />
-      </v-card-text>
-      <v-card-actions class="d-flex justify-end">
-        <v-btn text color="primary" @click="leaveGame"> Leave Game </v-btn>
-        <v-btn color="primary" depressed data-cy="login" @click="login"> Log In </v-btn>
-      </v-card-actions>
+      <form @submit.prevent="login">
+        <v-card-text>
+          <p>You have disconnected due to inactivity. Log in again to resume your session</p>
+          <!-- Login Form -->
+          <v-text-field
+            v-model="username"
+            outlined
+            :dense="$vuetify.breakpoint.mdAndDown"
+            label="Username"
+            data-cy="username"
+          />
+          <v-text-field
+            v-model="password"
+            outlined
+            label="Password"
+            :dense="$vuetify.breakpoint.mdAndDown"
+            type="password"
+            data-cy="password"
+          />
+        </v-card-text>
+        <v-card-actions class="d-flex justify-end">
+          <v-btn text color="primary" @click="leaveGame"> Leave Game </v-btn>
+          <v-btn color="primary" depressed data-cy="login" type="submit" @click="login">
+            Log In
+          </v-btn>
+        </v-card-actions>
+      </form>
     </v-card>
     <v-snackbar
       v-model="showSnackBar"

--- a/client/js/components/GameView/ReauthenticateDialog.vue
+++ b/client/js/components/GameView/ReauthenticateDialog.vue
@@ -24,7 +24,7 @@
         </v-card-text>
         <v-card-actions class="d-flex justify-end">
           <v-btn text color="primary" @click="leaveGame"> Leave Game </v-btn>
-          <v-btn color="primary" depressed data-cy="login" type="submit" @click="login">
+          <v-btn color="primary" depressed data-cy="login" type="submit">
             Log In
           </v-btn>
         </v-card-actions>

--- a/client/js/components/GameView/ReauthenticateDialog.vue
+++ b/client/js/components/GameView/ReauthenticateDialog.vue
@@ -24,9 +24,7 @@
         </v-card-text>
         <v-card-actions class="d-flex justify-end">
           <v-btn text color="primary" @click="leaveGame"> Leave Game </v-btn>
-          <v-btn color="primary" depressed data-cy="login" type="submit">
-            Log In
-          </v-btn>
+          <v-btn color="primary" depressed data-cy="login" type="submit"> Log In </v-btn>
         </v-card-actions>
       </form>
     </v-card>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "3.2.12",
+  "version": "3.2.13",
   "private": true,
   "description": "The deepest card game under the sea",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "private": true,
   "description": "The deepest card game under the sea",
   "scripts": {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Fixes #97 
As stated in the issue, this PR wraps `client\js\components\GameView\ReauthenticateDialog.vue`'s `v-text-field`s and buttons in a `form` element, with `@submit.prevent="login"`, following `LoginSignup` page's example.