### PR TITLE
DevEx#340 Update linting to require semicolons

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }],
+    semi: ['error', 'always'],
   },
   overrides: [
     // Vue specific rules

--- a/src/components/GameListItem.vue
+++ b/src/components/GameListItem.vue
@@ -109,7 +109,7 @@ export default {
         variant: 'outlined',
         minWidth: '200',
         loading: this.joiningGame,
-      }
+      };
     },
   },
   methods: {

--- a/src/components/Global/BaseDialog.vue
+++ b/src/components/Global/BaseDialog.vue
@@ -47,7 +47,7 @@ export default {
       },
     },
   },
-}
+};
 </script>
 
 <style scoped>

--- a/src/components/Global/BaseSnackbar.vue
+++ b/src/components/Global/BaseSnackbar.vue
@@ -26,5 +26,5 @@ export default {
       this.$emit('clear');
     },
   }
-}
+};
 </script>

--- a/src/components/StatsLeaderboard.vue
+++ b/src/components/StatsLeaderboard.vue
@@ -85,7 +85,7 @@ export default {
   },
   computed: {
     noSeasonRankingsExist() {
-      return !this.season || !this.season.rankings || this.season.rankings.length === 0
+      return !this.season || !this.season.rankings || this.season.rankings.length === 0;
     },
     tableColumns() {
       if (this.noSeasonRankingsExist) {
@@ -152,7 +152,7 @@ export default {
             winCount: wins.length,
             lossCount: losses.length,
             totalCount: matchesThisWeek.length,
-          }
+          };
         }
         return res;
       });

--- a/src/store/modules/gameList.js
+++ b/src/store/modules/gameList.js
@@ -34,7 +34,7 @@ export default {
       state.spectateGames.push(startedGame);
     },
     gameFinished(state, gameId) {
-      const game = state.spectateGames.find((game) => game.id === gameId)
+      const game = state.spectateGames.find((game) => game.id === gameId);
       if (!game) {
         return;
       }

--- a/src/views/StatsView.vue
+++ b/src/views/StatsView.vue
@@ -116,7 +116,7 @@ export default {
         return {
           title: season.name,
           value: season
-        }
+        };
       });
     }
   },
@@ -124,7 +124,7 @@ export default {
     this.loadingData = true;
     io.socket.get('/stats', (res) => {
       this.seasons = res;
-      const [selectedSeason] = this.seasons
+      const [selectedSeason] = this.seasons;
       this.selectedSeason = selectedSeason;
       this.loadingData = false;
     });


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant issue number (e.g. #404): #340 

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
This PR adds the `semi` rule to the .eslintrc file, to enforce requiring a semicolon. Documentation regarding this rule can be found here: https://eslint.org/docs/latest/rules/semi.

I tested the new rule by removing the semicolons from the lines mentioned in the issue (lines 160 and 163 of [GameOverDialog.vue](https://github.com/cuttle-cards/cuttle/blob/6a73d2a7cb3cb624578f5dfbe7833c339b96a101/src/components/GameView/GameOverDialog.vue#L160)) as per below:

![remove_semis](https://github.com/cuttle-cards/cuttle/assets/69952207/4ece9de4-c5cb-447a-a954-50fa265a97c1)

This resulted in the desired error messages when running `npm run lint`, as per below:

![results](https://github.com/cuttle-cards/cuttle/assets/69952207/89091974-09ab-46a0-85ab-2b8e03745b22)

As a result of the new rule, several missing semicolons throughout the code were picked up:

![errors](https://github.com/cuttle-cards/cuttle/assets/69952207/51f3c552-9d8a-4f01-90eb-32620ce4452d)

I confirmed that these are corrected by running `npm run lint:fix`. I also confirmed all the tests still pass upon inserting these semicolons:

![fixed](https://github.com/cuttle-cards/cuttle/assets/69952207/309ef2cd-a2a3-424b-89e3-b9291993b42e)

I note that the documentation lists some additional rules ([omitLastInOneLineBlock](https://eslint.org/docs/latest/rules/semi#omitlastinonelineblock) and [omitLastInOneLineClassBody](https://eslint.org/docs/latest/rules/semi#omitlastinonelineclassbody)) regarding semicolon usage which we also may want to add. Personally I think implementing the rule 'as is' is fine for now but someone with more knowledge than I might want to consider if we need those other rules as well.