### PR TITLE
Fix/console warnings - Resolves #289

### DIFF
--- a/src/components/CreateGameDialog.vue
+++ b/src/components/CreateGameDialog.vue
@@ -56,6 +56,7 @@ const LS_PREFERS_RANKED_NAME = 'prefersRanked';
 export default {
   name: 'CreateGameDialog',
   components: { StatsScoringDialog },
+  emits: ['error'],
   data() {
     return {
       show: false,

--- a/src/components/GameView/CannotCounterDialog.vue
+++ b/src/components/GameView/CannotCounterDialog.vue
@@ -43,6 +43,7 @@ export default {
   components: {
     GameCard,
   },
+  emits: ['resolve'],
   props: {
     modelValue: {
       type: Boolean,
@@ -69,7 +70,6 @@ export default {
       default: null,
     },
   },
-  emits: ['resolve'],
   data() {
     return {
       loading: false,

--- a/src/components/GameView/CannotCounterDialog.vue
+++ b/src/components/GameView/CannotCounterDialog.vue
@@ -70,11 +70,6 @@ export default {
       default: null,
     },
   },
-  data() {
-    return {
-      loading: false,
-    }
-  },
   computed: {
     show: {
       get() {

--- a/src/components/GameView/CannotCounterDialog.vue
+++ b/src/components/GameView/CannotCounterDialog.vue
@@ -44,7 +44,7 @@ export default {
     GameCard,
   },
   props: {
-    value: {
+    modelValue: {
       type: Boolean,
       required: true,
     },
@@ -69,13 +69,19 @@ export default {
       default: null,
     },
   },
+  emits: ['resolve'],
+  data() {
+    return {
+      loading: false,
+    }
+  },
   computed: {
     show: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
-      set(val) {
-        this.$emit('input', val);
+      set() {
+        // do nothing - parent controls whether dialog is open
       },
     },
     reason() {

--- a/src/components/GameView/CounterDialog.vue
+++ b/src/components/GameView/CounterDialog.vue
@@ -68,6 +68,7 @@ export default {
   components: {
     GameCard,
   },
+  emits: ['counter', 'resolve'],
   props: {
     modelValue: {
       type: Boolean,
@@ -91,7 +92,6 @@ export default {
       required: true,
     },
   },
-  emits: ['counter', 'resolve'],
   data() {
     return {
       choseToCounter: false,

--- a/src/components/GameView/CounterDialog.vue
+++ b/src/components/GameView/CounterDialog.vue
@@ -69,7 +69,7 @@ export default {
     GameCard,
   },
   props: {
-    value: {
+    modelValue: {
       type: Boolean,
       required: true,
     },
@@ -91,6 +91,7 @@ export default {
       required: true,
     },
   },
+  emits: ['counter', 'resolve'],
   data() {
     return {
       choseToCounter: false,
@@ -99,10 +100,10 @@ export default {
   computed: {
     show: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
-      set(val) {
-        this.$emit('input', val);
+      set() {
+        // do nothing - parent controls whether dialog is open
       },
     },
     opponentLastTwo() {
@@ -122,8 +123,8 @@ export default {
       this.choseToCounter = false;
     },
     resolve() {
-      this.choseToCounter = false;
       this.$emit('resolve');
+      this.choseToCounter = false;
     },
   },
 };

--- a/src/components/GameView/FourDialog.vue
+++ b/src/components/GameView/FourDialog.vue
@@ -38,11 +38,12 @@ export default {
     GameCard,
   },
   props: {
-    value: {
+    modelValue: {
       required: true,
       type: Boolean,
     },
   },
+  emits: ['discard'],
   data() {
     return {
       selectedIds: [],
@@ -51,10 +52,10 @@ export default {
   computed: {
     show: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
-      set(val) {
-        this.$emit('input', val);
+      set() {
+        // do nothing - parent controls whether dialog is open
       },
     },
     hand() {

--- a/src/components/GameView/FourDialog.vue
+++ b/src/components/GameView/FourDialog.vue
@@ -37,13 +37,13 @@ export default {
   components: {
     GameCard,
   },
+  emits: ['discard'],
   props: {
     modelValue: {
       required: true,
       type: Boolean,
     },
   },
-  emits: ['discard'],
   data() {
     return {
       selectedIds: [],

--- a/src/components/GameView/GameCard.vue
+++ b/src/components/GameView/GameCard.vue
@@ -11,7 +11,6 @@
   >
     <v-icon v-if="isFrozen" class="player-card-icon mr-1 mt-1" color="#00a5ff" icon="mdi-snowflake" />
     <v-overlay
-      v-ripple
       :model-value="isValidTarget"
       contained
       class="valid-move target-overlay"

--- a/src/components/GameView/GameDialogs.vue
+++ b/src/components/GameView/GameDialogs.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="game-dialogs">
     <counter-dialog
-      v-model="showCounterDialog"
+      :modelValue="showCounterDialog"
       :one-off="game.oneOff"
       :target="game.oneOffTarget"
       :twos-in-hand="twosInHand"
@@ -10,7 +10,7 @@
       @counter="counter($event)"
     />
     <cannot-counter-dialog
-      v-model="showCannotCounterDialog"
+      :modelValue="showCannotCounterDialog"
       :one-off="game.oneOff"
       :opponent-queen-count="opponentQueenCount"
       :player-two-count="playerTwoCount"
@@ -18,21 +18,21 @@
       :target="game.oneOffTarget"
       @resolve="resolve"
     />
-    <four-dialog v-model="discarding" @discard="discard" />
+    <four-dialog :modelValue="discarding" @discard="discard" />
     <three-dialog
-      v-model="pickingFromScrap"
+      :modelValue="pickingFromScrap"
       :one-off="game.oneOff"
       :scrap="scrap"
       @resolveThree="resolveThree($event)"
     />
     <seven-double-jacks-dialog
-      v-model="showSevenDoubleJacksDialog"
+      :modelValue="showSevenDoubleJacksDialog"
       :top-card="topCard"
       :second-card="secondCard"
       @resolveSevenDoubleJacks="resolveSevenDoubleJacks($event)"
     />
-    <game-over-dialog v-model="gameIsOver" :player-wins="playerWins" :stalemate="stalemate" />
-    <reauthenticate-dialog v-model="mustReauthenticate" />
+    <game-over-dialog :modelValue="gameIsOver" :player-wins="playerWins" :stalemate="stalemate" />
+    <reauthenticate-dialog :modelValue="mustReauthenticate" />
     <opponent-requested-stalemate-dialog v-model="consideringOpponentStalemateRequest" />
   </div>
 </template>

--- a/src/components/GameView/GameDialogs.vue
+++ b/src/components/GameView/GameDialogs.vue
@@ -62,6 +62,7 @@ export default {
     ThreeDialog,
     OpponentRequestedStalemateDialog,
   },
+  emits: ['clear-selection', 'handle-error'],
   computed: {
     ...mapState({
       playingFromDeck: ({ game }) => game.playingFromDeck,

--- a/src/components/GameView/GameOverDialog.vue
+++ b/src/components/GameView/GameOverDialog.vue
@@ -32,7 +32,7 @@
 export default {
   name: 'GameOverDialog',
   props: {
-    value: {
+    modelValue: {
       type: Boolean,
       required: true,
     },
@@ -48,10 +48,10 @@ export default {
   computed: {
     show: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
-      set(newValue) {
-        this.$emit('input', newValue);
+      set() {
+        // do nothing - parent controls whether dialog is open
       },
     },
   },

--- a/src/components/GameView/GameOverlays.vue
+++ b/src/components/GameView/GameOverlays.vue
@@ -86,6 +86,7 @@ export default {
       default: null,
     },
   },
+  emits:['points', 'face-card', 'one-off', 'clear-selection', 'target'],
   computed: {
     // Since we're not using namespacing, we need to destructure the game module
     // off of the global state to directly access the state values

--- a/src/components/GameView/GameOverlays.vue
+++ b/src/components/GameView/GameOverlays.vue
@@ -53,9 +53,9 @@
       :playing-from-deck="playingFromDeck"
       @points="$emit('points')"
       @faceCard="$emit('face-card')"
-      @oneOff="$emit('one-off')"
       @scuttle="handleTargeting"
       @jack="handleTargeting"
+      @oneOff="$emit('one-off')"
       @targetedOneOff="handleTargeting"
       @cancel="$emit('clear-selection')"
     />
@@ -72,6 +72,7 @@ export default {
   components: {
     MoveChoiceOverlay,
   },
+  emits:['points', 'face-card', 'one-off', 'clear-selection', 'target'],
   props: {
     targeting: {
       type: Boolean,
@@ -86,7 +87,6 @@ export default {
       default: null,
     },
   },
-  emits:['points', 'face-card', 'one-off', 'clear-selection', 'target'],
   computed: {
     // Since we're not using namespacing, we need to destructure the game module
     // off of the global state to directly access the state values

--- a/src/components/GameView/MoveChoiceCard.vue
+++ b/src/components/GameView/MoveChoiceCard.vue
@@ -28,6 +28,7 @@
 <script>
 export default {
   name: 'MoveChoiceCard',
+  emits: ['choose-move'],
   props: {
     moveName: {
       type: String,
@@ -55,7 +56,6 @@ export default {
       default: '30%',
     },
   },
-  emits: ['choose-move'],
   computed: {
     /**
      * Returns string name of which icon to display

--- a/src/components/GameView/MoveChoiceCard.vue
+++ b/src/components/GameView/MoveChoiceCard.vue
@@ -10,7 +10,7 @@
       :theme="isHovering ? 'light': 'dark'"
       :width="cardWidth"
       :data-move-choice="eventName"
-      @click="$emit('choose-move')"
+      @click.stop="$emit('choose-move')"
     >
       <v-card-title class="d-flex justify-center">
         <h2>{{ moveName }}</h2>

--- a/src/components/GameView/MoveChoiceCard.vue
+++ b/src/components/GameView/MoveChoiceCard.vue
@@ -5,7 +5,7 @@
       ripple
       :disabled="disabled"
       :class="{ pointer: !disabled }"
-      class="move-choice-card"
+      class="move-choice-card mx-4"
       hover
       :theme="isHovering ? 'light': 'dark'"
       :width="cardWidth"

--- a/src/components/GameView/MoveChoiceCard.vue
+++ b/src/components/GameView/MoveChoiceCard.vue
@@ -10,7 +10,7 @@
       :theme="isHovering ? 'light': 'dark'"
       :width="cardWidth"
       :data-move-choice="eventName"
-      @click.stop="$emit('click')"
+      @click="$emit('choose-move')"
     >
       <v-card-title class="d-flex justify-center">
         <h2>{{ moveName }}</h2>
@@ -55,6 +55,7 @@ export default {
       default: '30%',
     },
   },
+  emits: ['choose-move'],
   computed: {
     /**
      * Returns string name of which icon to display

--- a/src/components/GameView/MoveChoiceOverlay.vue
+++ b/src/components/GameView/MoveChoiceOverlay.vue
@@ -53,6 +53,7 @@ export default {
     MoveChoiceCard,
     GameCard,
   },
+  emits:['points', 'face-card', 'scuttle', 'jack', 'one-off', 'targetedOneOff', 'cancel'],
   props: {
     modelValue: {
       type: Boolean,
@@ -83,7 +84,6 @@ export default {
       default: null,
     },
   },
-  emits:['points', 'face-card', 'scuttle', 'jack', 'one-off', 'targetedOneOff', 'cancel'],
   computed: {
     // Determines if any moves are available
     allMovesAreDisabled() {

--- a/src/components/GameView/MoveChoiceOverlay.vue
+++ b/src/components/GameView/MoveChoiceOverlay.vue
@@ -36,7 +36,6 @@
         :disabled="move.disabled"
         :disabled-explanation="move.disabledExplanation"
         :card-width="cardWidth"
-        class="mx-4"
         @choose-move="$emit(move.eventName, move)"
       />
     </div>

--- a/src/components/GameView/MoveChoiceOverlay.vue
+++ b/src/components/GameView/MoveChoiceOverlay.vue
@@ -37,7 +37,7 @@
         :disabled-explanation="move.disabledExplanation"
         :card-width="cardWidth"
         class="mx-4"
-        @click="$emit(move.eventName, move)"
+        @choose-move="$emit(move.eventName, move)"
       />
     </div>
   </v-overlay>
@@ -83,6 +83,7 @@ export default {
       default: null,
     },
   },
+  emits:['points', 'face-card', 'scuttle', 'jack', 'one-off', 'targetedOneOff', 'cancel'],
   computed: {
     // Determines if any moves are available
     allMovesAreDisabled() {

--- a/src/components/GameView/MoveChoiceOverlay.vue
+++ b/src/components/GameView/MoveChoiceOverlay.vue
@@ -52,7 +52,7 @@ export default {
     MoveChoiceCard,
     GameCard,
   },
-  emits:['points', 'face-card', 'scuttle', 'jack', 'one-off', 'targetedOneOff', 'cancel'],
+  emits:['points', 'faceCard', 'scuttle', 'jack', 'oneOff', 'targetedOneOff', 'cancel'],
   props: {
     modelValue: {
       type: Boolean,

--- a/src/components/GameView/OpponentRequestedStalemateDialog.vue
+++ b/src/components/GameView/OpponentRequestedStalemateDialog.vue
@@ -40,7 +40,7 @@
 export default {
   name: 'OpponentRequestedStalemateDialog',
   props: {
-    value: Boolean,
+    modelValue: Boolean,
   },
   data() {
     return {
@@ -51,11 +51,11 @@ export default {
   computed: {
     show: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
-      set(value) {
-        this.$emit('input', value);
-      },
+      set() {
+        // do nothing - parent controls whether dialog is open
+      },  
     },
   },
   methods: {

--- a/src/components/GameView/ReauthenticateDialog.vue
+++ b/src/components/GameView/ReauthenticateDialog.vue
@@ -50,7 +50,7 @@
 export default {
   name: 'ReauthenticateDialog',
   props: {
-    value: {
+    modelValue: {
       type: Boolean,
       required: true,
     },
@@ -67,10 +67,10 @@ export default {
   computed: {
     show: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
-      set(val) {
-        this.$emit('input', val);
+      set() {
+        // do nothing - parent controls whether dialog is open
       },
     },
   },

--- a/src/components/GameView/SevenDoubleJacksDialog.vue
+++ b/src/components/GameView/SevenDoubleJacksDialog.vue
@@ -51,7 +51,7 @@ export default {
     GameCard,
   },
   props: {
-    value: {
+    modelValue: {
       type: Boolean,
       required: true,
     },
@@ -64,6 +64,7 @@ export default {
       default: null,
     },
   },
+  emits: ['resolveSevenDoubleJacks'],
   data() {
     return {
       selectedCardId: null,
@@ -72,10 +73,10 @@ export default {
   computed: {
     show: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
-      set(val) {
-        this.$emit('input', val);
+      set() {
+        // do nothing - parent controls whether dialog is open
       },
     },
     selectedJack() {

--- a/src/components/GameView/SevenDoubleJacksDialog.vue
+++ b/src/components/GameView/SevenDoubleJacksDialog.vue
@@ -50,6 +50,7 @@ export default {
   components: {
     GameCard,
   },
+  emits: ['resolveSevenDoubleJacks'],
   props: {
     modelValue: {
       type: Boolean,
@@ -64,7 +65,6 @@ export default {
       default: null,
     },
   },
-  emits: ['resolveSevenDoubleJacks'],
   data() {
     return {
       selectedCardId: null,

--- a/src/components/GameView/TargetSelectionOverlay.vue
+++ b/src/components/GameView/TargetSelectionOverlay.vue
@@ -21,6 +21,7 @@ export default {
   components: {
     GameCard,
   },
+  emits: ['cancel'],
   props: {
     value: {
       type: Boolean,
@@ -39,7 +40,6 @@ export default {
       required: true,
     },
   },
-  emits: ['cancel'],
 };
 </script>
 

--- a/src/components/GameView/TargetSelectionOverlay.vue
+++ b/src/components/GameView/TargetSelectionOverlay.vue
@@ -23,10 +23,6 @@ export default {
   },
   emits: ['cancel'],
   props: {
-    value: {
-      type: Boolean,
-      required: true,
-    },
     selectedCard: {
       type: Object,
       required: true,

--- a/src/components/GameView/TargetSelectionOverlay.vue
+++ b/src/components/GameView/TargetSelectionOverlay.vue
@@ -39,6 +39,7 @@ export default {
       required: true,
     },
   },
+  emits: ['cancel'],
 };
 </script>
 

--- a/src/components/GameView/ThreeDialog.vue
+++ b/src/components/GameView/ThreeDialog.vue
@@ -36,7 +36,7 @@ export default {
     CardListSortable,
   },
   props: {
-    value: {
+    modelValue: {
       type: Boolean,
       required: true,
     },
@@ -50,6 +50,7 @@ export default {
       required: true,
     },
   },
+  emits: ['resolveThree'],
   data() {
     return {
       choseToCounter: false,
@@ -59,10 +60,10 @@ export default {
   computed: {
     show: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
-      set(val) {
-        this.$emit('input', val);
+      set() {
+        // do nothing - parent controls whether dialog is open
       },
     },
     selectedIds() {

--- a/src/components/GameView/ThreeDialog.vue
+++ b/src/components/GameView/ThreeDialog.vue
@@ -35,6 +35,7 @@ export default {
   components: {
     CardListSortable,
   },
+  emits: ['resolveThree'],
   props: {
     modelValue: {
       type: Boolean,
@@ -50,7 +51,6 @@ export default {
       required: true,
     },
   },
-  emits: ['resolveThree'],
   data() {
     return {
       choseToCounter: false,

--- a/src/components/RulePreview.vue
+++ b/src/components/RulePreview.vue
@@ -41,6 +41,7 @@ export default {
       default: '',
     },
   },
+  emits: ['animate'],
   data() {
     return {
       animate: false,

--- a/src/components/RulePreview.vue
+++ b/src/components/RulePreview.vue
@@ -19,6 +19,7 @@
 <script>
 export default {
   name: 'RulePreview',
+  emits: ['animate'],
   props: {
     title: {
       type: String,
@@ -41,7 +42,6 @@ export default {
       default: '',
     },
   },
-  emits: ['animate'],
   data() {
     return {
       animate: false,

--- a/src/components/RulesDialog.vue
+++ b/src/components/RulesDialog.vue
@@ -216,6 +216,7 @@ export default {
       default: false,
     },
   },
+  emits: ['close'],
   data() {
     return {
       internalShow: false,

--- a/src/components/RulesDialog.vue
+++ b/src/components/RulesDialog.vue
@@ -206,6 +206,7 @@
 <script>
 export default {
   name: 'RulesDialog',
+  emits: ['close'],
   props: {
     show: {
       type: Boolean,
@@ -216,7 +217,6 @@ export default {
       default: false,
     },
   },
-  emits: ['close'],
   data() {
     return {
       internalShow: false,

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -25,18 +25,17 @@
         location="right"
       >
         <template #prepend>
-          <v-list-item lines="two">
-            <v-list-item-content>
-              <h3>History</h3>
-            </v-list-item-content>
-            <v-list-item-icon>
-              <v-icon
-                color="neutral"
-                icon="mdi-window-close"
-                size="large"
-                @click.stop="showHistoryDrawer = !showHistoryDrawer"
-              />
-            </v-list-item-icon>
+          <v-list-item>
+            <h3>History</h3>
+            <template #append>
+              <v-btn icon variant="text" @click.stop="showHistoryDrawer = !showHistoryDrawer">
+                <v-icon
+                  color="neutral"
+                  icon="mdi-window-close"
+                  size="large"
+                />
+              </v-btn>
+            </template>
           </v-list-item>
         </template>
 

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -350,7 +350,6 @@
             v-if="targeting && (selectedCard || cardSelectedFromDeck)"
             id="player-hand-targeting"
             key="target-selection-overlay"
-            :value="targeting"
             :selected-card="selectedCard || cardSelectedFromDeck"
             :is-players-turn="isPlayersTurn"
             :move-display-name="targetingMoveDisplayName"

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -72,7 +72,7 @@
                       selected-class="success"
                       :show-arrows="true"
                     >
-                      <v-slide-item v-for="card in opponent.hand" :key="card.id">
+                      <v-slide-group-item v-for="card in opponent.hand" :key="card.id">
                         <game-card
                           :key="card.id"
                           :suit="card.suit"
@@ -80,7 +80,7 @@
                           :data-opponent-hand-card="`${card.rank}-${card.suit}`"
                           class="transition-all opponent-hand-card-revealed"
                         />
-                      </v-slide-item>
+                      </v-slide-group-item>
                     </v-slide-group>
                     <game-card
                       v-for="card in opponent.hand"
@@ -315,7 +315,7 @@
                 :class="{ 'my-turn': isPlayersTurn }"
               >
                 <v-slide-group v-if="$vuetify.display.xs" key="slide-group" :show-arrows="true">
-                  <v-slide-item v-for="(card, index) in player.hand" :key="card.id">
+                  <v-slide-group-item v-for="(card, index) in player.hand" :key="card.id">
                     <game-card
                       :key="card.id"
                       :suit="card.suit"
@@ -327,7 +327,7 @@
                       :data-player-hand-card="`${card.rank}-${card.suit}`"
                       @click="selectCard(index)"
                     />
-                  </v-slide-item>
+                  </v-slide-group-item>
                 </v-slide-group>
 
                 <game-card


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Resolves #289 by fixing all vue errors that were appearing in the frontend console. The broad strokes are:
1. Update dialogs to use `modelValue` prop instead of `value`
2. Removing v-ripple from a v-overlay
3. Ensuring components declare the events they emit
