### PR TITLE
feat: enable use of cypress cloud to record runs as video

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -78,7 +78,11 @@ jobs:
           wait-on: 'http://localhost:1337'
           # wait for 2 minutes for the server to respond
           wait-on-timeout: 120
+          record: true
+          parallel: true
+          video: true
         env:
           VITE_API_URL: http://localhost:1337
           # pass GitHub token to allow accurately detecting a build vs a re-run build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Please check the following
Enable use of cypress cloud to record test run videos
- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
