### PR TITLE
feat: using preferred language from local storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cuttle",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cuttle",
-      "version": "5.2.2",
+      "version": "5.3.0",
       "dependencies": {
         "chart.js": "^4.3.3",
         "connect-redis": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "dependencies": {
     "chart.js": "^4.3.3",
     "connect-redis": "3.0.2",

--- a/src/components/TheUserMenu.vue
+++ b/src/components/TheUserMenu.vue
@@ -35,7 +35,7 @@
             :value="lang"
             :title="lang"
             :data-lang="lang"
-            @click="$i18n.locale = lang"
+            @click="changeLocale(lang)"
           />
         </v-list>
       </v-menu>
@@ -56,8 +56,14 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { ROUTE_NAME_LOGOUT } from '@/router.js';
+import { setLocalStorage } from '../../utils/local-storage-utils';
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
+
+const changeLocale = (lang) => {
+  locale.value = lang;
+  setLocalStorage('preferredLocale', lang);
+};
 
 const menuItems = computed(() => {
   return [{ text: t('global.logout'), icon: 'logout', page: { name: ROUTE_NAME_LOGOUT }, cyName: 'Log Out' }];

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -13,13 +13,17 @@ const messages = {
  es,
  fr,
 };
-// i18n.global.locale.value = getLocalStorage('preferredLocale') ?? 'en';
+
+const preferredLocale = getLocalStorage('preferredLocale');
+const fallbackLocale = 'en';
+const locale = Object.keys(messages).includes(preferredLocale) ? preferredLocale : fallbackLocale; 
+
 const i18n = createI18n({
   legacy: false,
   globalInjection: true,
-  locale: getLocalStorage('preferredLocale') ?? 'en',
+  locale,
   // https://vue-i18n.intlify.dev/guide/essentials/fallback.html
-  fallbackLocale: 'en',
+  fallbackLocale,
   messages,
 });
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,7 +1,7 @@
 // https://vue-i18n.intlify.dev/
 
 import { createI18n } from 'vue-i18n';
-
+import { getLocalStorage } from '_/utils/local-storage-utils';
 // TODO we should lazyload non global translations on a per page basis
 // https://vue-i18n.intlify.dev/guide/advanced/lazy.html
 import en from '@/translations/en.json';
@@ -13,11 +13,11 @@ const messages = {
  es,
  fr,
 };
-
+// i18n.global.locale.value = getLocalStorage('preferredLocale') ?? 'en';
 const i18n = createI18n({
   legacy: false,
   globalInjection: true,
-  locale: 'en',
+  locale: getLocalStorage('preferredLocale') ?? 'en',
   // https://vue-i18n.intlify.dev/guide/essentials/fallback.html
   fallbackLocale: 'en',
   messages,

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import router from '@/router';
 import store from '@/store/store';
 import i18n from '@/i18n';
 import { initCuttleGlobals } from '_/utils/config-utils';
-
+import { getLocalStorage } from '_/utils/local-storage-utils';
 import App from '@/App.vue';
 
 
@@ -22,6 +22,9 @@ app.use(store);
 
 // Add localization to vue
 app.use(i18n);
+
+//Using Language from Loacal Storage if not found than by defualt English is selceted
+i18n.global.locale.value = getLocalStorage('preferredLocale') ?? 'en';
 
 app.mount('#app');
 

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,6 @@ import router from '@/router';
 import store from '@/store/store';
 import i18n from '@/i18n';
 import { initCuttleGlobals } from '_/utils/config-utils';
-import { getLocalStorage } from '_/utils/local-storage-utils';
 import App from '@/App.vue';
 
 
@@ -21,7 +20,6 @@ app.use(vuetify);
 app.use(store);
 
 // Use language from Local Storage if it exists
-i18n.global.locale.value = getLocalStorage('preferredLocale') ?? 'en';
 
 // Add localization to vue
 app.use(i18n);

--- a/src/main.js
+++ b/src/main.js
@@ -19,8 +19,6 @@ app.use(vuetify);
 // Add vuex store to vue
 app.use(store);
 
-// Use language from Local Storage if it exists
-
 // Add localization to vue
 app.use(i18n);
 

--- a/src/main.js
+++ b/src/main.js
@@ -20,11 +20,11 @@ app.use(vuetify);
 // Add vuex store to vue
 app.use(store);
 
+// Use language from Local Storage if it exists
+i18n.global.locale.value = getLocalStorage('preferredLocale') ?? 'en';
+
 // Add localization to vue
 app.use(i18n);
-
-//Using Language from Loacal Storage if not found than by defualt English is selceted
-i18n.global.locale.value = getLocalStorage('preferredLocale') ?? 'en';
 
 app.mount('#app');
 

--- a/tests/e2e/specs/out-of-game/localization.spec.js
+++ b/tests/e2e/specs/out-of-game/localization.spec.js
@@ -1,37 +1,56 @@
 import { myUser } from '../../fixtures/userFixtures';
 import es from '../../../../src/translations/es.json';
 import fr from '../../../../src/translations/fr.json';
+import en from '../../../../src/translations/en.json';
 
-function setup() {
-  cy.viewport(1920, 1080);
-  cy.wipeDatabase();
-  cy.visit('/');
-  cy.signupPlayer(myUser);
-  cy.vueRoute('/');
-}
-
-describe('Localization ', () => {
-  beforeEach(setup);
-
-  it('Checking Translation For Spanish', () => {
-    checkTranslation ('es', es);
+describe('Localization', () => {
+  beforeEach(() => {
+    cy.viewport(1920, 1080);
+    cy.wipeDatabase();
+    cy.visit('/');
+    cy.signupPlayer(myUser);
+    cy.vueRoute('/');
   });
 
-  it('Checking Translation For French', () => {
-    checkTranslation ('fr', fr);
+  const checkAndChangeLanguage = (name, lang) => {
+    // Open the user menu
+    cy.get('[data-cy="user-menu"]').click();
+    cy.get('[data-cy="language-menu"]').click();
+
+    // Select the language
+    cy.get(`[data-lang="${name}"]`).click();
+
+    // Check the translation
+    checkTranslation(lang);
+  };
+
+  const checkTranslation = (lang) => {
+    // Check elements in the navbar for language translation
+    cy.get('[data-cy="Play"]').should('contain', lang.global.play);
+
+    // Log out and check the login page translation
+    cy.get('[data-nav="Log Out"]').click();
+    cy.reload();
+    cy.contains('h1', lang.login.title);
+    cy.get('[data-cy="submit"]').should('contain', lang.global.login);
+    cy.loginPlayer(myUser);
+    cy.reload();
+
+    // Check elements in the navbar again
+    cy.get('[data-cy="Play"]').should('contain', lang.global.play);
+    cy.get('[data-cy="user-menu"]').click();
+    cy.get('[data-nav="Log Out"]').should('contain', lang.global.logout);
+  };
+
+  it('Should check translation for default', () => {
+    checkAndChangeLanguage('en', en);
+  });
+
+  it('Should check translation for Spanish', () => {
+    checkAndChangeLanguage('es', es);
+  });
+
+  it('Should check translation for French', () => {
+    checkAndChangeLanguage('fr', fr);
   });
 });
-
-function checkTranslation(name, lang) {
-  // Open the menu
-  cy.get('[data-cy="user-menu"]').click();
-  cy.get('[data-cy="language-menu"]').click();
-
-  //Selects the language 
-  cy.get(`[data-lang="${name}"]`).click();
-
-  // checks elements in navbar has changed language
-  cy.get('[data-cy="Play"]').should('contain', lang.global.play);
-  cy.get('[data-cy="user-menu"]').click();
-  cy.get('[data-nav="Log Out"]').should('contain', lang.global.logout);
-}

--- a/tests/e2e/specs/out-of-game/localization.spec.js
+++ b/tests/e2e/specs/out-of-game/localization.spec.js
@@ -42,7 +42,7 @@ describe('Localization', () => {
     cy.get('[data-nav="Log Out"]').should('contain', lang.global.logout);
   };
 
-  it('Should check translation for default', () => {
+  it('Should check translation for English (default)', () => {
     checkAndChangeLanguage('en', en);
   });
 


### PR DESCRIPTION
## Issue number #549 

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

Resolves [[Feature]: Store language preference in local storage and set it when bootstrapping client #549](https://github.com/cuttle-cards/cuttle/issues/549)
## Please check the following

- [X] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [X] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
