### PR TITLE
Fix/sort leaderboard by rank

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/src/components/StatsLeaderboard.vue
+++ b/src/components/StatsLeaderboard.vue
@@ -131,7 +131,7 @@ export default {
           res[`week_${weekNum}_points`] = playerScores[weekNum];
         }
         return res;
-      });
+      }).sort((player1, player2) => player1.rank - player2.rank);
     },
     playerWins() {
       if (!this.season || !this.season.rankings || this.season.rankings.length === 0) {

--- a/tests/e2e/specs/out-of-game/stats.spec.js
+++ b/tests/e2e/specs/out-of-game/stats.spec.js
@@ -63,7 +63,7 @@ describe('Stats Page Error States', () => {
 describe('Stats Page', () => {
   beforeEach(setup);
 
-  it('Displays Headers, Cards, and Table', () => {
+  it.only('Displays Headers, Cards, and Table', () => {
     const [seasonOne] = seasonFixtures;
     cy.get('[data-cy=selected-season-header]');
     cy.get('[data-cy=season-start-date').should('contain', dayjs(seasonOne.startTime).format('YYYY/MM/DD'));
@@ -122,6 +122,13 @@ describe('Stats Page', () => {
     cy.get('[data-player-results=Player3-week-total]').find('[data-cy=close-player-results]').click();
     cy.get('[data-players-beaten=Player3-week-total').should('not.exist');
     cy.get('[data-players-lost-to=Player3-week-total').should('not.exist');
+
+    // Players should be sorted in rank order
+    cy.get('[data-rank]').eq(0).should('contain', '1');
+    cy.get('[data-rank]').eq(1).should('contain', '1');
+    cy.get('[data-rank]').eq(2).should('contain', '3');
+    cy.get('[data-rank]').eq(3).should('contain', '4');
+    cy.get('[data-rank]').eq(4).should('contain', '5');
   });
 
   it('Filters table to display wins, points, or both', () => {

--- a/tests/e2e/specs/out-of-game/stats.spec.js
+++ b/tests/e2e/specs/out-of-game/stats.spec.js
@@ -63,7 +63,7 @@ describe('Stats Page Error States', () => {
 describe('Stats Page', () => {
   beforeEach(setup);
 
-  it.only('Displays Headers, Cards, and Table', () => {
+  it('Displays Headers, Cards, and Table', () => {
     const [seasonOne] = seasonFixtures;
     cy.get('[data-cy=selected-season-header]');
     cy.get('[data-cy=season-start-date').should('contain', dayjs(seasonOne.startTime).format('YYYY/MM/DD'));


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Fixes bug where leaderboard was not sorted by rank.
Before:
![image](https://user-images.githubusercontent.com/6520704/216993564-d6a1461a-602c-457a-9389-5ebd19c18208.png)

After:
![image](https://user-images.githubusercontent.com/6520704/216993691-c9738276-6bc4-4133-87cb-3f28342a3546.png)
