### PR TITLE
Fix #560  Added 4px margin between icons and tab labels in TheHeader

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -23,7 +23,7 @@
             :data-cy="cyName"
             :title="text"
             :to="page"
-            :style="{margin : '4px' }"
+            :style="{margin :'4px'}"
           >
             <v-icon
               :icon="`mdi-${icon}`"

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -23,6 +23,7 @@
             :data-cy="cyName"
             :title="text"
             :to="page"
+            :style="{margin : '4px' }"
           >
             <v-icon
               :icon="`mdi-${icon}`"


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number #560 

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

-  All tests ran successfully
- The code is formatted properly , according to the guidelines
- For New Features:
  - No tests added
  - No documentation update

<img width="1680" alt="Screenshot 2023-09-23 at 7 55 43 PM" src="https://github.com/cuttle-cards/cuttle/assets/60127798/b679955c-0588-4406-a3fc-d912f5933a6d">


