### PR TITLE
(#581) navigation disappears between 960 & 1280px

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -14,7 +14,7 @@
           >
         </div>
       </v-toolbar-title>
-      <v-toolbar-items v-if="!mobile" class="hidden-xs-only">
+      <v-toolbar-items v-if="!smAndDown" class="hidden-xs-only">
         <v-tabs class="pa-2">
           <v-tab
             v-for="({ text, icon, page, cyName }, i) in pageLinks"
@@ -56,7 +56,7 @@ const props = defineProps({
 
 const route = useRoute();
 const { variant } = toRefs(props);
-const { mobile } = useDisplay();
+const { smAndDown } = useDisplay();
 const pageLinks = getPageLinks();
 const linkColor = computed(() => variant.value === 'light' ? 'text-surface-1' : 'text-surface-2');
 const logoColor = computed(() => variant.value === 'light' ? 'brown' : 'white');


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #581

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

For testing you can set the window width to 1000px and it should show you the navigation options in the header, at 960px it should show it as well but when lowered to 959px or less, the navigation options in header should be hidden and it should show the navigation footer