### PR TITLE
Fix/scuttle animation firefox

### DIFF
--- a/client/js/components/GameView/Card.vue
+++ b/client/js/components/GameView/Card.vue
@@ -22,9 +22,12 @@
       opacity=".8"
     />
     <transition name="slide-above">
-      <v-overlay v-if="scuttledBy" absolute :value="true" class="scuttled-by-overlay">
-        <card :suit="scuttledBy.suit" :rank="scuttledBy.rank"></card>
-      </v-overlay>
+      <template v-if="scuttledBy">
+        <img
+          class="scuttled-by-card"
+          :src="require(`../../img/cards/card_${scuttledBy.suit}_${scuttledBy.rank}.svg`)"
+        />
+      </template>
     </transition>
     <img
       v-if="isGlasses"
@@ -153,6 +156,15 @@ export default {
     max-width: 20vh;
     height: calc(20vh / 1.45);
   }
+
+  & .scuttled-by-card {
+    height: 100%;
+    top: -42px;
+    left: 16px;
+    transition: all 1s ease;
+    position: absolute;
+    z-index: 1;
+  }
 }
 .player-card-icon {
   position: absolute;
@@ -207,11 +219,6 @@ export default {
   }
 }
 
-.scuttled-by-overlay {
-  height: 80%;
-  top: -32px;
-  transition: all 1s ease;
-}
 .slide-below-leave-active,
 .slide-above-leave-active,
 .in-below-out-left-leave-active {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "3.2.13",
+  "version": "3.2.14",
   "private": true,
   "description": "The deepest card game under the sea",
   "scripts": {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
The scuttle animation didn't work on firefox because the scuttling card is not properly sized. The result looks like this:
![image](https://user-images.githubusercontent.com/6520704/204297261-8962b26f-062a-4ed5-a111-5308f4efb4d5.png)

This fix reworks the template and css for the scuttling card to ensure it renders on firefox and also repositions the scuttling card (up and left) for a more organic feel)
![image](https://user-images.githubusercontent.com/6520704/204297499-02d45edd-6b97-4141-86ab-3e09c9905db5.png)

