### PR TITLE
Enable debugging the backend by default and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,26 @@ to execute the entire test suite headlessly against localhost:1337, which you ca
 
 **NOTE** you should run `npm run build` (see above) before this command so that the server (backend) serves the most up-to-date version of the client.
 
+#### Debugging Backend Server
+
+You can utilize the node debugger in VSCode to debug the backend server.
+
+To do so, start the backend server with:
+
+```
+npm run start:dev
+```
+
+or
+
+```
+npm run start:server
+```
+
+Then, hit cmd+shift+p or ctrl+shift+p, and then enter `Debug: Attach to node process` in the top window opened, to select the process you want to watch.
+
+You will be able to utilize many standard debugging features, such as setting breakpoints by clicking line numbers, stepping in and over function, and watching variables. For details, please refer to the [documentation](https://code.visualstudio.com/docs/editor/debugging).
+
 #### Linting (Formatting)
 
 Format the project with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "description": "The deepest card game under the sea",
   "scripts": {
@@ -21,7 +21,7 @@
     "start:devtools": "vue-devtools",
     "start:mockprod": "cross-env CUTTLE_ENV=production npm run build && CUTTLE_ENV=production npm run start:server",
     "start:mockprod:tools": "concurrently \"cross-env NODE_ENV=dev ENABLE_VUE_DEVTOOLS=true npm run build && npm run start:server\" \"npm run start:devtools\"",
-    "start:server": "node app.js",
+    "start:server": "node app.js --inspect",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [x] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Fixes #208 
This adds the `--inspect` flag to the `node app.js` command used by `start:dev` and `start:server`, to enable debugging the backend server by default.
With this, a section about debugging the backend server is added in README.md to inform people on debugging it using the node debugger in VSCode.
