### PR TITLE
Fix/rules royal description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/src/views/RulesView.vue
+++ b/src/views/RulesView.vue
@@ -269,7 +269,7 @@ export default {
         {
           title: 'Royal',
           icon: 'crown',
-          description: `Scrap an opponent's point card with a bigger one from your hand.  Ties are broken by the suit: ♣️ (weakest) < ♦️ < ♥️ < ♠️ (strongest).`,
+          description: `Play a royal to the field for a persistent benefit -- as long as it stays in play`,
           staticImg: '/img/game/cuttle-king.png',
           animatedImg: 'https://github.com/cuttle-cards/cuttle-assets/blob/main/assets/king.gif?raw=true',
         },


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Fixes the rules description of the Royal move type (was previously duplicating the scuttle description)