### PR TITLE
Feat/show one offs in overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/src/components/GameView/GameCard.vue
+++ b/src/components/GameView/GameCard.vue
@@ -75,6 +75,10 @@ export default {
       default: '',
       validator: (val) => ['', 'player', 'opponent'].includes(val),
     },
+    highElevation: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     suitName() {
@@ -127,7 +131,13 @@ export default {
       return `${this.rankName} of ${this.suitName}`;
     },
     elevation() {
-      return this.isGlasses ? '0' : '1';
+      if (this.isGlasses) {
+        return '0';
+      }
+      if (this.highElevation) {
+        return '7';
+      }
+      return '1';
     },
     isBack() {
       return !this.suit && !this.rank;

--- a/src/components/GameView/GameOverlays.vue
+++ b/src/components/GameView/GameOverlays.vue
@@ -28,7 +28,7 @@
       <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3', 'overlay-header']">
         {{ showWaitingForOpponetToCounterMessage }}
       </h1>
-      <div class="mt-4 d-flex justify-center">
+      <div id="counter-scrim-cards">
         <game-card
           v-if="oneOff"
           :rank="oneOff.rank"
@@ -48,17 +48,6 @@
             :high-elevation="true"
           />
         </div>
-        <!-- <div class="jacks-container">
-        </div> -->
-        <!-- <span v-for="two in twos" :key="`overlay-two-${two.id}`" class="d-flex align-center">
-          <v-icon icon="mdi-chevron-right" size="x-large" color="black" />
-          <game-card
-            :rank="two.rank"
-            :suit="two.suit"
-            :data-overlay-counter="`${two.rank}-${two.suit}`"
-            class="overlay-card"
-          />
-        </span> -->
       </div>
     </v-overlay>
 
@@ -235,6 +224,9 @@ export default {
 </script>
 
 <style scoped lang="scss">
+:deep(.v-overlay__content) {
+  left: 0;
+}
 .game-overlay {
   display: flex;
   justify-content: center;
@@ -245,7 +237,6 @@ export default {
     font-weight: bold;
     background-color: #FFF4D7;
     padding: 24px;
-    margin-top: 80px;
     text-align: center;
     width: 100vw;
   }
@@ -260,13 +251,19 @@ export default {
     flex-direction: column;
     align-items: flex-end;
   }
+  #counter-scrim-cards {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin-top: 16px;
+  }
   .overlay-card {
     position: relative;
     display: inline-block;
     margin-right: -48px !important;
   }
   .overlay-two-0 {
-    // height: 90%;
     transform: rotate(-5deg);
   }
   .overlay-two-1 {
@@ -274,5 +271,8 @@ export default {
   }
   .overlay-two-2 {
     transform: rotate(-10deg);
+  }
+  .overlay-two-3 {
+    transform: rotate(-4deg);
   }
 </style>

--- a/src/components/GameView/GameOverlays.vue
+++ b/src/components/GameView/GameOverlays.vue
@@ -45,6 +45,7 @@
             :suit="two.suit"
             :data-overlay-counter="`${two.rank}-${two.suit}`"
             :class="`overlay-card overlay-two overlay-two-${index}`"
+            :high-elevation="true"
           />
         </div>
         <!-- <div class="jacks-container">

--- a/src/components/GameView/GameOverlays.vue
+++ b/src/components/GameView/GameOverlays.vue
@@ -6,7 +6,7 @@
       v-model="waitingForGameToStart"
       class="game-overlay"
     >
-      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3']">
+      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3', 'overlay-header']">
         Waiting for Game to Start
       </h1>
       <v-btn
@@ -25,7 +25,7 @@
       v-model="waitingForOpponentToCounter"
       class="d-flex flex-column justify-center align-center"
     >
-      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3']">
+      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3', 'overlay-header']">
         {{ showWaitingForOpponetToCounterMessage }}
       </h1>
       <div class="mt-4 d-flex justify-center">
@@ -67,7 +67,7 @@
       v-model="waitingForOpponentToDiscard"
       class="game-overlay"
     >
-      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3']">
+      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3', 'overlay-header']">
         Opponent Is Discarding
       </h1>
     </v-overlay>
@@ -77,7 +77,7 @@
       v-model="waitingForOpponentToPickFromScrap"
       class="game-overlay"
     >
-      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3']">
+      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3', 'overlay-header']">
         Opponent Choosing Card from Scrap
       </h1>
     </v-overlay>
@@ -87,7 +87,7 @@
       v-model="showWaitingForOpponentToPlayFromDeck"
       class="game-overlay"
     >
-      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3']">
+      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3', 'overlay-header']">
         Opponent Playing from Deck
       </h1>
     </v-overlay>
@@ -97,7 +97,7 @@
       v-model="showWaitingForOpponentToDiscardJackFromDeck"
       class="game-overlay"
     >
-      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3']">
+      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3', 'overlay-header']">
         Opponent Must Discard Jack
       </h1>
     </v-overlay>
@@ -107,7 +107,7 @@
       v-model="waitingForOpponentToStalemate"
       class="game-overlay"
     >
-      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3']">
+      <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3', 'overlay-header']">
         <div>Opponent Considering Stalemate Request</div>
       </h1>
     </v-overlay>
@@ -241,8 +241,13 @@ export default {
   align-items: center;
   text-align: center;
 }
-.text-h3, .text-h5 {
+.overlay-header {
     font-weight: bold;
+    background-color: #FFF4D7;
+    padding: 24px;
+    margin-top: 80px;
+    text-align: center;
+    width: 100vw;
   }
 
 .jacks-container {

--- a/src/components/GameView/GameOverlays.vue
+++ b/src/components/GameView/GameOverlays.vue
@@ -262,6 +262,7 @@ export default {
     position: relative;
     display: inline-block;
     margin-right: -48px !important;
+    min-width: 90px;
   }
   .overlay-two-0 {
     transform: rotate(-5deg);

--- a/src/components/GameView/GameOverlays.vue
+++ b/src/components/GameView/GameOverlays.vue
@@ -240,17 +240,6 @@ export default {
     text-align: center;
     width: 100vw;
   }
-
-.jacks-container {
-    position: absolute;
-    right: -5%;
-    top: 0;
-    width: 100%;
-    height: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-  }
   #counter-scrim-cards {
     position: absolute;
     display: flex;

--- a/src/components/GameView/GameOverlays.vue
+++ b/src/components/GameView/GameOverlays.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="game-overlays">
+
     <v-overlay
       id="waiting-for-game-to-start-scrim"
       v-model="waitingForGameToStart"
@@ -18,15 +19,48 @@
         Leave Game
       </v-btn>
     </v-overlay>
+
     <v-overlay
       id="waiting-for-opponent-counter-scrim"
       v-model="waitingForOpponentToCounter"
-      class="game-overlay"
+      class="d-flex flex-column justify-center align-center"
     >
       <h1 :class="[this.$vuetify.display.xs === true ? 'text-h5' : 'text-h3']">
         {{ showWaitingForOpponetToCounterMessage }}
       </h1>
+      <div class="mt-4 d-flex justify-center">
+        <game-card
+          v-if="oneOff"
+          :rank="oneOff.rank"
+          :suit="oneOff.suit"
+          :data-overlay-one-off="`${oneOff.rank}-${oneOff.suit}`"
+          :jacks="twos"
+          class="overlay-card"
+        />
+        <div>
+          <game-card
+            v-for="(two, index) in twos"
+            :key="`overlay-two-${two.id}`"
+            :rank="two.rank"
+            :suit="two.suit"
+            :data-overlay-counter="`${two.rank}-${two.suit}`"
+            :class="`overlay-card overlay-two overlay-two-${index}`"
+          />
+        </div>
+        <!-- <div class="jacks-container">
+        </div> -->
+        <!-- <span v-for="two in twos" :key="`overlay-two-${two.id}`" class="d-flex align-center">
+          <v-icon icon="mdi-chevron-right" size="x-large" color="black" />
+          <game-card
+            :rank="two.rank"
+            :suit="two.suit"
+            :data-overlay-counter="`${two.rank}-${two.suit}`"
+            class="overlay-card"
+          />
+        </span> -->
+      </div>
     </v-overlay>
+
     <v-overlay
       id="waiting-for-opponent-discard-scrim"
       v-model="waitingForOpponentToDiscard"
@@ -36,6 +70,7 @@
         Opponent Is Discarding
       </h1>
     </v-overlay>
+
     <v-overlay
       id="waiting-for-opponent-resolve-three-scrim"
       v-model="waitingForOpponentToPickFromScrap"
@@ -45,6 +80,7 @@
         Opponent Choosing Card from Scrap
       </h1>
     </v-overlay>
+
     <v-overlay
       id="waiting-for-opponent-play-from-deck-scrim"
       v-model="showWaitingForOpponentToPlayFromDeck"
@@ -54,6 +90,7 @@
         Opponent Playing from Deck
       </h1>
     </v-overlay>
+
     <v-overlay
       id="waiting-for-opponent-to-discard-jack-from-deck"
       v-model="showWaitingForOpponentToDiscardJackFromDeck"
@@ -63,6 +100,7 @@
         Opponent Must Discard Jack
       </h1>
     </v-overlay>
+
     <v-overlay
       id="waiting-for-opponent-stalemate-scrim"
       v-model="waitingForOpponentToStalemate"
@@ -72,6 +110,7 @@
         <div>Opponent Considering Stalemate Request</div>
       </h1>
     </v-overlay>
+
     <move-choice-overlay
       v-if="selectedCard || cardSelectedFromDeck"
       :modelValue="!targeting && (!!selectedCard || !!cardSelectedFromDeck)"
@@ -96,11 +135,13 @@
 import { mapGetters, mapState } from 'vuex';
 
 import MoveChoiceOverlay from '@/components/GameView/MoveChoiceOverlay.vue';
+import GameCard from '@/components/GameView/GameCard.vue';
 
 export default {
   name: 'GameOverlays',
   components: {
     MoveChoiceOverlay,
+    GameCard,
   },
   emits:['points', 'face-card', 'one-off', 'clear-selection', 'target'],
   props: {
@@ -133,6 +174,8 @@ export default {
       waitingForOpponentToStalemate: ({ game }) => game.waitingForOpponentToStalemate,
       topCard: ({ game }) => game.topCard,
       secondCard: ({ game }) => game.secondCard,
+      oneOff: ({ game }) => game.oneOff,
+      twos: ({ game }) => game.twos,
       playingFromDeck: ({ game }) => game.playingFromDeck,
     }),
     ...mapGetters([
@@ -196,11 +239,34 @@ export default {
   justify-content: center;
   align-items: center;
   text-align: center;
-  & .text-h3 {
+}
+.text-h3, .text-h5 {
     font-weight: bold;
   }
-}
-.text-h5 {
-    font-weight: bold;
+
+.jacks-container {
+    position: absolute;
+    right: -5%;
+    top: 0;
+    width: 100%;
+    height: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
+  .overlay-card {
+    position: relative;
+    display: inline-block;
+    margin-right: -48px !important;
+  }
+  .overlay-two-0 {
+    // height: 90%;
+    transform: rotate(-5deg);
+  }
+  .overlay-two-1 {
+    transform: rotate(3deg);
+  }
+  .overlay-two-2 {
+    transform: rotate(-10deg);
   }
 </style>

--- a/tests/e2e/specs/in-game/countering.spec.js
+++ b/tests/e2e/specs/in-game/countering.spec.js
@@ -2,7 +2,6 @@ import { assertGameState, Card, playOutOfTurn } from '../../support/helpers';
 
 describe('Countering One-Offs', () => {
   beforeEach(() => {
-    // cy.viewport('iphone-8');
     cy.setupGameAsP1();
   });
 
@@ -263,7 +262,7 @@ describe('Countering One-Offs', () => {
     });
   });
 
-  it.only('Quadruple counters successfully', () => {
+  it('Quadruple counters successfully', () => {
     cy.loadGameFixture({
       // Opponent is P0
       p0Hand: [Card.ACE_OF_CLUBS, Card.TWO_OF_CLUBS, Card.TWO_OF_DIAMONDS],
@@ -296,30 +295,30 @@ describe('Countering One-Offs', () => {
     cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-2]').should('exist');
     cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-0]').should('exist');
     // Opponent plays 4th and final counter
-    // cy.counterOpponent(Card.TWO_OF_DIAMONDS);
-    // // Player cannot counter back
-    // cy.get('#cannot-counter-dialog').should('be.visible').get('[data-cy=cannot-counter-resolve]').click();
-    // assertGameState(1, {
-    //   // Opponent is P0
-    //   p0Hand: [],
-    //   p0Points: [],
-    //   p0FaceCards: [Card.KING_OF_SPADES],
-    //   // Player is P1
-    //   p1Hand: [],
-    //   p1Points: [],
-    //   p1FaceCards: [Card.KING_OF_HEARTS],
-    //   scrap: [
-    //     Card.ACE_OF_CLUBS,
-    //     Card.TWO_OF_HEARTS,
-    //     Card.TWO_OF_CLUBS,
-    //     Card.TWO_OF_SPADES,
-    //     Card.TWO_OF_DIAMONDS,
-    //     Card.TEN_OF_SPADES,
-    //     Card.ACE_OF_SPADES,
-    //     Card.TEN_OF_HEARTS,
-    //     Card.ACE_OF_DIAMONDS,
-    //   ],
-    // });
+    cy.counterOpponent(Card.TWO_OF_DIAMONDS);
+    // Player cannot counter back
+    cy.get('#cannot-counter-dialog').should('be.visible').get('[data-cy=cannot-counter-resolve]').click();
+    assertGameState(1, {
+      // Opponent is P0
+      p0Hand: [],
+      p0Points: [],
+      p0FaceCards: [Card.KING_OF_SPADES],
+      // Player is P1
+      p1Hand: [],
+      p1Points: [],
+      p1FaceCards: [Card.KING_OF_HEARTS],
+      scrap: [
+        Card.ACE_OF_CLUBS,
+        Card.TWO_OF_HEARTS,
+        Card.TWO_OF_CLUBS,
+        Card.TWO_OF_SPADES,
+        Card.TWO_OF_DIAMONDS,
+        Card.TEN_OF_SPADES,
+        Card.ACE_OF_SPADES,
+        Card.TEN_OF_HEARTS,
+        Card.ACE_OF_DIAMONDS,
+      ],
+    });
   });
 
   it('Cannot Counter When Opponent Has Queen', () => {

--- a/tests/e2e/specs/in-game/countering.spec.js
+++ b/tests/e2e/specs/in-game/countering.spec.js
@@ -262,7 +262,7 @@ describe('Countering One-Offs', () => {
     });
   });
 
-  it('Quadruple counters successfully', () => {
+  it.only('Quadruple counters successfully', () => {
     cy.loadGameFixture({
       // Opponent is P0
       p0Hand: [Card.ACE_OF_CLUBS, Card.TWO_OF_CLUBS, Card.TWO_OF_DIAMONDS],
@@ -283,37 +283,42 @@ describe('Countering One-Offs', () => {
     cy.get('#counter-dialog').should('be.visible').get('[data-cy=counter]').click();
     cy.get('#choose-two-dialog').should('be.visible').get('[data-counter-dialog-card=2-2]').click();
     cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
+    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-one-off=1-0]').should('be.visible');
+    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-2]').should('be.visible');
     // Opponent counters back (2nd counter)
     cy.counterOpponent(Card.TWO_OF_CLUBS);
     // Player counters again (3rd counter)
     cy.get('#counter-dialog').should('be.visible').get('[data-cy=counter]').click();
     cy.get('#choose-two-dialog').should('be.visible').get('[data-counter-dialog-card=2-3]').click();
     cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
+    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-one-off=1-0]').should('be.visible');
+    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-2]').should('be.visible');
+    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-0]').should('be.visible');
     // Opponent plays 4th and final counter
-    cy.counterOpponent(Card.TWO_OF_DIAMONDS);
-    // Player cannot counter back
-    cy.get('#cannot-counter-dialog').should('be.visible').get('[data-cy=cannot-counter-resolve]').click();
-    assertGameState(1, {
-      // Opponent is P0
-      p0Hand: [],
-      p0Points: [],
-      p0FaceCards: [Card.KING_OF_SPADES],
-      // Player is P1
-      p1Hand: [],
-      p1Points: [],
-      p1FaceCards: [Card.KING_OF_HEARTS],
-      scrap: [
-        Card.ACE_OF_CLUBS,
-        Card.TWO_OF_HEARTS,
-        Card.TWO_OF_CLUBS,
-        Card.TWO_OF_SPADES,
-        Card.TWO_OF_DIAMONDS,
-        Card.TEN_OF_SPADES,
-        Card.ACE_OF_SPADES,
-        Card.TEN_OF_HEARTS,
-        Card.ACE_OF_DIAMONDS,
-      ],
-    });
+    // cy.counterOpponent(Card.TWO_OF_DIAMONDS);
+    // // Player cannot counter back
+    // cy.get('#cannot-counter-dialog').should('be.visible').get('[data-cy=cannot-counter-resolve]').click();
+    // assertGameState(1, {
+    //   // Opponent is P0
+    //   p0Hand: [],
+    //   p0Points: [],
+    //   p0FaceCards: [Card.KING_OF_SPADES],
+    //   // Player is P1
+    //   p1Hand: [],
+    //   p1Points: [],
+    //   p1FaceCards: [Card.KING_OF_HEARTS],
+    //   scrap: [
+    //     Card.ACE_OF_CLUBS,
+    //     Card.TWO_OF_HEARTS,
+    //     Card.TWO_OF_CLUBS,
+    //     Card.TWO_OF_SPADES,
+    //     Card.TWO_OF_DIAMONDS,
+    //     Card.TEN_OF_SPADES,
+    //     Card.ACE_OF_SPADES,
+    //     Card.TEN_OF_HEARTS,
+    //     Card.ACE_OF_DIAMONDS,
+    //   ],
+    // });
   });
 
   it('Cannot Counter When Opponent Has Queen', () => {

--- a/tests/e2e/specs/in-game/countering.spec.js
+++ b/tests/e2e/specs/in-game/countering.spec.js
@@ -2,6 +2,7 @@ import { assertGameState, Card, playOutOfTurn } from '../../support/helpers';
 
 describe('Countering One-Offs', () => {
   beforeEach(() => {
+    // cy.viewport('iphone-8');
     cy.setupGameAsP1();
   });
 
@@ -283,17 +284,17 @@ describe('Countering One-Offs', () => {
     cy.get('#counter-dialog').should('be.visible').get('[data-cy=counter]').click();
     cy.get('#choose-two-dialog').should('be.visible').get('[data-counter-dialog-card=2-2]').click();
     cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
-    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-one-off=1-0]').should('be.visible');
-    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-2]').should('be.visible');
+    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-one-off=1-0]').should('exist');
+    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-2]').should('exist');
     // Opponent counters back (2nd counter)
     cy.counterOpponent(Card.TWO_OF_CLUBS);
     // Player counters again (3rd counter)
     cy.get('#counter-dialog').should('be.visible').get('[data-cy=counter]').click();
     cy.get('#choose-two-dialog').should('be.visible').get('[data-counter-dialog-card=2-3]').click();
     cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
-    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-one-off=1-0]').should('be.visible');
-    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-2]').should('be.visible');
-    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-0]').should('be.visible');
+    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-one-off=1-0]').should('exist');
+    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-2]').should('exist');
+    cy.get('#waiting-for-opponent-counter-scrim [data-overlay-counter=2-0]').should('exist');
     // Opponent plays 4th and final counter
     // cy.counterOpponent(Card.TWO_OF_DIAMONDS);
     // // Player cannot counter back


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Please check the following
Resolves #353 

Changes the visual style of in-game overlays and adds the one-offs on the stack to the #waiting-for-opponent-counter-scrim

Adds background color to overlays in addition to showing the one-off cards
![image](https://user-images.githubusercontent.com/6520704/230099870-f78e2087-ba4c-42b9-b8fc-fe55f83f3914.png)

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
