### PR TITLE
Fix/signup copy typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -168,7 +168,7 @@
           </div>
         </v-col>
         <v-col :cols="$vuetify.display.mdAndUp ? 10 : 12" class="mx-auto">
-          <div class="d-flex flex-md-row flex-column align-center text-h5 my-10">
+          <div class="d-flex flex-md-row flex-column-reverse align-center text-h5 my-10">
             <img class="w-50 h-50 my-6" src="/img/loginView/game-screenshot-2.png" >
             <p class="px-8">
               Be the first to score 21 points in this explosive battle of wits. 

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -160,7 +160,7 @@
               Cuttle is a 2 player battle card game played with a 
               standard 52-card deck of cards. It has the strategic 
               nuance of trading card games like Magic, with the 
-              elegant balance of a standard deck--
+              elegant balance of a standard deck --
               and you can play it for free! Test your mettle in 
               the deepest cardgame under the sea!
             </p>


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Just a simple typo fix in copy text and a style swap so that the signup page alternates text and images on portrait mobile.

Before
![image](https://github.com/cuttle-cards/cuttle/assets/6520704/6e995398-ca9f-422d-8351-ab90d61563b8)


After
![image](https://github.com/cuttle-cards/cuttle/assets/6520704/3d67e991-9821-46b9-9194-8fdd2d42bc7a)


Larger screen sizes are unaffected and still use horizontal alignment
![image](https://github.com/cuttle-cards/cuttle/assets/6520704/a3a27262-c46a-44dd-90bc-0f653f4e689c)

## Issue number
N/A

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
