### PR TITLE
feat: hide the stats leaderboard when no matches are available

### DIFF
--- a/client/js/components/StatsLeaderboard.vue
+++ b/client/js/components/StatsLeaderboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div data-cy="stats-leaderboard">
     <!-- Select Metric and Weeks -->
     <div id="stats-table-upper-surface" class="d-flex align-end">
       <v-select

--- a/client/js/views/Stats.vue
+++ b/client/js/views/Stats.vue
@@ -61,11 +61,15 @@
         </p>
       </div>
       <!-- Rankings Table -->
-      <h2 class="text-h2 mb-4">
-        Weekly Rankings
-        <stats-scoring-dialog />
-      </h2>
-      <stats-leaderboard :loading="loadingData" :season="selectedSeason" />
+      <template
+        v-if="selectedSeason && selectedSeason.rankings && selectedSeason.rankings.length > 0"
+      >
+        <h2 class="text-h2 mb-4">
+          Weekly Rankings
+          <stats-scoring-dialog />
+        </h2>
+        <stats-leaderboard :loading="loadingData" :season="selectedSeason" />
+      </template>
     </section>
   </div>
 </template>

--- a/tests/e2e/fixtures/statsFixtures.js
+++ b/tests/e2e/fixtures/statsFixtures.js
@@ -28,6 +28,17 @@ const seasonFixtures = [
     // endTime: 1674178200,
     endTime: dayjs().add(1, 'year').valueOf(),
   },
+  {
+    name: 'World Championship Season',
+    startTime: dayjs().subtract(1, 'second').valueOf(),
+    endTime: dayjs().add(13, 'week').valueOf(),
+    firstPlace: 'player1',
+    secondPlace: 'player2',
+    thirdPlace: 'player3',
+    fourthPlace: 'player4',
+    bracketLink: 'https://github.com/cuttle-cards/cuttle',
+    footageLink: 'https://github.com/cuttle-cards/cuttle-assets',
+  },
 ];
 
 const seasonOneMatches = [

--- a/tests/e2e/specs/out-of-game/stats.spec.js
+++ b/tests/e2e/specs/out-of-game/stats.spec.js
@@ -30,7 +30,6 @@ function setup() {
           fourthPlace: season.fourthPlace ? this[season.fourthPlace] : null,
         };
       });
-
       // Convert usernames to ids
       const transformMatchFixture = (match) => {
         // Grab player ids
@@ -210,8 +209,32 @@ describe('Stats Page', () => {
     cy.get('[data-week-2=Player1]').should('contain', 'W: 3, P: 4');
   });
 
-  it('Selects season that should not be available', () => {
+  it('Hides season that should not be available', () => {
     cy.get('[data-cy=season-select]').click({ force: true });
     cy.get('[role=option]').contains('Future Spades Season').should('not.exist');
+  });
+
+  it('Hides stats table when matches are not available', () => {
+    // Select World Championship
+    cy.get('[data-cy=season-select]').click({ force: true });
+    cy.get('[role=option]').contains('World Championship Season').click();
+    cy.get('[data-cy=stats-leaderboard]').should('not.exist');
+
+    const worldChampionshipSeason = seasonFixtures[seasonFixtures.length - 1];
+    // Tournament Data
+    cy.get('[data-cy=tournament-bracket-link]').should(
+      'have.attr',
+      'href',
+      worldChampionshipSeason.bracketLink
+    );
+    cy.get('[data-cy=tournament-footage-link]').should(
+      'have.attr',
+      'href',
+      worldChampionshipSeason.footageLink
+    );
+    // Award Cards
+    cy.get('[data-tournament=1st]').should('contain', playerOne.username);
+    cy.get('[data-tournament=2nd]').should('contain', playerTwo.username);
+    cy.get('[data-tournament=3rd]').should('contain', playerThree.username);
   });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
This is intended to facilitate creating a season page for the World Championship, where the leaderboard doesn't make sense or isn't necessary
