### PR TITLE
Convert snackbar to base component

### DIFF
--- a/src/components/GameView/ReauthenticateDialog.vue
+++ b/src/components/GameView/ReauthenticateDialog.vue
@@ -32,23 +32,23 @@
         </v-card-actions>
       </form>
     </v-card>
-    <v-snackbar
+    <BaseSnackbar
       v-model="showSnackBar"
       color="error"
-    >
+      @clear="clearSnackBar">
       {{ snackBarMessage }}
-      <template #actions>
-        <v-btn icon variant="text" @click="clearSnackBar">
-          <v-icon icon="mdi-close" />
-        </v-btn>
-      </template>
-    </v-snackbar>
+    </BaseSnackbar>
   </v-dialog>
 </template>
 
 <script>
+import BaseSnackbar from '@/components/Global/BaseSnackbar.vue';
+
 export default {
   name: 'ReauthenticateDialog',
+  components: {
+    BaseSnackbar,
+  },
   props: {
     modelValue: {
       type: Boolean,

--- a/src/components/Global/BaseSnackbar.vue
+++ b/src/components/Global/BaseSnackbar.vue
@@ -8,11 +8,11 @@
     v-bind="$attrs"
   >
     <slot />
-    <slot name="actions">
+    <template #actions>
       <v-btn data-cy="close-snackbar" icon variant="text" @click="clear">
         <v-icon icon="mdi-close" />
       </v-btn>
-    </slot>
+    </template>
   </v-snackbar>
 </template>
 

--- a/src/components/Global/BaseSnackbar.vue
+++ b/src/components/Global/BaseSnackbar.vue
@@ -1,0 +1,31 @@
+<template>
+  <v-snackbar
+    v-model="showSnackBar"
+    :color="color"
+    class="base-snackbar"
+    position="absolute"
+    location="bottom"
+    data-cy="auth-snackbar"
+    v-bind="$attrs"
+  >
+    <slot />
+    <slot name="actions">
+      <v-btn data-cy="close-snackbar" icon variant="text" @click="clear">
+        <v-icon icon="mdi-close" />
+      </v-btn>
+    </slot>
+  </v-snackbar>
+</template>
+
+<script>
+export default {
+  name: 'BaseSnackbar',
+  emits: ['clear'],
+  props: ['showSnackBar', 'color'],
+  methods: {
+    clear() {
+      this.$emit('clear');
+    },
+  }
+}
+</script>

--- a/src/components/Global/BaseSnackbar.vue
+++ b/src/components/Global/BaseSnackbar.vue
@@ -5,7 +5,6 @@
     class="base-snackbar"
     position="absolute"
     location="bottom"
-    data-cy="auth-snackbar"
     v-bind="$attrs"
   >
     <slot />

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -358,18 +358,13 @@
         </div>
       </div>
 
-      <v-snackbar
+      <BaseSnackbar
         v-model="showSnack"
         :color="snackColor"
         data-cy="game-snackbar"
-      >
+        @clear="clearSnackBar">
         {{ snackMessage }}
-        <template #actions>
-          <v-btn icon variant="text">
-            <v-icon icon="mdi-close" data-cy="close-snackbar" @click="clearSnackBar" />
-          </v-btn>
-        </template>
-      </v-snackbar>
+      </BaseSnackbar>
       <game-overlays
         :targeting="targeting"
         :selected-card="selectedCard"
@@ -397,6 +392,7 @@ import ReauthenticateDialog from '@/components/GameView/ReauthenticateDialog.vue
 import TargetSelectionOverlay from '@/components/GameView/TargetSelectionOverlay.vue';
 import ScrapDialog from '@/components/GameView/ScrapDialog.vue';
 import UsernameToolTip from '@/components/GameView/UsernameToolTip.vue';
+import BaseSnackbar from '@/components/Global/BaseSnackbar.vue';
 
 export default {
   name: 'GameView',
@@ -410,6 +406,7 @@ export default {
     TargetSelectionOverlay,
     ScrapDialog,
     UsernameToolTip,
+    BaseSnackbar,
   },
   data() {
     return {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -80,30 +80,27 @@
         </v-row>
       </div>
     </v-container>
-    <v-snackbar
+    <BaseSnackbar
       v-model="showSnackBar"
       color="error"
       data-cy="newgame-snackbar"
-    >
+      @clear="clearSnackBar">
       {{ snackBarMessage }}
-      <template #actions>
-        <v-btn data-cy="close-snackbar" icon variant="text" @click="clearSnackBar">
-          <v-icon icon="mdi-close" />
-        </v-btn>
-      </template>
-    </v-snackbar>
+    </BaseSnackbar>
   </div>
 </template>
 <script>
 import { mapState } from 'vuex';
 import GameListItem from '@/components/GameListItem.vue';
-import CreateGameDialog from '../components/CreateGameDialog.vue';
+import CreateGameDialog from '@/components/CreateGameDialog.vue';
+import BaseSnackbar from '@/components/Global/BaseSnackbar.vue';
 
 export default {
   name: 'HomeView',
   components: {
     GameListItem,
     CreateGameDialog,
+    BaseSnackbar,
   },
   data() {
     return {

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -42,18 +42,13 @@
           </v-btn>
         </div>
 
-        <v-snackbar
+        <BaseSnackbar
           v-model="showSnackBar"
           color="error"
           data-cy="auth-snackbar"
-        >
+          @clear="clearSnackBar">
           {{ snackBarMessage }}
-          <template #actions>
-            <v-btn data-cy="close-snackbar" icon variant="text" @click="clearSnackBar">
-              <v-icon icon="mdi-close" />
-            </v-btn>
-          </template>
-        </v-snackbar>
+        </BaseSnackbar>
       </v-col>
     </v-row>
 
@@ -101,8 +96,13 @@
 <script>
 import { ROUTE_NAME_LOGIN, ROUTE_NAME_SIGNUP } from '@/router';
 
+import BaseSnackbar from '@/components/Global/BaseSnackbar.vue';
+
 export default {
   name: 'LoginView',
+  components: {
+    BaseSnackbar,
+  },
   data() {
     return {
       username: '',


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

Little bit of both with this PR, fixed the mobile positioning and started the consolidation of the base components so we can reduce (and better use) the vuetify components.

