### PR TITLE
575: Fix warnings

### DIFF
--- a/src/components/GameView/ReauthenticateDialog.vue
+++ b/src/components/GameView/ReauthenticateDialog.vue
@@ -46,6 +46,7 @@
     <BaseSnackbar
       v-model="showSnackBar"
       :message="snackBarMessage"
+      data-cy="game-snackbar"
       @clear="clearSnackBar"
     />
   </div>

--- a/src/components/GameView/ReauthenticateDialog.vue
+++ b/src/components/GameView/ReauthenticateDialog.vue
@@ -46,7 +46,7 @@
     <BaseSnackbar
       v-model="showSnackBar"
       :message="snackBarMessage"
-      data-cy="game-snackbar"
+      data-cy="reauth-snackbar"
       @clear="clearSnackBar"
     />
   </div>

--- a/src/components/GameView/ScrapDialog.vue
+++ b/src/components/GameView/ScrapDialog.vue
@@ -2,7 +2,7 @@
   <base-dialog
     id="scrap-dialog"
     v-model="show"
-    scrollable="true"
+    :scrollable="true"
     :persistent="false"
   >
     <template #activator="{ props }">


### PR DESCRIPTION
- Resolves #https://github.com/cuttle-cards/cuttle/issues/575

1: `scrollable` was not properly defined as a boolean in `src/components/GameView/ScrapDialog.vue`
2: `data-cy` was missing in `src/components/GameView/ReauthenticateDialog.vue`

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
