### PR TITLE
I added 4px of margin between the icons and the text in the tabs inside  src/components/TheHeader.vue

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -15,7 +15,7 @@
         </div>
       </v-toolbar-title>
       <v-toolbar-items v-if="!mobile" class="hidden-xs-only">
-        <v-tabs class="pa-2">
+        <v-tabs class="pa-2 tab-with-margin">
           <v-tab
             v-for="({ text, icon, page }, i) in pageLinks"
             :key="i"
@@ -46,3 +46,14 @@ import { useDisplay } from 'vuetify';
 const { mobile } = useDisplay();
 const pageLinks = getPageLinks();
 </script>
+
+<style scoped>
+.tab-with-margin .v-tab {
+  display: flex;
+  align-items: center;
+}
+
+.tab-with-margin .v-tab .v-icon {
+  margin-right: 4px;
+}
+</style>


### PR DESCRIPTION
src/components/TheHeader.vue


## Issue number

 [https://github.com/cuttle-cards/cuttle/issues/560](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)


## Please check the following

- [x] Do the tests still pass?
- [x] Is the code formatted properly? 
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [x] Has the documentation been updated accordingly?

## Here's how I modified your code to achieve this:

_Add a CSS class to your <v-tabs> element. For example, let's call it "tab-with-margin"
Define the CSS style for this class in your component's <style> section_

_.tab-with-margin .v-tab selects the individual tabs inside the <v-tabs> component and makes them flex containers so that the icon and text are aligned horizontally._
_.tab-with-margin .v-tab .v-icon selects the icons within the tabs and adds a right margin of 4px._

**In this code, I've added the "tab-with-margin" class to the <v-tabs> element and defined CSS styles to add a 4px margin**
