### PR TITLE
Bug #401 Allowing one-off on itself if seven and last card in deck

### DIFF
--- a/api/controllers/game/seven/untargeted-one-off.js
+++ b/api/controllers/game/seven/untargeted-one-off.js
@@ -25,7 +25,7 @@ module.exports = function (req, res) {
                 case 4:
                   if (opponent.hand.length === 0)
                     return Promise.reject({
-                      message: 'You cannot play a 4 as a one-off while your opponent has no cards in hand',
+                      message: 'You cannot play a 4 as a ONE-OFF while your opponent has no cards in hand',
                     });
                   break;
                 case 5:
@@ -33,6 +33,10 @@ module.exports = function (req, res) {
                   if (!game.topCard)
                     return Promise.reject({
                       message: 'You can only play a 7 as a ONE-OFF if there are cards in the deck',
+                    });
+                  if (game.topCard.id === card.id && !game.secondCard)
+                    return Promise.reject({
+                      message: 'You can not play a 7 as a ONE-OFF if it the last card in the deck',
                     });
                   break;
               }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-<<<<<<< HEAD
-  "version": "4.3.29",
-=======
   "version": "4.3.30",
->>>>>>> f006cb9 (chore: update package number)
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
+<<<<<<< HEAD
   "version": "4.3.29",
+=======
+  "version": "4.3.30",
+>>>>>>> f006cb9 (chore: update package number)
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/src/components/GameView/MoveChoiceOverlay.vue
+++ b/src/components/GameView/MoveChoiceOverlay.vue
@@ -80,7 +80,7 @@ export default {
       required: true,
     },
     cardSelectedFromDeck: {
-      type: Boolean,
+      type: Object,
       default: null,
     },
   },

--- a/src/components/GameView/MoveChoiceOverlay.vue
+++ b/src/components/GameView/MoveChoiceOverlay.vue
@@ -142,14 +142,14 @@ export default {
           oneOffDisabled = true;
           oneOffDisabledExplanation = "Can't be played with empty deck";
         }
-        return {
-          displayName: 'One-Off',
-          eventName: 'oneOff',
-          moveDescription: this.selectedCard.ruleText,
-          disabled: oneOffDisabled,
-          disabledExplanation: oneOffDisabledExplanation,
-        };
       }
+      return {
+        displayName: 'One-Off',
+        eventName: 'oneOff',
+        moveDescription: this.selectedCard.ruleText,
+        disabled: oneOffDisabled,
+        disabledExplanation: oneOffDisabledExplanation,
+      };
     },
 
     targetedOneOffMove() {

--- a/src/components/GameView/MoveChoiceOverlay.vue
+++ b/src/components/GameView/MoveChoiceOverlay.vue
@@ -53,7 +53,7 @@ export default {
     MoveChoiceCard,
     GameCard,
   },
-  emits:['points', 'faceCard', 'scuttle', 'jack', 'oneOff', 'targetedOneOff', 'cancel'],
+  emits: ['points', 'faceCard', 'scuttle', 'jack', 'oneOff', 'targetedOneOff', 'cancel'],
   props: {
     modelValue: {
       type: Boolean,
@@ -131,12 +131,27 @@ export default {
       };
     },
     oneOffMove() {
+      let oneOffDisabled = this.allMovesAreDisabled;
+      let oneOffDisabledExplanation = this.disabledText;
+      //Check deck while playing 7s
+      if (this.selectedCard.rank === 7) {
+        if (!this.$store.state.game.topCard) {
+          oneOffDisabled = true;
+          oneOffDisabledExplanation = 'Cannot play one-off with an empty deck';
+        } else if (
+          this.selectedCard.id === this.$store.state.game.topCard.id &&
+          !this.store.state.game.secondCard
+        ) {
+          oneOffDisabled = true;
+          oneOffDisabledExplanation = 'Cannot play one-off on last card in deck';
+        }
+      }
       return {
         displayName: 'One-Off',
         eventName: 'oneOff',
         moveDescription: this.selectedCard.ruleText,
-        disabled: this.allMovesAreDisabled,
-        disabledExplanation: this.disabledText,
+        disabled: oneOffDisabled,
+        disabledExplanation: oneOffDisabledExplanation,
       };
     },
 
@@ -161,7 +176,6 @@ export default {
               oneOffDisabled = true;
               oneOffDisabledExplanation = 'There are no Royals to target';
             }
-            // Nines
           } else {
             const numValidTargets =
               this.$store.getters.opponent.points.length + this.$store.getters.opponent.faceCards.length;

--- a/src/components/GameView/MoveChoiceOverlay.vue
+++ b/src/components/GameView/MoveChoiceOverlay.vue
@@ -135,24 +135,21 @@ export default {
       let oneOffDisabledExplanation = this.disabledText;
       //Check deck while playing 7s
       if (this.selectedCard.rank === 7) {
-        if (!this.$store.state.game.topCard) {
+        const noTopCard = !this.$store.state.game.topCard;
+        const playingTopCard = this.selectedCard?.id === this.$store.state.game.topCard?.id;
+        const noSecondCard = !this.$store.state.game.secondCard;
+        if (noTopCard || (playingTopCard && noSecondCard)) {
           oneOffDisabled = true;
-          oneOffDisabledExplanation = 'Cannot play one-off with an empty deck';
-        } else if (
-          this.selectedCard.id === this.$store.state.game.topCard.id &&
-          !this.store.state.game.secondCard
-        ) {
-          oneOffDisabled = true;
-          oneOffDisabledExplanation = 'Cannot play one-off on last card in deck';
+          oneOffDisabledExplanation = "Can't be played with empty deck";
         }
+        return {
+          displayName: 'One-Off',
+          eventName: 'oneOff',
+          moveDescription: this.selectedCard.ruleText,
+          disabled: oneOffDisabled,
+          disabledExplanation: oneOffDisabledExplanation,
+        };
       }
-      return {
-        displayName: 'One-Off',
-        eventName: 'oneOff',
-        moveDescription: this.selectedCard.ruleText,
-        disabled: oneOffDisabled,
-        disabledExplanation: oneOffDisabledExplanation,
-      };
     },
 
     targetedOneOffMove() {

--- a/tests/e2e/specs/in-game/sevens.spec.js
+++ b/tests/e2e/specs/in-game/sevens.spec.js
@@ -1499,7 +1499,7 @@ describe('Playing sevens at the end of the deck', () => {
       p1FaceCards: [],
       topCard: Card.SIX_OF_HEARTS,
       secondCard: Card.SEVEN_OF_HEARTS,
-      deck: [Card.FIVE_OF_DIAMONDS, Card.FOUR_OF_DIAMONDS],
+      deck: [Card.FIVE_OF_DIAMONDS],
     });
     cy.drawCardOpponent();
     cy.get('#deck').click();

--- a/tests/e2e/specs/in-game/sevens.spec.js
+++ b/tests/e2e/specs/in-game/sevens.spec.js
@@ -1508,7 +1508,7 @@ describe('Playing sevens at the end of the deck', () => {
     cy.get('[data-move-choice=oneOff').should('have.class', 'v-card--disabled');
   });
 
-  it.only("Cannot play last card of deck as 7 one-off when chaining 7's", () => {
+  it("Cannot play last card of deck as 7 one-off when chaining 7's", () => {
     cy.setupGameAsP1();
     cy.loadGameFixture(1, {
       p0Hand: [],

--- a/tests/e2e/specs/in-game/sevens.spec.js
+++ b/tests/e2e/specs/in-game/sevens.spec.js
@@ -1487,4 +1487,25 @@ describe('Playing sevens at the end of the deck', () => {
       scrap: [Card.SEVEN_OF_CLUBS],
     });
   });
+
+  it.only('Cannot play one-off on last card in deck after playing seven one off - special case', () => {
+    cy.setupGameAsP1();
+    cy.loadGameFixture(1, {
+      p0Hand: [],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [Card.SEVEN_OF_CLUBS],
+      p1Points: [],
+      p1FaceCards: [],
+      topCard: Card.SIX_OF_HEARTS,
+      secondCard: Card.SEVEN_OF_HEARTS,
+      deck: [],
+    });
+    cy.drawCardOpponent();
+    cy.get('[data-player-hand-card=7-0]').click();
+    cy.get('[data-move-choice=oneOff').click();
+    cy.resolveOpponent();
+    cy.get('#deck').click();
+    cy.get('[data-move-choice=oneOff]').should('have.class', 'v-card--disabled');
+  });
 });

--- a/tests/e2e/specs/in-game/sevens.spec.js
+++ b/tests/e2e/specs/in-game/sevens.spec.js
@@ -1525,7 +1525,7 @@ describe('Playing sevens at the end of the deck', () => {
     cy.get('[data-player-hand-card=7-0]').click();
     cy.get('[data-move-choice=oneOff').should('not.have.class', 'v-card--disabled').click();
     cy.resolveOpponent();
-    cy.get('#deck').click();
+    cy.get('[data-top-card=7-2]').click();
     cy.get('[data-move-choice=oneOff').should('have.class', 'v-card--disabled');
   });
 });

--- a/tests/e2e/specs/in-game/sevens.spec.js
+++ b/tests/e2e/specs/in-game/sevens.spec.js
@@ -1488,13 +1488,13 @@ describe('Playing sevens at the end of the deck', () => {
     });
   });
 
-  it.only('Cannot play one-off on last card in deck after playing seven one off - special case', () => {
+  it('Cannot play one-off on last card in deck after playing seven one off - special case', () => {
     cy.setupGameAsP1();
     cy.loadGameFixture(1, {
       p0Hand: [],
       p0Points: [],
       p0FaceCards: [],
-      p1Hand: [Card.SEVEN_OF_CLUBS],
+      p1Hand: [Card.SEVEN_OF_CLUBS, Card.ACE_OF_CLUBS],
       p1Points: [],
       p1FaceCards: [],
       topCard: Card.SIX_OF_HEARTS,
@@ -1502,10 +1502,29 @@ describe('Playing sevens at the end of the deck', () => {
       deck: [],
     });
     cy.drawCardOpponent();
-    cy.get('[data-player-hand-card=7-0]').click();
-    cy.get('[data-move-choice=oneOff').click();
-    cy.resolveOpponent();
     cy.get('#deck').click();
-    cy.get('[data-move-choice=oneOff]').should('have.class', 'v-card--disabled');
+    cy.passOpponent();
+    cy.get('[data-player-hand-card=7-0]').click();
+    cy.get('[data-move-choice=oneOff').should('have.class', 'v-card--disabled');
+  });
+
+  it('Cannot play one-off if no cards in deck', () => {
+    cy.setupGameAsP1();
+    cy.loadGameFixture(1, {
+      p0Hand: [],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [Card.SEVEN_OF_CLUBS, Card.ACE_OF_CLUBS],
+      p1Points: [],
+      p1FaceCards: [],
+      topCard: Card.SIX_OF_HEARTS,
+      secondCard: Card.SEVEN_OF_HEARTS,
+      deck: [Card.FIVE_OF_DIAMONDS, Card.FOUR_OF_DIAMONDS],
+    });
+    cy.drawCardOpponent();
+    cy.get('#deck').click();
+    cy.drawCardOpponent();
+    cy.get('[data-player-hand-card=7-0]').click();
+    cy.get('[data-move-choice=oneOff').should('have.class', 'v-card--disabled');
   });
 });

--- a/tests/e2e/specs/in-game/sevens.spec.js
+++ b/tests/e2e/specs/in-game/sevens.spec.js
@@ -499,7 +499,7 @@ describe('Playing SEVENS', () => {
       // Should not allow playing 4 as one-off
       cy.get('#waiting-for-opponent-counter-scrim').should('not.exist');
       cy.get('#waiting-for-opponent-discard-scrim').should('not.exist');
-      assertSnackbarError('You cannot play a 4 as a one-off while your opponent has no cards in hand');
+      assertSnackbarError('You cannot play a 4 as a ONE-OFF while your opponent has no cards in hand');
     });
   }); // End player seven one-off describe
 

--- a/tests/e2e/specs/in-game/sevens.spec.js
+++ b/tests/e2e/specs/in-game/sevens.spec.js
@@ -1488,7 +1488,7 @@ describe('Playing sevens at the end of the deck', () => {
     });
   });
 
-  it('Cannot play one-off if deck is empty', () => {
+  it('Cannot play seven one-off if deck is empty', () => {
     cy.setupGameAsP1();
     cy.loadGameFixture(1, {
       p0Hand: [],
@@ -1508,7 +1508,7 @@ describe('Playing sevens at the end of the deck', () => {
     cy.get('[data-move-choice=oneOff').should('have.class', 'v-card--disabled');
   });
 
-  it('Cannot play one-off on last card (7) in deck after playing 7 one off - special case', () => {
+  it.only("Cannot play last card of deck as 7 one-off when chaining 7's", () => {
     cy.setupGameAsP1();
     cy.loadGameFixture(1, {
       p0Hand: [],
@@ -1522,9 +1522,10 @@ describe('Playing sevens at the end of the deck', () => {
       deck: [],
     });
     cy.drawCardOpponent();
-    cy.get('#deck').click();
-    cy.passOpponent();
     cy.get('[data-player-hand-card=7-0]').click();
+    cy.get('[data-move-choice=oneOff').should('not.have.class', 'v-card--disabled').click();
+    cy.resolveOpponent();
+    cy.get('#deck').click();
     cy.get('[data-move-choice=oneOff').should('have.class', 'v-card--disabled');
   });
 });

--- a/tests/e2e/specs/in-game/sevens.spec.js
+++ b/tests/e2e/specs/in-game/sevens.spec.js
@@ -1488,27 +1488,7 @@ describe('Playing sevens at the end of the deck', () => {
     });
   });
 
-  it('Cannot play one-off on last card in deck after playing seven one off - special case', () => {
-    cy.setupGameAsP1();
-    cy.loadGameFixture(1, {
-      p0Hand: [],
-      p0Points: [],
-      p0FaceCards: [],
-      p1Hand: [Card.SEVEN_OF_CLUBS, Card.ACE_OF_CLUBS],
-      p1Points: [],
-      p1FaceCards: [],
-      topCard: Card.SIX_OF_HEARTS,
-      secondCard: Card.SEVEN_OF_HEARTS,
-      deck: [],
-    });
-    cy.drawCardOpponent();
-    cy.get('#deck').click();
-    cy.passOpponent();
-    cy.get('[data-player-hand-card=7-0]').click();
-    cy.get('[data-move-choice=oneOff').should('have.class', 'v-card--disabled');
-  });
-
-  it('Cannot play one-off if no cards in deck', () => {
+  it('Cannot play one-off if deck is empty', () => {
     cy.setupGameAsP1();
     cy.loadGameFixture(1, {
       p0Hand: [],
@@ -1524,6 +1504,26 @@ describe('Playing sevens at the end of the deck', () => {
     cy.drawCardOpponent();
     cy.get('#deck').click();
     cy.drawCardOpponent();
+    cy.get('[data-player-hand-card=7-0]').click();
+    cy.get('[data-move-choice=oneOff').should('have.class', 'v-card--disabled');
+  });
+
+  it('Cannot play one-off on last card (7) in deck after playing 7 one off - special case', () => {
+    cy.setupGameAsP1();
+    cy.loadGameFixture(1, {
+      p0Hand: [],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [Card.SEVEN_OF_CLUBS, Card.ACE_OF_CLUBS],
+      p1Points: [],
+      p1FaceCards: [],
+      topCard: Card.SIX_OF_HEARTS,
+      secondCard: Card.SEVEN_OF_HEARTS,
+      deck: [],
+    });
+    cy.drawCardOpponent();
+    cy.get('#deck').click();
+    cy.passOpponent();
     cy.get('[data-player-hand-card=7-0]').click();
     cy.get('[data-move-choice=oneOff').should('have.class', 'v-card--disabled');
   });

--- a/tests/e2e/specs/in-game/sevens.spec.js
+++ b/tests/e2e/specs/in-game/sevens.spec.js
@@ -1508,7 +1508,7 @@ describe('Playing sevens at the end of the deck', () => {
     cy.get('[data-move-choice=oneOff').should('have.class', 'v-card--disabled');
   });
 
-  it("Cannot play last card of deck as 7 one-off when chaining 7's", () => {
+  it('Cannot play last card of deck as 7 one-off when chaining sevens', () => {
     cy.setupGameAsP1();
     cy.loadGameFixture(1, {
       p0Hand: [],


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Resolves #401 

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

- Fixed bug allowing one-off to be played on last card in deck
- Added logic to disable one-off option if deck is empty or if trying to play one off on last 7 in deck
- Added test cases for bug fix as well as disabling one off option
- Updated casing on error message of Fours to match casing on other errors

![image](https://github.com/cuttle-cards/cuttle/assets/108551827/8d4e9723-245a-4c40-ae41-2a6a598ef8f5)
