### PR TITLE
added v-if to game-over-dialog component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "4.0.7",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/src/components/GameView/GameDialogs.vue
+++ b/src/components/GameView/GameDialogs.vue
@@ -31,7 +31,12 @@
       :second-card="secondCard"
       @resolveSevenDoubleJacks="resolveSevenDoubleJacks($event)"
     />
-    <game-over-dialog :modelValue="gameIsOver" :player-wins="playerWins" :stalemate="stalemate" />
+    <game-over-dialog
+      v-if="gameIsOver"
+      :modelValue="gameIsOver"
+      :player-wins="playerWins"
+      :stalemate="stalemate"
+    />
     <reauthenticate-dialog :modelValue="mustReauthenticate" />
     <opponent-requested-stalemate-dialog v-model="consideringOpponentStalemateRequest" />
   </div>


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

I added a v-if statement based on the gameIsOver prop. This closes out the component before it has to run through all the computed values.

I tested this through the cypress GUI, as well as opening two browsers, making two users, and winning/losing/and stalemating, with network setting set to low end mobile.