### PR TITLE
feat: enable ci for pr's into feature/vue-3

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - feature/vue-3
     # Defaults + ready_for_review to trigger a re-run when a Draft PR is converted to a normal PR
     # See: https://github.community/t/dont-run-actions-on-draft-pull-requests/16817/17
     types: [opened, synchronize, reopened, ready_for_review]


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Enables CI runs when PR's are opened into feature/vue-3. Should work the same as pr's into main
