### PR TITLE
Added 8px margin between buttons in CreateGameDialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cuttle",
-  "version": "5.10.2",
+  "version": "5.10.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cuttle",
-      "version": "5.10.2",
+      "version": "5.10.3",
       "dependencies": {
         "chart.js": "^4.3.3",
         "connect-redis": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "5.10.2",
+  "version": "5.10.3",
   "dependencies": {
     "chart.js": "^4.3.3",
     "connect-redis": "3.0.2",

--- a/src/components/CreateGameDialog.vue
+++ b/src/components/CreateGameDialog.vue
@@ -53,6 +53,7 @@
     <template #actions>
       <v-form>
         <v-btn
+          class="mr-2"
           data-cy="cancel-create-game"
           :disabled="loading"
           variant="text"


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number #614 

Relevant #614 
- Resolves #614 

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
I don't think additional details are required as it's just adding mr-2 (margin right: 8px)
