### PR TITLE
Spectator display hotfix - Spectator names being displayed after leaving and returning

### DIFF
--- a/api/controllers/game/spectate.js
+++ b/api/controllers/game/spectate.js
@@ -16,7 +16,13 @@ module.exports = async function (req, res) {
     await UserSpectatingGame.findOrCreate(
       { gameSpectated: game.id, spectator: spectator.id },
       { gameSpectated: game.id, spectator: spectator.id },
-    );
+    ).exec(async (err, record, wasCreated) => {
+      if (!wasCreated) {
+        await UserSpectatingGame.update({ gameSpectated: game.id, spectator: spectator.id }).set({
+          activelySpectating: true,
+        });
+      }
+    });
 
     const fullGame = await gameService.populateGame({ gameId: game.id });
     Game.publish([fullGame.id], {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cuttle",
-  "version": "4.3.18",
+  "version": "4.3.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.3.18",
+  "version": "4.3.19",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/tests/e2e/specs/in-game/spectating.spec.js
+++ b/tests/e2e/specs/in-game/spectating.spec.js
@@ -339,7 +339,7 @@ describe('Spectating Games', () => {
       cy.get('[data-cy="spectate-list-menu"').should('not.contain', playerThree.username);
     });
 
-    it('Should only show `Rules` and `Go Home` in menu and should leave game', () => {
+    it('Should show correct menu options, leave game, then return to re-add name to list', () => {
       cy.setupGameAsSpectator();
       cy.get('#game-menu-activator').click();
       cy.get('#game-menu')
@@ -349,6 +349,10 @@ describe('Spectating Games', () => {
         .should('not.contain', 'Concede');
       cy.get('[data-cy="stop-spectating"]').click();
       cy.hash().should('eq', '#/');
+      cy.get('[data-cy-game-list-selector=spectate]').click();
+      cy.get(`[data-cy-spectate-game]`).click();
+      cy.get('[data-cy="spectate-list-button"]').should('contain', '1').click();
+      cy.get('[data-cy="spectate-list-menu"').should('contain', 'myUsername');
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant issue number (e.g. #404): #

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

This is a hot-fix for my displaying spectator usernames commit. If you left spectating a game, to return to watch it later you're name wouldn't be added back to the spectator list. 