### PR TITLE
issue235 - [Feature]: Create Separate url links for login vs signup

### DIFF
--- a/client/js/router/index.js
+++ b/client/js/router/index.js
@@ -37,6 +37,11 @@ const routes = [
     name: 'Login',
     component: LoginSignup,
   },
+  {
+    path: '/signup',
+    name: 'Signup ',
+    component: LoginSignup,
+  },
   // This route is just a passthrough to make sure the user is fully logged out before putting
   // them on the login screen
   {

--- a/client/js/views/LoginSignup.vue
+++ b/client/js/views/LoginSignup.vue
@@ -99,15 +99,14 @@ export default {
     return {
       username: '',
       pw: '',
-      isLoggingIn: true,
       showSnackBar: false,
       snackBarMessage: '',
       loading: false,
     };
   },
   computed: {
-    isSigningUp() {
-      return !this.isLoggingIn;
+    isLoggingIn() {
+      return this.$route.name === 'Login';
     },
     buttonText() {
       if (this.isLoggingIn) {
@@ -137,8 +136,12 @@ export default {
       }
     },
     switchMode() {
-      this.isLoggingIn = !this.isLoggingIn;
       this.pw = '';
+      if (this.isLoggingIn) {
+        this.$router.push('/signup');
+      } else {
+        this.$router.push('/login');
+      }
     },
     handleLogin() {
       this.username = '';


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [o] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [o] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [o] Have tests been added to cover any new features or fixes?
  - [] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
There is currently no separate route for signup. So, in order to access the sign-up page, you must access the login page first.
I created a new signup path and modified the Login Signup page as required.
Please let me know if there is anything to be revised.
Thank you!

