### PR TITLE
Cannot counter dialog translations

### DIFF
--- a/src/routes/game/components/CannotCounterDialog.vue
+++ b/src/routes/game/components/CannotCounterDialog.vue
@@ -7,20 +7,20 @@
   >
     <template #body>
       <div v-if="!opponentLastTwo" class="my-2">
-        Your opponent has played the 
+        {{ t(`game.dialogs.cannotCounterDialog.opponentPlayed`) }}
         <GameCardName :card-name="oneOff.name" />
-        as a one-off
+        {{ t(`game.dialogs.cannotCounterDialog.oneOff`) }}
         <span v-if="target">
-          targeting your
+          {{ t(`game.dialogs.cannotCounterDialog.target`) + t(`global.your`) }}
           <GameCardName :card-name="target.name" />
         </span>
       </div>
       <div v-else class="my-2">
-        Your opponent has played 
+        {{ t(`game.dialogs.cannotCounterDialog.opponentPlayed`) }}
         <GameCardName :card-name="opponentLastTwo.name" />
-        to Counter
+        {{ t(`game.dialogs.cannotCounterDialog.counter`) }}
         <span v-if="playerLastTwo">
-          your 
+          {{ t(`global.your`) }}
           <GameCardName :card-name="playerLastTwo.name" />.
         </span>
       </div>
@@ -42,7 +42,7 @@
           <GameCard :suit="target.suit" :rank="target.rank" />
         </div>
       </div>
-      You cannot Counter, because {{ reason }}.
+      {{ t(`game.dialogs.cannotCounterDialog.cannotCounter`) + reason }}.
     </template>
 
     <template #actions>
@@ -52,7 +52,7 @@
         variant="flat"
         @click="$emit('resolve')"
       >
-        Resolve
+        {{ t(`game.dialogs.cannotCounterDialog.action.resolve`) }}
       </v-btn>
     </template>
   </BaseDialog>
@@ -113,8 +113,8 @@ export default {
     },
     reason() {
       let reason = '';
-      const OPPONENT_HAS_QUEEN = 'your opponent has a queen';
-      const PLAYER_HAS_NO_TWOS = 'you do not have a two';
+      const OPPONENT_HAS_QUEEN = this.$t('game.dialogs.cannotCounterDialog.reasons.opponentWithQueen');
+      const PLAYER_HAS_NO_TWOS = this.$t('game.dialogs.cannotCounterDialog.reasons.noTwoPresent');
       if (this.opponentQueenCount > 0) {
         reason += OPPONENT_HAS_QUEEN;
       }

--- a/src/routes/game/components/CannotCounterDialog.vue
+++ b/src/routes/game/components/CannotCounterDialog.vue
@@ -52,7 +52,7 @@
         variant="flat"
         @click="$emit('resolve')"
       >
-        {{ t(`game.dialogs.cannotCounterDialog.action.resolve`) }}
+        {{ t(`game.resolve`) }}
       </v-btn>
     </template>
   </BaseDialog>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -36,7 +36,8 @@
     "invite": "Invite",
     "rankedChangedAlert":"Game Mode changed to"
   },
-  "game":{
+  "game": {
+    "resolve": "Resolve",
     "dialogs": {
       "reauthentication": {
         "reconnectToGame": "Reconnect to game",
@@ -69,9 +70,6 @@
         "target": "targeting ",
         "counter": "to Counter",
         "cannotCounter": "You cannot Counter, because ",
-        "action": {
-          "resolve": "Resolve"
-        },
         "reasons": {
           "opponentWithQueen": "your opponent has a queen",
           "noTwoPresent": "you do not have a two"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -11,7 +11,8 @@
     "collapseMenu": "Collapse Menu",
     "cancel": "Cancel",
     "ranked": "Ranked",
-    "casual": "Casual"
+    "casual": "Casual",
+    "your": "your"
   },
   "login": {
     "noAccount": "Don't have an account?",
@@ -60,6 +61,20 @@
           "label": "Sort",
           "chronologically": "Chronologically",
           "rank": "By Rank"
+        }
+      },
+      "cannotCounterDialog": {
+        "opponentPlayed": "Your opponent has played the ",
+        "oneOff": "as a one-off",
+        "target": "targeting ",
+        "counter": "to Counter",
+        "cannotCounter": "You cannot Counter, because ",
+        "action": {
+          "resolve": "Resolve"
+        },
+        "reasons": {
+          "opponentWithQueen": "your opponent has a queen",
+          "noTwoPresent": "you do not have a two"
         }
       }
     },

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -11,7 +11,8 @@
     "collapseMenu": "Contraer menú",
     "cancel": "Cancelar",
     "ranked": "Clasificado",
-    "casual": "Casual"
+    "casual": "Casual",
+    "your": "su"
   },
   "login": {
     "noAccount": "¿No tienes una cuenta?",
@@ -61,6 +62,20 @@
         "discardTwoCards": "Descartar dos cartas",
         "discard": "Desechar",
         "oppponentHasResolved": "Tu oponente ha resuelto un Four One-Off. Debes descartar dos cartas. Haz clic para seleccionar cartas para descartar."
+      },
+      "cannotCounterDialog": {
+        "opponentPlayed": "Tu oponente ha jugado el",
+        "oneOff": "como un one-off",
+        "target": "apuntar ",
+        "counter": "para contrarrestar",
+        "cannotCounter": "No puedes contrarrestar, porque",
+        "action": {
+          "resolve": "Resolver"
+        },
+        "reasons": {
+          "opponentWithQueen": "Tu oponente tiene una queen",
+          "noTwoPresent": "no tienes un dos"
+        }
       }
     },
     "moves":{

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -37,6 +37,7 @@
     "rankedChangedAlert":"Modo de juego cambió a"
   },
   "game":{
+    "resolve": "Resolver",
     "dialogs": {
       "reauthentication": {
         "reconnectToGame": "Vuelve a conectarte al juego",
@@ -69,9 +70,6 @@
         "target": "apuntar ",
         "counter": "para contrarrestar",
         "cannotCounter": "No puedes contrarrestar, porque",
-        "action": {
-          "resolve": "Resolver"
-        },
         "reasons": {
           "opponentWithQueen": "Tu oponente tiene una queen",
           "noTwoPresent": "no tienes un dos"

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -37,6 +37,7 @@
     "rankedChangedAlert":"Jeu mode modifié à"
   },
   "game":{
+    "resolve": "Résoudre",
     "dialogs": {
       "reauthentication": {
         "reconnectToGame": "Reconnectez-vous au jeu",
@@ -69,9 +70,6 @@
         "target": "ciblage ",
         "counter": "contrer",
         "cannotCounter": "Vous ne pouvez pas contrer, parce que",
-        "action": {
-          "resolve": "Résoudre"
-        },
         "reasons": {
           "opponentWithQueen": "ton adversaire a une queen",
           "noTwoPresent": "tu n'as pas de deux"

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -11,7 +11,8 @@
     "collapseMenu": "Réduire le menu",
     "cancel": "Annuler",
     "ranked": "Classé",
-    "casual": "Occasionnel"
+    "casual": "Occasionnel",
+    "your": "ton"
   },
   "login": {
     "noAccount": "Vous n'avez pas de compte ?",
@@ -61,6 +62,20 @@
         "discardTwoCards": "Défaussez deux cartes",
         "discard": "Jeter",
         "oppponentHasResolved": "Votre adversaire a résolu un Quatre One-Off. Vous devez défausser deux cartes. Cliquez pour sélectionner les cartes à défausser."
+      },
+      "cannotCounterDialog": {
+        "opponentPlayed": "Votre adversaire a joué le ",
+        "oneOff": "comme un one-off",
+        "target": "ciblage ",
+        "counter": "contrer",
+        "cannotCounter": "Vous ne pouvez pas contrer, parce que",
+        "action": {
+          "resolve": "Résoudre"
+        },
+        "reasons": {
+          "opponentWithQueen": "ton adversaire a une queen",
+          "noTwoPresent": "tu n'as pas de deux"
+        }
       }
     },
     "moves":{

--- a/tests/e2e/specs/in-game/one-offs/0_countering.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/0_countering.spec.js
@@ -475,7 +475,7 @@ describe('Countering One-Offs P0 Perspective', () => {
     cy.get('#cannot-counter-dialog')
       .should('be.visible')
       .should('contain', 'You cannot Counter, because your opponent has a queen.')
-      .contains('Your opponent has played 2♥️ to Counter', {includeShadowDom: true});
+      .contains('Your opponent has played the 2♥️ to Counter', {includeShadowDom: true});
     cy.get('[data-cy=cannot-counter-resolve]')
       .click();
   });


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Resolves #626 

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
I have used google translator for the translations. Please review and suggest the changes.

Line number 19 -  `Your opponent has played ` will be now ` Your opponent has played the `. Since we already have a translation for line number 10, it felt redundant to have another translation just to skip `the`. Let me know if its really important not to have it. I can add new translation for that