### PR TITLE
Fix bug where overlay scrim appeared while spectating after cannot counter dialog appeared/disappeared

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/src/plugins/sails.js
+++ b/src/plugins/sails.js
@@ -102,6 +102,7 @@ io.socket.on('game', function (evData) {
         case 'resolve':
           store.dispatch('updateGameThenResetPNumIfNull', evData.data.game);
           store.commit('setWaitingForOpponentToCounter', false);
+          store.commit('setMyTurnToCounter', false);
           if (evData.data.happened) {
             switch (evData.data.oneOff.rank) {
               case 3:

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -1,71 +1,8 @@
-import { assertGameState, Card, username, opponentUsername } from '../../support/helpers';
+import { assertGameState, Card, username, opponentUsername, assertLoss, assertVictory, assertStalemate } from '../../support/helpers';
 import { seasonFixtures } from '../../fixtures/statsFixtures';
 import { playerOne, playerTwo, playerThree } from '../../fixtures/userFixtures';
 
 const dayjs = require('dayjs');
-
-function assertVictory() {
-  cy.log('Asserting player victory');
-  cy.get('#game-over-dialog').should('be.visible').get('[data-cy=victory-heading]').should('be.visible');
-  cy.window()
-    .its('cuttle.app.config.globalProperties.$store.state.game')
-    .then((game) => {
-      if (game.isRanked) {
-        const gameNumber = game.currentMatch.games.length;
-        const matchWinner = game.currentMatch.winner;
-        cy.get('#game-over-dialog')
-          .should('be.visible')
-          .should('contain', matchWinner ? 'You Win the Match' : `Game ${gameNumber}: You Win`)
-          .get('[data-cy=match-result-section]')
-          .should('be.visible');
-      } else {
-        cy.get('#game-over-dialog').should('be.visible').should('not.contain', 'Match against');
-      }
-    });
-}
-
-export function assertLoss() {
-  cy.log('Asserting player loss');
-  cy.get('#game-over-dialog').should('be.visible').get('[data-cy=loss-heading]').should('be.visible');
-  cy.get('[data-cy=loss-img]').should('be.visible');
-  cy.window()
-    .its('cuttle.app.config.globalProperties.$store.state.game')
-    .then((game) => {
-      if (game.isRanked) {
-        const gameNumber = game.currentMatch.games.length;
-        const matchWinner = game.currentMatch.winner;
-        cy.get('#game-over-dialog')
-          .should('contain', matchWinner ? 'You Lose the Match' : `Game ${gameNumber}: You Lose`)
-          .should('be.visible')
-          .get('[data-cy=match-result-section]')
-          .should('be.visible');
-      } else {
-        cy.get('#game-over-dialog').should('be.visible').should('not.contain', 'Match against');
-      }
-    });
-}
-
-function assertStalemate() {
-  cy.log('Asserting stalemate');
-  cy.get('#game-over-dialog').should('be.visible').get('[data-cy=stalemate-heading]').should('be.visible');
-  cy.get('[data-cy=stalemate-img]').should('be.visible');
-  cy.window()
-    .its('cuttle.app.config.globalProperties.$store.state.game')
-    .then((game) => {
-      if (game.isRanked) {
-        const gameNumber = game.currentMatch.games.length;
-        cy.get('#game-over-dialog')
-          .should('be.visible')
-          // Don't need to check match winner as we do in assertVictory or assertLoss
-          // since a stalemate won't decide a match winner
-          .should('contain', `Game ${gameNumber}: Draw`)
-          .get('[data-cy=match-result-section]')
-          .should('be.visible');
-      } else {
-        cy.get('#game-over-dialog').should('be.visible').should('not.contain', 'Match against');
-      }
-    });
-}
 
 function goHomeJoinNewGame() {
   cy.log('Going home');

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -1,4 +1,12 @@
-import { assertGameState, Card, username, opponentUsername, assertLoss, assertVictory, assertStalemate } from '../../support/helpers';
+import {
+  assertGameState,
+  Card,
+  username,
+  opponentUsername,
+  assertLoss,
+  assertVictory,
+  assertStalemate
+} from '../../support/helpers';
 import { seasonFixtures } from '../../fixtures/statsFixtures';
 import { playerOne, playerTwo, playerThree } from '../../fixtures/userFixtures';
 

--- a/tests/e2e/specs/in-game/spectating.spec.js
+++ b/tests/e2e/specs/in-game/spectating.spec.js
@@ -106,7 +106,7 @@ describe('Spectating Games', () => {
     cy.url().should('not.include', '/game');
   });
 
-  it.only('Correctly shows and hides dialogs and overlays', () => {
+  it('Correctly shows and hides dialogs and overlays', () => {
     cy.setupGameAsSpectator();
     cy.loadGameFixture({
       p0Hand: [

--- a/tests/e2e/specs/in-game/spectating.spec.js
+++ b/tests/e2e/specs/in-game/spectating.spec.js
@@ -106,7 +106,7 @@ describe('Spectating Games', () => {
     cy.url().should('not.include', '/game');
   });
 
-  it('Correctly shows and hides dialogs and overlays', () => {
+  it.only('Correctly shows and hides dialogs and overlays', () => {
     cy.setupGameAsSpectator();
     cy.loadGameFixture({
       p0Hand: [
@@ -123,11 +123,14 @@ describe('Spectating Games', () => {
 
     cy.recoverSessionOpponent(playerOne);
     cy.playOneOffSpectator(Card.ACE_OF_SPADES, 0);
+    cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
 
     cy.recoverSessionOpponent(playerTwo);
     cy.resolveOpponent();
+    cy.get('#waiting-for-opponent-counter-scrim').should('not.exist');
 
     cy.playOneOffSpectator(Card.ACE_OF_DIAMONDS, 1);
+    cy.get('#cannot-counter-dialog').should('be.visible');
     cy.recoverSessionOpponent(playerOne);
     cy.resolveOpponent();
 

--- a/tests/e2e/specs/in-game/spectating.spec.js
+++ b/tests/e2e/specs/in-game/spectating.spec.js
@@ -130,6 +130,8 @@ describe('Spectating Games', () => {
     cy.playOneOffSpectator(Card.ACE_OF_DIAMONDS, 1);
     cy.recoverSessionOpponent(playerOne);
     cy.resolveOpponent();
+
+    cy.get('.v-overlay').should('not.exist');
   });
 
   it('Prevents spectator from making moves', () => {

--- a/tests/e2e/specs/in-game/spectating.spec.js
+++ b/tests/e2e/specs/in-game/spectating.spec.js
@@ -106,6 +106,32 @@ describe('Spectating Games', () => {
     cy.url().should('not.include', '/game');
   });
 
+  it.only('Correctly shows and hides dialogs and overlays', () => {
+    cy.setupGameAsSpectator();
+    cy.loadGameFixture({
+      p0Hand: [
+        Card.ACE_OF_SPADES,
+        Card.THREE_OF_CLUBS
+      ],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [Card.FOUR_OF_CLUBS, Card.ACE_OF_DIAMONDS],
+      p1Points: [Card.ACE_OF_CLUBS],
+      p1FaceCards: [Card.KING_OF_HEARTS],
+    });
+    cy.get('[data-player-hand-card]').should('have.length', 2);
+
+    cy.recoverSessionOpponent(playerOne);
+    cy.playOneOffSpectator(Card.ACE_OF_SPADES, 0);
+
+    cy.recoverSessionOpponent(playerTwo);
+    cy.resolveOpponent();
+
+    cy.playOneOffSpectator(Card.ACE_OF_DIAMONDS, 1);
+    cy.recoverSessionOpponent(playerOne);
+    cy.resolveOpponent();
+  });
+
   it('Prevents spectator from making moves', () => {
     cy.setupGameAsSpectator();
     cy.loadGameFixture({

--- a/tests/e2e/specs/in-game/spectating.spec.js
+++ b/tests/e2e/specs/in-game/spectating.spec.js
@@ -6,8 +6,8 @@ import {
   assertGameState,
   assertSnackbarError,
   SnackBarError,
+  assertLoss
 } from '../../support/helpers';
-import { assertLoss } from './gameOver.spec';
 
 function setup() {
   cy.wipeDatabase();

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -345,6 +345,41 @@ Cypress.Commands.add('playPointsSpectator', (card, pNum) => {
 /**
  * @param card {suit: number, rank: number}
  */
+Cypress.Commands.add('playOneOffSpectator', (card, pNum) => {
+  if (!hasValidSuitAndRank(card)) {
+    throw new Error('Cannot play opponent one-off as spectator: Invalid card input');
+  }
+  return cy
+    .window()
+    .its('cuttle.app.config.globalProperties.$store.state.game')
+    .then((game) => {
+      const foundCard = game.players[pNum].hand.find((handCard) => cardsMatch(card, handCard));
+      if (!foundCard) {
+        throw new Error(
+          `Error playing one-off while spectating: could not find ${card.rank} of ${card.suit} in specified player's hand`,
+        );
+      }
+      const cardId = foundCard.id;
+      const opponentId = game.players[(pNum + 1) % 2].id;
+      io.socket.get(
+        '/game/untargetedOneOff',
+        {
+          cardId,
+          opId: opponentId,
+        },
+        function handleResponse(res, jwres) {
+          if (jwres.statusCode !== 200) {
+            throw new Error(jwres.body.message);
+          }
+          return jwres;
+        },
+      );
+    });
+});
+
+/**
+ * @param card {suit: number, rank: number}
+ */
 Cypress.Commands.add('playFaceCardOpponent', (card) => {
   if (!hasValidSuitAndRank(card)) {
     throw new Error('Cannot play opponent Face Card: Invalid card input');

--- a/tests/e2e/support/helpers.js
+++ b/tests/e2e/support/helpers.js
@@ -354,6 +354,70 @@ function assertStoreMatchesFixture(fixture) {
       }
     });
 }
+
+export function assertVictory() {
+  cy.log('Asserting player victory');
+  cy.get('#game-over-dialog').should('be.visible').get('[data-cy=victory-heading]').should('be.visible');
+  cy.window()
+    .its('cuttle.app.config.globalProperties.$store.state.game')
+    .then((game) => {
+      if (game.isRanked) {
+        const gameNumber = game.currentMatch.games.length;
+        const matchWinner = game.currentMatch.winner;
+        cy.get('#game-over-dialog')
+          .should('be.visible')
+          .should('contain', matchWinner ? 'You Win the Match' : `Game ${gameNumber}: You Win`)
+          .get('[data-cy=match-result-section]')
+          .should('be.visible');
+      } else {
+        cy.get('#game-over-dialog').should('be.visible').should('not.contain', 'Match against');
+      }
+    });
+}
+
+export function assertLoss() {
+  cy.log('Asserting player loss');
+  cy.get('#game-over-dialog').should('be.visible').get('[data-cy=loss-heading]').should('be.visible');
+  cy.get('[data-cy=loss-img]').should('be.visible');
+  cy.window()
+    .its('cuttle.app.config.globalProperties.$store.state.game')
+    .then((game) => {
+      if (game.isRanked) {
+        const gameNumber = game.currentMatch.games.length;
+        const matchWinner = game.currentMatch.winner;
+        cy.get('#game-over-dialog')
+          .should('contain', matchWinner ? 'You Lose the Match' : `Game ${gameNumber}: You Lose`)
+          .should('be.visible')
+          .get('[data-cy=match-result-section]')
+          .should('be.visible');
+      } else {
+        cy.get('#game-over-dialog').should('be.visible').should('not.contain', 'Match against');
+      }
+    });
+}
+
+export function assertStalemate() {
+  cy.log('Asserting stalemate');
+  cy.get('#game-over-dialog').should('be.visible').get('[data-cy=stalemate-heading]').should('be.visible');
+  cy.get('[data-cy=stalemate-img]').should('be.visible');
+  cy.window()
+    .its('cuttle.app.config.globalProperties.$store.state.game')
+    .then((game) => {
+      if (game.isRanked) {
+        const gameNumber = game.currentMatch.games.length;
+        cy.get('#game-over-dialog')
+          .should('be.visible')
+          // Don't need to check match winner as we do in assertVictory or assertLoss
+          // since a stalemate won't decide a match winner
+          .should('contain', `Game ${gameNumber}: Draw`)
+          .get('[data-cy=match-result-section]')
+          .should('be.visible');
+      } else {
+        cy.get('#game-over-dialog').should('be.visible').should('not.contain', 'Match against');
+      }
+    });
+}
+
 /**
  * @param fixture:
  * {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

Resolves #377 

## Please check the following

Adds test case for spectating and seeing cannot counter dialog, then having dialog disappear and confirming that no overlay scrim is shown

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
