### PR TITLE
Fix/logout test selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "4.4.7",
+  "version": "4.4.8",
   "dependencies": {
     "connect-redis": "3.0.2",
     "dayjs": "1.11.3",

--- a/tests/e2e/specs/out-of-game/authentication.spec.js
+++ b/tests/e2e/specs/out-of-game/authentication.spec.js
@@ -51,7 +51,7 @@ describe('Auth - Page Content', () => {
     cy.wipeDatabase();
     cy.get('[data-cy=password]').type(myUser.password);
     cy.get('[data-cy=username]').type(myUser.username + '{enter}');
-    cy.get('[data-nav=Logout]').click();
+    cy.get("[data-nav='Log Out']").click();
     cy.visit('/');
     cy.hash().should('eq', '#/login');
     cy.clearLocalStorage();

--- a/tests/e2e/specs/out-of-game/home.spec.js
+++ b/tests/e2e/specs/out-of-game/home.spec.js
@@ -56,7 +56,7 @@ describe('Home - Page Content', () => {
   });
 
   it('Logs user out', () => {
-    cy.get('[data-nav=Logout]').click();
+    cy.get("[data-nav='Log Out']").click();
     cy.contains('p', 'Log In to get Started!');
     cy.get('[data-nav=Home]').should('not.exist');
   });

--- a/tests/e2e/specs/out-of-game/navigation.spec.js
+++ b/tests/e2e/specs/out-of-game/navigation.spec.js
@@ -12,7 +12,7 @@ describe('Navigation Drawer', () => {
     cy.viewport(1920, 1080);
     cy.get('[data-cy=nav-drawer]')
       .should('be.visible')
-      .should('contain', 'Logout')
+      .should('contain', 'Log Out')
       .should('contain', 'Rules')
       .should('not.have.class', 'v-navigation-drawer--rail')
       // Collapse nav
@@ -27,7 +27,7 @@ describe('Navigation Drawer', () => {
     // Should be expanded again
     cy.get('[data-cy=nav-drawer]')
       .should('be.visible')
-      .should('contain', 'Logout')
+      .should('contain', 'Log Out')
       .should('contain', 'Rules')
       .should('not.have.class', 'v-navigation-drawer--rail');
 
@@ -56,7 +56,7 @@ describe('Navigation Drawer', () => {
       cy.get('[data-nav=Stats]').click();
       cy.hash().should('equal', '#/stats');
       // Log out
-      cy.get('[data-nav=Logout]').click();
+      cy.get("[data-nav='Log Out']").click();
       cy.hash().should('equal', '#/login');
     }
     beforeEach(() => {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes a testing bug where the logout button selectors we’re incorrect as if #457 due to the change from “Logout” to “Log Out”
## Issue number

Relevant issue number (e.g. #404): Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
