### PR TITLE
Bug/667 French "How it works"-button spills to the next line

### DIFF
--- a/src/routes/home/HomeView.vue
+++ b/src/routes/home/HomeView.vue
@@ -74,7 +74,7 @@
         <v-col class="home-card-games" :cols="$vuetify.display.mdAndUp ? 8 : 12">
           <div class="mx-auto my-4 my-xl-2 homeContent">
             <CreateGameDialog @error="handleError" />
-            <div class="d-flex flex-row justify-md-space-between justify-space-evenly align-center flex-wrap my-4">
+            <div class="d-flex flex-row justify-md-space-between justify-space-evenly align-center my-4">
               <v-btn
                 v-if="!$vuetify.display.smAndUp"
                 variant="text"

--- a/src/routes/home/components/HowItWorksDialog.vue
+++ b/src/routes/home/components/HowItWorksDialog.vue
@@ -14,7 +14,7 @@
         size="x-large"
         data-cy="how-it-works-button"
       >
-        {{ t('home.howItWorks.button') }} 
+        {{ t('home.howItWorks.button') }}
       </v-btn>
     </template>
     <template #body>

--- a/src/routes/home/components/HowItWorksDialog.vue
+++ b/src/routes/home/components/HowItWorksDialog.vue
@@ -14,7 +14,7 @@
         size="x-large"
         data-cy="how-it-works-button"
       >
-        {{ t('home.howItWorks.button') }}
+        {{ t('home.howItWorks.button') }} 
       </v-btn>
     </template>
     <template #body>


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

#667 

<img width="770" alt="Screenshot 2023-10-12 at 22 19 26" src="https://github.com/cuttle-cards/cuttle/assets/40244574/8c9bbc99-db9b-43ac-90c1-843e68f1c074">

There's a bit of overlap, but at least it now stays on one line

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
