### PR TITLE
[Bug] Fix case issue and middleware warning

### DIFF
--- a/config/policies.js
+++ b/config/policies.js
@@ -38,7 +38,7 @@ module.exports.policies = {
   'game/subscribe': ['isLoggedIn', 'hasGameId'],
   'game/spectate': ['isLoggedIn', 'hasGameId'],
   'game/ready': 'isLoggedIn',
-  'game/setIsRanked': 'isInGame',
+  'game/set-is-ranked': 'isInGame',
   'game/leave-lobby': ['isSocket', 'isLoggedIn', 'isInGame'],
   'game/draw': ['isLoggedIn', 'isInGame'],
   'game/pass': ['isLoggedIn', 'isInGame'],


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Resolves #688 

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
The policy had a camelCase and on starting server, there was a warning from middleware:
<img width="1044" alt="image" src="https://github.com/cuttle-cards/cuttle/assets/76804118/e58f1bbd-5a33-4816-a1d1-4372bbc376ab">
