### PR TITLE
Feat #619 Animate fours

### DIFF
--- a/api/services/gameService.js
+++ b/api/services/gameService.js
@@ -7,13 +7,7 @@ const GameStatus = require('../../utils/GameStatus.json');
  * @param {rank: number, suit: number} card1
  * @param {rank: number, suit: number} card2
  */
-function compareByRankThenSuit(card1, card2) {
-  let res = card1.rank - card2.rank;
-  if (res === 0) {
-    res = card1.suit - card2.suit;
-  }
-  return res;
-}
+
 
 async function fetchSpectatorUsernames(gameId) {
   const spectators = await UserSpectatingGame.find({
@@ -31,9 +25,6 @@ function formatPlayerData(user, points) {
     points,
   };
   delete res.encryptedPassword;
-  res.hand.sort(compareByRankThenSuit);
-  res.points.sort(compareByRankThenSuit);
-  res.faceCards.sort(compareByRankThenSuit);
   return res;
 }
 

--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -53,9 +53,7 @@ export async function handleInGameEvents(evData) {
       gameStore.processThrees(evData.chosenCard, evData.game);
       break;
     case SocketEvent.RESOLVE_FOUR:
-      gameStore.updateGameThenResetPNumIfNull(evData.game);
-      gameStore.waitingForOpponentToDiscard = false;
-      gameStore.discarding = false;
+      gameStore.processFours(evData.discardedCards, evData.game);
       break;
     case SocketEvent.RESOLVE:
       gameStore.updateGameThenResetPNumIfNull(evData.game);

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -110,8 +110,8 @@
                     <GameCard
                       v-for="(card) in gameStore.opponent.hand"
                       :key="card.id"
-                      :suit="checkIsFoursDiscarded(card) && card.suit"
-                      :rank="checkIsFoursDiscarded(card) && card.rank"
+                      :suit="isBeingDiscarded(card) ? card.suit : undefined"
+                      :rank="isBeingDiscarded(card) ? card.rank : undefined"
                       data-opponent-hand-card
                       class="transition-all opponent-card-back-wrapper opponent-hand-card mx-2"
                     />
@@ -1090,7 +1090,7 @@ export default {
         this.$refs.logsContainer.scrollTop = this.$refs.logsContainer.scrollHeight;
       }
     },
-    checkIsFoursDiscarded(card) {
+    isBeingDiscarded(card) {
       return this.gameStore.discardedCards?.some(id => id === card.id); 
     }
   },

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -110,6 +110,8 @@
                     <GameCard
                       v-for="(card, index) in gameStore.opponent.hand"
                       :key="index"
+                      :suit="checkIsFoursDiscarded(card) && card.suit"
+                      :rank="checkIsFoursDiscarded(card) && card.rank"
                       data-opponent-hand-card
                       class="transition-all opponent-card-back-wrapper opponent-hand-card mx-2"
                     />
@@ -1088,6 +1090,9 @@ export default {
         this.$refs.logsContainer.scrollTop = this.$refs.logsContainer.scrollHeight;
       }
     },
+    checkIsFoursDiscarded(card) {
+      return this.gameStore.discardedCards?.some(id => id === card.id); 
+    }
   },
 };
 </script>

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -108,8 +108,8 @@
                     class="opponent-hand-wrapper transition-all"
                   >
                     <GameCard
-                      v-for="(card, index) in gameStore.opponent.hand"
-                      :key="index"
+                      v-for="(card) in gameStore.opponent.hand"
+                      :key="card.id"
                       :suit="checkIsFoursDiscarded(card) && card.suit"
                       :rank="checkIsFoursDiscarded(card) && card.rank"
                       data-opponent-hand-card

--- a/src/routes/game/components/GameCard.vue
+++ b/src/routes/game/components/GameCard.vue
@@ -28,22 +28,25 @@
         <img :class="scuttledByClass" :src="`/img/cards/card-${scuttledBy.suit}-${scuttledBy.rank}.svg`">
       </template>
     </Transition>
-    <img
-      v-if="isGlasses"
-      :src="`/img/cards/glasses-${suitName.toLowerCase()}.png`"
-      :alt="`Glasses - $${cardName}`"
-    >
-    <img
-      v-else-if="isBack"
-      src="/img/cards/card-back.png"
-      class="opponent-card-back"
-      alt="card back"
-    >
-    <img
-      v-else
-      :src="`/img/cards/card-${suit}-${rank}.svg`"
-      :alt="cardName"
-    >
+    <Transition name="card-flip">
+      <img
+        v-if="isGlasses"
+        :src="`/img/cards/glasses-${suitName.toLowerCase()}.png`"
+        :alt="`Glasses - $${cardName}`"
+      >
+      <img
+        v-else-if="isBack"
+        src="/img/cards/card-back.png"
+        class="opponent-card-back"
+        alt="card back"
+      >
+      <img
+        v-else
+        :src="`/img/cards/card-${suit}-${rank}.svg`"
+        :alt="cardName"
+        class="face-card"
+      >
+    </Transition>
   </v-card>
 </template>
 
@@ -52,11 +55,11 @@ export default {
   name: 'GameCard',
   props: {
     suit: {
-      type: Number,
+      type: [Number, Boolean],
       default: undefined,
     },
     rank: {
-      type: Number,
+      type: [Number, Boolean],
       default: undefined,
     },
     isSelected: {
@@ -290,6 +293,16 @@ export default {
 .slide-above-leave-to {
   opacity: 0;
   transform: translateY(-32px);
+}
+
+.card-flip-enter-active{
+  transition: all 1s;
+}
+.card-flip-enter-from{
+  transform: rotateY(-90deg);
+}
+.card-flip-enter-to{
+  transform: rotateY(0deg);
 }
 
 @media (max-width: 600px) {

--- a/src/routes/game/components/GameCard.vue
+++ b/src/routes/game/components/GameCard.vue
@@ -55,11 +55,11 @@ export default {
   name: 'GameCard',
   props: {
     suit: {
-      type: [Number, Boolean],
+      type: Number,
       default: undefined,
     },
     rank: {
-      type: [Number, Boolean],
+      type: Number,
       default: undefined,
     },
     isSelected: {

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -13,6 +13,21 @@ function queenCount(player) {
   }
   return player.faceCards.reduce((queenCount, card) => queenCount + (card.rank === 12 ? 1 : 0), 0);
 }
+  
+const compareByRankThenSuit = (card1, card2) => {
+  return (card1.rank - card2.rank) || (card1.suit - card2.suit);
+};
+
+const setPlayers = (player, myPnum) => {
+  const sortP1 = (cards) => player.pNum === myPnum ? cards?.sort(compareByRankThenSuit) : cards;
+  return {
+    ...player,
+    hand: sortP1(player.hand)?.map((card) => createGameCard(card)),
+    points: sortP1(player.points)?.map((card) => createGameCard(card)),
+    faceCards: sortP1(player.faceCards)?.map((card) => createGameCard(card))
+  };
+};
+
 
 class GameCard {
   constructor(card) {
@@ -211,12 +226,7 @@ export const useGameStore = defineStore('game', {
         this.passes = newGame.passes;
       }
       if (Object.hasOwnProperty.call(newGame, 'players')) {
-        this.players = newGame.players.map((player) => ({
-          ...player,
-          hand: player.hand?.map((card) => createGameCard(card)),
-          points: player.points?.map((card) => createGameCard(card)),
-          faceCards: player.faceCards?.map((card) => createGameCard(card)),
-        }));
+        this.players = newGame.players.map((player) => setPlayers(player, this.myPNum));
       }
       if (Object.hasOwnProperty.call(newGame, 'spectatingUsers')) {
         this.spectatingUsers = newGame.spectatingUsers;

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -73,6 +73,7 @@ export const useGameStore = defineStore('game', {
     // Fours
     discarding: false,
     waitingForOpponentToDiscard: false,
+    discardedCards : null,
     // Sevens
     playingFromDeck: false,
     waitingForOpponentToPlayFromDeck: false,
@@ -171,6 +172,11 @@ export const useGameStore = defineStore('game', {
         } else {
           this.cardChosenFromScrap = null;
           this.playerChoosingFromScrap = null;
+        }
+        if (Object.hasOwnProperty.call(newGame.lastEvent, 'discardedCards')) {
+          this.discardedCards = newGame.lastEvent.discardedCards;
+        } else {
+          this.discardedCards = null;
         }
       }
       this.waitingForOpponentToStalemate = false;
@@ -331,6 +337,15 @@ export const useGameStore = defineStore('game', {
       this.waitingForOpponentToPickFromScrap = false;
       this.pickingFromScrap = false;
       this.cardChosenFromScrap = chosenCard;
+
+      setTimeout(() => {
+        this.updateGameThenResetPNumIfNull(game);
+      }, 1000);
+    },
+    processFours(discardedCards, game) {
+      this.waitingForOpponentToDiscard = false;
+      this.discarding = false;
+      this.discardedCards = discardedCards;
 
       setTimeout(() => {
         this.updateGameThenResetPNumIfNull(game);


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #619 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

- Updated API endpoint to added the discarded cards to the last event, as well as send the `cardsToScrap` in the socket message
- Added a state variable to the store `discardedCards`
- Dynamically showed suit and rank by checking if the cards id was inside `discardedCards`
- Added store function with timeout to delay store being updated.
- Added transition to flip card when changed
- The game will now only sort the players hand and not the opponents, this will also happen in the `updateGame` function in the store instead of in `populateGame` on the server side



https://github.com/cuttle-cards/cuttle/assets/108551827/430f4729-c9d9-4a81-9b4c-c1f4323669ce




