### PR TITLE
Add count of matches won, lost, and total to Stats page

### DIFF
--- a/client/js/components/StatsLeaderboardCell.vue
+++ b/client/js/components/StatsLeaderboardCell.vue
@@ -28,7 +28,7 @@
         </v-list>
         <h3>Win Rate</h3>
         <v-list :data-win-rate="`${username}-week-${week}`">
-          {{ winRatePercentage }} {{ winRateText }}
+          {{ winRateText }}
         </v-list>
       </v-card-text>
       <v-card-actions class="d-flex justify-end">
@@ -158,7 +158,7 @@ export default {
       return this.weekCount - this.wins;
     },
     winRateText() {
-      return `(${this.wins} Won, ${this.losses} Lost, ${this.weekCount} Total)`;
+      return `${this.winRatePercentage} (${this.wins} Won, ${this.losses} Lost, ${this.weekCount} Total)`;
     },
   },
 };

--- a/client/js/components/StatsLeaderboardCell.vue
+++ b/client/js/components/StatsLeaderboardCell.vue
@@ -28,7 +28,7 @@
         </v-list>
         <h3>Win Rate</h3>
         <v-list :data-win-rate="`${username}-week-${week}`">
-          {{ winRatePercentage }}
+          {{ winRatePercentage }} {{ winRateText }}
         </v-list>
       </v-card-text>
       <v-card-actions class="d-flex justify-end">
@@ -153,6 +153,12 @@ export default {
     winRatePercentage() {
       const winRate = Math.floor((this.wins / this.weekCount) * 100);
       return `${winRate}%`;
+    },
+    losses() {
+      return this.weekCount - this.wins;
+    },
+    winRateText() {
+      return `(${this.wins} Won, ${this.losses} Lost, ${this.weekCount} Total)`;
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "description": "The deepest card game under the sea",
   "scripts": {

--- a/tests/e2e/specs/out-of-game/stats.spec.js
+++ b/tests/e2e/specs/out-of-game/stats.spec.js
@@ -103,6 +103,9 @@ describe('Stats Page', () => {
     cy.get('[data-players-beaten=Player1-week-1').should('not.be.visible');
     cy.get('[data-players-lost-to=Player1-week-1').should('not.be.visible');
     cy.get('[data-win-rate=Player1-week-1]').should('contain', '100%');
+    cy.get('[data-win-rate=Player1-week-1]').should('contain', '3 Won');
+    cy.get('[data-win-rate=Player1-week-1]').should('contain', '0 Lost');
+    cy.get('[data-win-rate=Player1-week-1]').should('contain', '3 Total');
     // Player result menus (Week with losses)
     cy.get("[data-week-1='Player2']").click();
     cy.get('[data-players-beaten=Player2-week-1]').should('contain', 'Player3, Player4');
@@ -111,6 +114,9 @@ describe('Stats Page', () => {
     cy.get('[data-players-beaten=Player2-week-1').should('not.be.visible');
     cy.get('[data-players-lost-to=Player2-week-1').should('not.be.visible');
     cy.get('[data-win-rate=Player2-week-1]').should('contain', '66%');
+    cy.get('[data-win-rate=Player2-week-1]').should('contain', '2 Won');
+    cy.get('[data-win-rate=Player2-week-1]').should('contain', '1 Lost');
+    cy.get('[data-win-rate=Player2-week-1]').should('contain', '3 Total');
     // Player result menus (Total)
     cy.get("[data-week-total='Player3']").click();
     cy.get('[data-players-beaten=Player3-week-total]').should('contain', 'Player5 (1)');
@@ -124,6 +130,9 @@ describe('Stats Page', () => {
     cy.get('[data-players-beaten=Player3-week-total').should('not.be.visible');
     cy.get('[data-players-lost-to=Player3-week-total').should('not.be.visible');
     cy.get('[data-win-rate=Player3-week-total]').should('contain', '12%');
+    cy.get('[data-win-rate=Player3-week-total]').should('contain', '1 Won');
+    cy.get('[data-win-rate=Player3-week-total]').should('contain', '7 Lost');
+    cy.get('[data-win-rate=Player3-week-total]').should('contain', '8 Total');
   });
 
   it('Filters table to display wins, points, or both', () => {


### PR DESCRIPTION
Added `(X Won, X Lost, X Total)` text to the stats page, next to the win rate percentage. Updated tests accordingly.