### PR TITLE
fix: remove /public from lobby sounds urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/src/views/LobbyView.vue
+++ b/src/views/LobbyView.vue
@@ -23,8 +23,8 @@
         />
       </v-col>
       <v-col offset="1">
-        <audio ref="enterLobbySound" src="/public/sounds/lobby/enter-lobby.mp3"></audio>
-        <audio ref="leaveLobbySound" src="/public/sounds/lobby/leave-lobby.mp3"></audio>
+        <audio ref="enterLobbySound" src="/sounds/lobby/enter-lobby.mp3"></audio>
+        <audio ref="leaveLobbySound" src="/sounds/lobby/leave-lobby.mp3"></audio>
         <lobby-player-indicator
           :player-username="opponentUsername"
           :player-ready="opponentIsReady"


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Please check the following
Fix bug where the lobby sounds wouldn't load in prod b/c they reference the /public folder which doesn't exist in prod

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
