### PR TITLE
set the colors of the selected bottom nav elements to newPrimary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cuttle",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cuttle",
-      "version": "5.5.1",
+      "version": "5.6.0",
       "dependencies": {
         "chart.js": "^4.3.3",
         "connect-redis": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "dependencies": {
     "chart.js": "^4.3.3",
     "connect-redis": "3.0.2",

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -9,7 +9,7 @@
         v-for="({ text, icon, page, cyName }, i) in pageLinks"
         :key="i"
         variant="text"
-        :class="[variant === 'light' ? 'text-surface-1' : 'text-surface-2']"
+        :class="tabColor(page.name)"
         :data-cy="cyName"
         :title="text"
         :to="page"
@@ -28,13 +28,23 @@
 
 <script setup>
 import { getPageLinks } from '@/composables/navLink.js';
+import { useRoute } from 'vue-router';
+import { computed, toRefs } from 'vue';
 
-defineProps({
+const props = defineProps({
   variant:{
       type:String,
       default:'light'
     }
 });
 
+const route = useRoute();
+const { variant } = toRefs(props);
 const pageLinks = getPageLinks();
+const linkColor = computed(() => variant.value === 'light' ? 'text-surface-1' : 'text-surface-2');
+
+const tabColor = (page) => {
+  return route.name === page ? 'text-newPrimary' : linkColor.value;
+};
+
 </script>


### PR DESCRIPTION
## Issue

Relevant [issue number](https://github.com/cuttle-cards/cuttle/issues/583)
- Resolves #583 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [X] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - Has the documentation been updated accordingly: No need, minor UI change.

## Please describe additional details for testing this change

- Similar implementation used to set the color as is done in `TheHeader.vue`
- Can see result in image below
- **Note**: The primary color clashes a bit with the brown background in dark mode. For that, an option considered was to change the variant of the `v-btn` to `plain` instead of `text` to hide background. However, did not proceed with it since it also lowers the opacity of the text. More details [here](https://vuetifyjs.com/en/components/buttons/#variants).

![footer-color-changes](https://github.com/cuttle-cards/cuttle/assets/75930195/91a2ed72-e7a7-495d-bfc9-c77bbb3fb7a2)
