### PR TITLE
Move some assertion tests to skipped e2e tests block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "private": true,
   "description": "The deepest card game under the sea",
   "scripts": {

--- a/tests/e2e/specs/in-game/layout.spec.js
+++ b/tests/e2e/specs/in-game/layout.spec.js
@@ -474,4 +474,4 @@ describe.skip('Aesthetic tests', () => {
       p1FaceCards: [Card.KING_OF_HEARTS],
     });
   });
-})
+});

--- a/tests/e2e/specs/in-game/layout.spec.js
+++ b/tests/e2e/specs/in-game/layout.spec.js
@@ -22,6 +22,210 @@ describe('Game View Layout', () => {
     cy.get('[data-cy=player-username]').should('be.visible');
   });
 
+  it('Three dialogs', () => {
+    // Set Up
+    cy.loadGameFixture({
+      p0Hand: [Card.THREE_OF_CLUBS],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [Card.TEN_OF_DIAMONDS],
+      p1Points: [Card.ACE_OF_HEARTS],
+      p1FaceCards: [Card.KING_OF_HEARTS],
+      scrap: [Card.ACE_OF_SPADES, Card.TEN_OF_HEARTS, Card.TEN_OF_SPADES],
+    });
+    cy.get('[data-player-hand-card]').should('have.length', 1);
+    cy.log('Loaded fixture');
+
+    // Player plays three
+    cy.get('[data-player-hand-card=3-0]').click(); // three of clubs
+    cy.get('[data-move-choice=oneOff]').click();
+
+    cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
+
+    cy.resolveOpponent();
+
+    cy.get('#waiting-for-opponent-counter-scrim').should('not.be.visible');
+
+    cy.get('#three-dialog').should('be.visible');
+    // resolve button should be disabled
+    cy.get('[data-cy=three-resolve').should('be.disabled');
+
+    // Player selects a card from scrap
+    cy.get('[data-three-dialog-card=10-2]').click();
+    cy.get('[data-cy=three-resolve').should('not.be.disabled').click();
+
+    assertGameState(0, {
+      p0Hand: [Card.TEN_OF_HEARTS],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [Card.TEN_OF_DIAMONDS],
+      p1Points: [Card.ACE_OF_HEARTS],
+      p1FaceCards: [Card.KING_OF_HEARTS],
+      scrap: [Card.ACE_OF_SPADES, Card.THREE_OF_CLUBS, Card.TEN_OF_SPADES],
+    });
+
+    // Player attempts to play out of turn
+    cy.get('[data-player-hand-card=10-2]').click(); // ten of hearts
+    playOutOfTurn('points');
+
+    cy.playPointsOpponent(Card.TEN_OF_DIAMONDS);
+
+    assertGameState(0, {
+      p0Hand: [Card.TEN_OF_HEARTS],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [],
+      p1Points: [Card.ACE_OF_HEARTS, Card.TEN_OF_DIAMONDS],
+      p1FaceCards: [Card.KING_OF_HEARTS],
+      scrap: [Card.ACE_OF_SPADES, Card.THREE_OF_CLUBS, Card.TEN_OF_SPADES],
+    });
+  });
+
+  it('Click the scrap to view contents', () => {
+    // Given-- the initial game state with 3 cards in the scrap
+    const scrap = [
+      Card.ACE_OF_SPADES,
+      Card.TEN_OF_HEARTS,
+      Card.TEN_OF_SPADES,
+      Card.FOUR_OF_CLUBS,
+      Card.TWO_OF_HEARTS,
+      Card.EIGHT_OF_SPADES,
+      Card.TWO_OF_CLUBS,
+      Card.ACE_OF_CLUBS,
+      Card.TWO_OF_DIAMONDS,
+    ];
+    cy.loadGameFixture({
+      p0Hand: [Card.THREE_OF_CLUBS],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [Card.TEN_OF_DIAMONDS],
+      p1Points: [Card.ACE_OF_HEARTS],
+      p1FaceCards: [Card.KING_OF_HEARTS],
+      scrap,
+    });
+    cy.get('[data-player-hand-card]').should('have.length', 1);
+    cy.log('Loaded fixture');
+
+    // When-- Click the scrap
+    cy.log('Clicking scrap');
+    cy.get('#scrap').click();
+
+    // Then-- Assert that the overlay that should show up does
+    cy.get('#scrap-dialog').should('be.visible');
+
+    // Make sure that the three cards in the scrap are shown
+    cy.get('[data-scrap-dialog-card]').should('have.length', 9);
+    cy.get('[data-scrap-dialog-card=1-3]').should('be.visible');
+    cy.get('[data-scrap-dialog-card=10-2]').should('be.visible');
+    cy.get('[data-scrap-dialog-card=10-3]').should('be.visible');
+
+    // Given-- the scrap is currently open
+    // When-- Close it with X
+    cy.log('Closing scrap with X');
+    cy.get('[data-cy=close-scrap-dialog-x]').click();
+    // Then-- Scrap should be closed
+    cy.get('#scrap-dialog').should('not.be.visible');
+
+    // Given-- the scrap is currently open
+    cy.get('#scrap').click();
+    cy.get('#scrap-dialog').should('be.visible');
+    // When-- Close it with the close button
+    cy.log('Closing scrap with button');
+    cy.get('[data-cy=close-scrap-dialog-button]').click();
+    // Then-- Scrap should be closed
+    cy.get('#scrap-dialog').should('not.be.visible');
+
+    // Given -- the scrap is currently open
+    cy.get('#scrap').click();
+    cy.get('#scrap-dialog').should('be.visible');
+
+    // Then-- All cards should be in ascending rank order
+    const mapElementsToRank = (elements) => {
+      return _.map(elements, (element) => {
+        return Number(element.attributes['data-scrap-dialog-card'].value.split('-')[0]);
+      });
+    };
+    cy.get('[data-scrap-dialog-card]')
+      .then(mapElementsToRank)
+      .then((elementRanks) => {
+        const sortedScrapRanksFromFixture = _.sortBy(scrap, 'rank').map((card) => card.rank);
+        expect(elementRanks).to.deep.equal(sortedScrapRanksFromFixture);
+      });
+  });
+
+  it('Clicking the scrap while empty shows that it is empty', () => {
+    // Given-- the initial game state with 3 cards in the scrap
+    cy.loadGameFixture({
+      p0Hand: [Card.THREE_OF_CLUBS],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [Card.TEN_OF_DIAMONDS],
+      p1Points: [Card.ACE_OF_HEARTS],
+      p1FaceCards: [Card.KING_OF_HEARTS],
+      scrap: [],
+    });
+    cy.get('[data-player-hand-card]').should('have.length', 1);
+    cy.log('Loaded fixture');
+
+    // When-- Click the scrap
+    cy.log('Clicking scrap');
+    cy.get('#scrap').click();
+
+    // Then-- Assert that the overlay that should show up does and that there are no cards in it
+    cy.get('#scrap-dialog')
+      .should('be.visible')
+      .should('contain', 'There are no cards in the scrap pile.');
+  });
+});
+
+describe('Four dialogs layout', () => {
+  beforeEach(() => {
+    setupGameAsP1();
+  });
+
+  it('Four dialogs', () => {
+    cy.loadGameFixture({
+      p0Hand: [Card.FOUR_OF_CLUBS, Card.ACE_OF_HEARTS],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [Card.FOUR_OF_SPADES, Card.ACE_OF_DIAMONDS, Card.TEN_OF_HEARTS],
+      p1Points: [],
+      p1FaceCards: [],
+    });
+    cy.get('[data-player-hand-card]').should('have.length', 3);
+    cy.log('Loaded fixture');
+
+    // Opponent plays four
+    cy.playOneOffOpponent(Card.FOUR_OF_CLUBS);
+    // Player cannot counter
+    cy.get('#cannot-counter-dialog')
+      .should('be.visible')
+      .get('[data-cy=cannot-counter-resolve]')
+      .click();
+
+    // Four Dialog appears (you must discard)
+    cy.get('#four-discard-dialog').should('be.visible');
+    // Choosing cards to discard
+    cy.log('Choosing two cards to discard');
+    cy.get('[data-cy=submit-four-dialog]').should('be.disabled'); // can't prematurely submit
+    cy.get('[data-discard-card=1-1]').click(); // ace of diamonds
+    cy.get('[data-cy=submit-four-dialog]').should('be.disabled'); // can't prematurely submit
+    cy.get('[data-discard-card=4-3]').click(); // four of spades
+    cy.get('[data-cy=submit-four-dialog]').click(); // submit choice to discard
+
+    assertGameState(1, {
+      p0Hand: [Card.ACE_OF_HEARTS],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [Card.TEN_OF_HEARTS],
+      p1Points: [],
+      p1FaceCards: [],
+      scrap: [Card.FOUR_OF_CLUBS, Card.FOUR_OF_SPADES, Card.ACE_OF_DIAMONDS],
+    });
+  });
+});
+
+describe.skip('Aesthetic tests', () => {
   it('Many cards on field', () => {
     // Set Up
     cy.loadGameFixture({
@@ -270,206 +474,4 @@ describe('Game View Layout', () => {
       p1FaceCards: [Card.KING_OF_HEARTS],
     });
   });
-
-  it('Three dialogs', () => {
-    // Set Up
-    cy.loadGameFixture({
-      p0Hand: [Card.THREE_OF_CLUBS],
-      p0Points: [],
-      p0FaceCards: [],
-      p1Hand: [Card.TEN_OF_DIAMONDS],
-      p1Points: [Card.ACE_OF_HEARTS],
-      p1FaceCards: [Card.KING_OF_HEARTS],
-      scrap: [Card.ACE_OF_SPADES, Card.TEN_OF_HEARTS, Card.TEN_OF_SPADES],
-    });
-    cy.get('[data-player-hand-card]').should('have.length', 1);
-    cy.log('Loaded fixture');
-
-    // Player plays three
-    cy.get('[data-player-hand-card=3-0]').click(); // three of clubs
-    cy.get('[data-move-choice=oneOff]').click();
-
-    cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
-
-    cy.resolveOpponent();
-
-    cy.get('#waiting-for-opponent-counter-scrim').should('not.be.visible');
-
-    cy.get('#three-dialog').should('be.visible');
-    // resolve button should be disabled
-    cy.get('[data-cy=three-resolve').should('be.disabled');
-
-    // Player selects a card from scrap
-    cy.get('[data-three-dialog-card=10-2]').click();
-    cy.get('[data-cy=three-resolve').should('not.be.disabled').click();
-
-    assertGameState(0, {
-      p0Hand: [Card.TEN_OF_HEARTS],
-      p0Points: [],
-      p0FaceCards: [],
-      p1Hand: [Card.TEN_OF_DIAMONDS],
-      p1Points: [Card.ACE_OF_HEARTS],
-      p1FaceCards: [Card.KING_OF_HEARTS],
-      scrap: [Card.ACE_OF_SPADES, Card.THREE_OF_CLUBS, Card.TEN_OF_SPADES],
-    });
-
-    // Player attempts to play out of turn
-    cy.get('[data-player-hand-card=10-2]').click(); // ten of hearts
-    playOutOfTurn('points');
-
-    cy.playPointsOpponent(Card.TEN_OF_DIAMONDS);
-
-    assertGameState(0, {
-      p0Hand: [Card.TEN_OF_HEARTS],
-      p0Points: [],
-      p0FaceCards: [],
-      p1Hand: [],
-      p1Points: [Card.ACE_OF_HEARTS, Card.TEN_OF_DIAMONDS],
-      p1FaceCards: [Card.KING_OF_HEARTS],
-      scrap: [Card.ACE_OF_SPADES, Card.THREE_OF_CLUBS, Card.TEN_OF_SPADES],
-    });
-  });
-
-  it('Click the scrap to view contents', () => {
-    // Given-- the initial game state with 3 cards in the scrap
-    const scrap = [
-      Card.ACE_OF_SPADES,
-      Card.TEN_OF_HEARTS,
-      Card.TEN_OF_SPADES,
-      Card.FOUR_OF_CLUBS,
-      Card.TWO_OF_HEARTS,
-      Card.EIGHT_OF_SPADES,
-      Card.TWO_OF_CLUBS,
-      Card.ACE_OF_CLUBS,
-      Card.TWO_OF_DIAMONDS,
-    ];
-    cy.loadGameFixture({
-      p0Hand: [Card.THREE_OF_CLUBS],
-      p0Points: [],
-      p0FaceCards: [],
-      p1Hand: [Card.TEN_OF_DIAMONDS],
-      p1Points: [Card.ACE_OF_HEARTS],
-      p1FaceCards: [Card.KING_OF_HEARTS],
-      scrap,
-    });
-    cy.get('[data-player-hand-card]').should('have.length', 1);
-    cy.log('Loaded fixture');
-
-    // When-- Click the scrap
-    cy.log('Clicking scrap');
-    cy.get('#scrap').click();
-
-    // Then-- Assert that the overlay that should show up does
-    cy.get('#scrap-dialog').should('be.visible');
-
-    // Make sure that the three cards in the scrap are shown
-    cy.get('[data-scrap-dialog-card]').should('have.length', 9);
-    cy.get('[data-scrap-dialog-card=1-3]').should('be.visible');
-    cy.get('[data-scrap-dialog-card=10-2]').should('be.visible');
-    cy.get('[data-scrap-dialog-card=10-3]').should('be.visible');
-
-    // Given-- the scrap is currently open
-    // When-- Close it with X
-    cy.log('Closing scrap with X');
-    cy.get('[data-cy=close-scrap-dialog-x]').click();
-    // Then-- Scrap should be closed
-    cy.get('#scrap-dialog').should('not.be.visible');
-
-    // Given-- the scrap is currently open
-    cy.get('#scrap').click();
-    cy.get('#scrap-dialog').should('be.visible');
-    // When-- Close it with the close button
-    cy.log('Closing scrap with button');
-    cy.get('[data-cy=close-scrap-dialog-button]').click();
-    // Then-- Scrap should be closed
-    cy.get('#scrap-dialog').should('not.be.visible');
-
-    // Given -- the scrap is currently open
-    cy.get('#scrap').click();
-    cy.get('#scrap-dialog').should('be.visible');
-
-    // Then-- All cards should be in ascending rank order
-    const mapElementsToRank = (elements) => {
-      return _.map(elements, (element) => {
-        return Number(element.attributes['data-scrap-dialog-card'].value.split('-')[0]);
-      });
-    };
-    cy.get('[data-scrap-dialog-card]')
-      .then(mapElementsToRank)
-      .then((elementRanks) => {
-        const sortedScrapRanksFromFixture = _.sortBy(scrap, 'rank').map((card) => card.rank);
-        expect(elementRanks).to.deep.equal(sortedScrapRanksFromFixture);
-      });
-  });
-
-  it('Clicking the scrap while empty shows that it is empty', () => {
-    // Given-- the initial game state with 3 cards in the scrap
-    cy.loadGameFixture({
-      p0Hand: [Card.THREE_OF_CLUBS],
-      p0Points: [],
-      p0FaceCards: [],
-      p1Hand: [Card.TEN_OF_DIAMONDS],
-      p1Points: [Card.ACE_OF_HEARTS],
-      p1FaceCards: [Card.KING_OF_HEARTS],
-      scrap: [],
-    });
-    cy.get('[data-player-hand-card]').should('have.length', 1);
-    cy.log('Loaded fixture');
-
-    // When-- Click the scrap
-    cy.log('Clicking scrap');
-    cy.get('#scrap').click();
-
-    // Then-- Assert that the overlay that should show up does and that there are no cards in it
-    cy.get('#scrap-dialog')
-      .should('be.visible')
-      .should('contain', 'There are no cards in the scrap pile.');
-  });
-});
-
-describe('Four dialogs layout', () => {
-  beforeEach(() => {
-    setupGameAsP1();
-  });
-
-  it('Four dialogs', () => {
-    cy.loadGameFixture({
-      p0Hand: [Card.FOUR_OF_CLUBS, Card.ACE_OF_HEARTS],
-      p0Points: [],
-      p0FaceCards: [],
-      p1Hand: [Card.FOUR_OF_SPADES, Card.ACE_OF_DIAMONDS, Card.TEN_OF_HEARTS],
-      p1Points: [],
-      p1FaceCards: [],
-    });
-    cy.get('[data-player-hand-card]').should('have.length', 3);
-    cy.log('Loaded fixture');
-
-    // Opponent plays four
-    cy.playOneOffOpponent(Card.FOUR_OF_CLUBS);
-    // Player cannot counter
-    cy.get('#cannot-counter-dialog')
-      .should('be.visible')
-      .get('[data-cy=cannot-counter-resolve]')
-      .click();
-
-    // Four Dialog appears (you must discard)
-    cy.get('#four-discard-dialog').should('be.visible');
-    // Choosing cards to discard
-    cy.log('Choosing two cards to discard');
-    cy.get('[data-cy=submit-four-dialog]').should('be.disabled'); // can't prematurely submit
-    cy.get('[data-discard-card=1-1]').click(); // ace of diamonds
-    cy.get('[data-cy=submit-four-dialog]').should('be.disabled'); // can't prematurely submit
-    cy.get('[data-discard-card=4-3]').click(); // four of spades
-    cy.get('[data-cy=submit-four-dialog]').click(); // submit choice to discard
-
-    assertGameState(1, {
-      p0Hand: [Card.ACE_OF_HEARTS],
-      p0Points: [],
-      p0FaceCards: [],
-      p1Hand: [Card.TEN_OF_HEARTS],
-      p1Points: [],
-      p1FaceCards: [],
-      scrap: [Card.FOUR_OF_CLUBS, Card.FOUR_OF_SPADES, Card.ACE_OF_DIAMONDS],
-    });
-  });
-});
+})


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [x] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Changes include refactoring existing E2E tests and moving some 'Aesthetic tests', which are not necessarily have to be runned on the CI to `describe.skip('Aesthetic tests'` block to increase the CI performance 

Issue #192 

