### PR TITLE
chore: add line breaks to too-long text in rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.3.21",
+  "version": "4.3.22",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/src/components/RulesDialog.vue
+++ b/src/components/RulesDialog.vue
@@ -131,8 +131,11 @@
             You keep control of the point card as long as you control the top jack.
           </p>
           <p>
-            <strong>Queen:</strong> While you control a Queen, your other cards cannot be targeted by your
-            opponent's cards. This effectively protects your other cards from the effects of 2's (<strong>including countering</strong>), 9's and Jacks. Note that Queens do not protect against Scuttling.
+            <strong>Queen:</strong> 
+            While you control a Queen, your other cards cannot be targeted by your
+            opponent's cards. This effectively protects your other cards from the effects of 2's 
+            (<strong>including countering</strong>), 9's and Jacks. 
+            Note that Queens do not protect against Scuttling.
           </p>
           <p>
             <strong>King:</strong> While you have a King, the minimum points needed to win is reduced. Each


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number
Fixes the only lint warning by breaking up a long line of text in the RulesView

Relevant issue number (e.g. #404): #

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
