### PR TITLE
Fix/close busted games on join failure

### DIFF
--- a/api/controllers/game/subscribe.js
+++ b/api/controllers/game/subscribe.js
@@ -19,6 +19,11 @@ module.exports = function (req, res) {
       // Fast fail if game is full
       const gameIsFull = sails.helpers.isGameFull(game);
       if (gameIsFull) {
+        // Ensure game is closed for future
+        await Game.updateOne({ id: game.id })
+          .set({
+            status: false
+          });
         throw { message: `Cannot join that game because it's already full` };
       }
       // Does the user already have a pnum for this game?

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -23,6 +23,11 @@ module.exports = defineConfig({
       return config;
     },
   },
+  // Retry tests 2 times headlessly, no retries in UI
+  retries: {
+    runMode: 2,
+    openMode: 0,
+  },
   numTestsKeptInMemory: 25,
   // https://docs.cypress.io/guides/references/configuration#Videos
   video: false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.3.16",
+  "version": "4.3.17",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Please check the following
Follow up to https://github.com/cuttle-cards/cuttle/pull/403. Sometimes games are unavailable to join because they've started incorrectly even though the status is `true`. This ensures that the status gets correctly set to `false` whenever a join/subscribe request fails.

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
