### PR TITLE
fix: set default timezone to 'America/New York' - Resolves #358

### DIFF
--- a/api/controllers/StatsController.js
+++ b/api/controllers/StatsController.js
@@ -1,8 +1,13 @@
 const dayjs = require('dayjs');
 const isBetween = require('dayjs/plugin/isBetween');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
 const Result = require('../../types/Result.es5');
-dayjs.extend(isBetween);
 
+dayjs.extend(isBetween);
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('America/New_York');
 /////////////
 // Helpers //
 /////////////

--- a/api/helpers/add-game-to-match.js
+++ b/api/helpers/add-game-to-match.js
@@ -1,4 +1,10 @@
 const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('America/New_York');
 
 module.exports = {
   friendlyName: 'Add Game to Match',

--- a/api/helpers/find-or-create-current-match.js
+++ b/api/helpers/find-or-create-current-match.js
@@ -1,4 +1,10 @@
 const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('America/New_York');
 
 module.exports = {
   friendlyName: 'Find Or Create Current Match Between Two Players',

--- a/api/helpers/get-seasons-without-rankings.js
+++ b/api/helpers/get-seasons-without-rankings.js
@@ -1,4 +1,10 @@
 const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('America/New_York');
 
 module.exports = {
   friendlyName: 'Get Seasons Without Matches',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/tests/e2e/fixtures/statsFixtures.js
+++ b/tests/e2e/fixtures/statsFixtures.js
@@ -1,4 +1,10 @@
 const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('America/New_York');
 
 const seasonFixtures = [
   {

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -3,6 +3,12 @@ import { seasonFixtures } from '../../fixtures/statsFixtures';
 import { playerOne, playerTwo, playerThree } from '../../fixtures/userFixtures';
 
 const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('America/New_York');
 
 function assertVictory() {
   cy.log('Asserting player victory');

--- a/tests/e2e/specs/out-of-game/stats.spec.js
+++ b/tests/e2e/specs/out-of-game/stats.spec.js
@@ -1,6 +1,12 @@
 import { playerOne, playerTwo, playerThree, playerFour, playerFive } from '../../fixtures/userFixtures';
 import { seasonFixtures, matchesFixture } from '../../fixtures/statsFixtures';
 const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('America/New_York');
 
 function setup() {
   cy.viewport(1980, 1080);


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Resolves #358 by setting default timezone to America/New York wherever dayjs is configured