### PR TITLE
Fix/prevent joining closed games

### DIFF
--- a/api/controllers/game/ready.js
+++ b/api/controllers/game/ready.js
@@ -29,7 +29,8 @@ module.exports = function (req, res) {
         if (bothReady) {
           // Inform all clients this game has started
           sails.sockets.blast('gameStarted', { gameId: game.id });
-
+          // Ensure game is no longer available for new players to join
+          gameUpdates.status = false;
           // Create Cards
           return new Promise(function makeDeck(resolveMakeDeck) {
             const findP0 = userService.findUser({ userId: game.players[0].id });

--- a/api/controllers/game/subscribe.js
+++ b/api/controllers/game/subscribe.js
@@ -17,7 +17,7 @@ module.exports = function (req, res) {
       const [game, user] = arr;
 
       // Fast fail if game is full
-      const gameIsFull = !game.status || game.players.length >= 2 || game.log.length > 0;
+      const gameIsFull = sails.helpers.isGameFull(game);
       if (gameIsFull) {
         throw { message: `Cannot join that game because it's already full` };
       }

--- a/api/controllers/game/subscribe.js
+++ b/api/controllers/game/subscribe.js
@@ -15,6 +15,10 @@ module.exports = function (req, res) {
     .then(async function success(arr) {
       // Catch promise values
       const [game, user] = arr;
+
+      if (!game.status) {
+        throw {message: `Cannot join that game because it's already full`};
+      }
       // Does the user already have a pnum for this game?
       let pNum = getPlayerPnumByUsername(game.players, user.username);
       if (!pNumIsValid(pNum) && game.players) {

--- a/api/controllers/game/subscribe.js
+++ b/api/controllers/game/subscribe.js
@@ -9,7 +9,7 @@ module.exports = function (req, res) {
   }
   Game.subscribe(req, [req.body.id]);
   const promiseClearOldGame = gameService.clearGame({ userId: req.session.usr });
-  const promiseGame = gameAPI.findGame(req.body.id).populate('players');
+  const promiseGame = gameAPI.findGame(req.body.id);
   const promiseUser = userAPI.findUser(req.session.usr);
   Promise.all([promiseGame, promiseUser, promiseClearOldGame])
     .then(async function success(arr) {

--- a/api/helpers/is-game-full.js
+++ b/api/helpers/is-game-full.js
@@ -1,0 +1,25 @@
+module.exports = {
+  friendlyName: 'Is Game Full?',
+
+  description: 'Returns true if a game is full and unavailable to join',
+
+  inputs: {
+    game: {
+      type: 'ref',
+      description: 'Game to be evaluated',
+      required: true,
+    },
+  },
+
+  sync: true, // synchronous helper
+
+  fn: ({ game }, exits) => {
+
+    const gameIsFull = !game.status || 
+      game.players.length >= 2 || 
+      game.log.length > 0 || 
+      !_.isEqual(game.lastEvent, {});
+
+    return exits.success(gameIsFull);
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.3.15",
+  "version": "4.3.16",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/src/store/modules/game.js
+++ b/src/store/modules/game.js
@@ -326,7 +326,8 @@ export default {
               });
               return resolve();
             }
-            return reject(new Error('error subscribing'));
+            const message = res.message ?? 'error subscribing';
+            return reject(new Error(message));
           },
         );
       });

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -35,7 +35,7 @@
                       :status="game.status"
                       :num-players="game.numPlayers"
                       :is-ranked="game.isRanked"
-                      @error="handleError"
+                      @error="handleSubscribeError(game.id, $event)"
                     />
                   </div>
                 </v-window-item>
@@ -172,6 +172,10 @@ export default {
     clearSnackBar() {
       this.snackMessage = '';
       this.showSnackBar = false;
+    },
+    handleSubscribeError(gameId, message) {
+      this.$store.commit('updateGameStatus', {id: gameId, newStatus: false});
+      this.handleError(message);
     },
     handleError(message) {
       this.creatingGame = false;

--- a/tests/e2e/fixtures/snackbarError.js
+++ b/tests/e2e/fixtures/snackbarError.js
@@ -4,6 +4,7 @@ const SnackBarError = {
     "You can only scuttle an opponent's point card with a higher rank point card, or the same rank with a higher suit. Suit order (low to high) is: Clubs < Diamonds < Hearts < Spades",
   FROZEN_CARD: 'That card is frozen! You must wait a turn to play it',
   NOT_IN_GAME: "You can't do that because you're not a player in this game",
+  GAME_IS_FULL: `Cannot join that game because it's already full`,
 };
 
 export { SnackBarError };

--- a/tests/e2e/specs/out-of-game/home.spec.js
+++ b/tests/e2e/specs/out-of-game/home.spec.js
@@ -1,6 +1,7 @@
 import { assertSnackbarError } from '../../support/helpers';
 import { Card } from '../../fixtures/cards';
 import { myUser, opponentOne, opponentTwo, playerOne, playerTwo } from '../../fixtures/userFixtures';
+import { SnackBarError } from '../../fixtures/snackbarError';
 
 function setup() {
   cy.wipeDatabase();
@@ -148,6 +149,15 @@ describe('Home - Game List', () => {
 
       // Test that join button is now disabled
       cy.contains('[data-cy-join-game]', 'Play').should('be.disabled');
+
+      // Manually re-enable join button to confirm backend rejects request
+      cy.window().its('cuttle.app.config.globalProperties.$store')
+        .invoke('commit', 'updateGameStatus', {id: gameData.gameId, newStatus: true});
+      cy.contains('[data-cy-join-game]', 'Play')
+        .should('not.be.disabled')
+        .click();
+
+      assertSnackbarError(SnackBarError.GAME_IS_FULL, 'newgame');
     });
   });
 

--- a/tests/e2e/specs/out-of-game/home.spec.js
+++ b/tests/e2e/specs/out-of-game/home.spec.js
@@ -155,9 +155,12 @@ describe('Home - Game List', () => {
         .invoke('commit', 'updateGameStatus', {id: gameData.gameId, newStatus: true});
       cy.contains('[data-cy-join-game]', 'Play')
         .should('not.be.disabled')
-        .click();
+        .click()
+        .should('be.disabled');
 
       assertSnackbarError(SnackBarError.GAME_IS_FULL, 'newgame');
+
+
     });
   });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Please check the following
Resolves #346 by throwing backend error when subscribing to game that's already full. Added appropriate assertions to the relevant test case.

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Throw an error when request to subscribe is made on a full game, disable the join button and add display a snackbar error
![image](https://user-images.githubusercontent.com/6520704/236846822-d02facdf-3a91-4338-a40a-8b6c5a0cd559.png)
