### PR TITLE
Bug: #694 Reconnecting spec winning hand

### DIFF
--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -95,7 +95,7 @@ describe('Reconnecting to a game', () => {
       });
     });
 
-    it('targetedOneOff -- reconnect into cannot counter dialog', () => {
+    it.only('targetedOneOff -- reconnect into cannot counter dialog', () => {
       cy.setupGameAsP1();
 
       cy.loadGameFixture(1, {
@@ -103,7 +103,7 @@ describe('Reconnecting to a game', () => {
         p0Points: [],
         p0FaceCards: [],
         p1Hand: [Card.ACE_OF_CLUBS],
-        p1Points: [Card.SEVEN_OF_DIAMONDS, Card.SEVEN_OF_HEARTS],
+        p1Points: [Card.SEVEN_OF_DIAMONDS, Card.SIX_OF_HEARTS],
         p1FaceCards: [Card.KING_OF_CLUBS],
       });
 
@@ -122,7 +122,7 @@ describe('Reconnecting to a game', () => {
         p0Points: [],
         p0FaceCards: [],
         p1Hand: [Card.ACE_OF_CLUBS],
-        p1Points: [Card.SEVEN_OF_DIAMONDS, Card.SEVEN_OF_HEARTS],
+        p1Points: [Card.SEVEN_OF_DIAMONDS, Card.SIX_OF_HEARTS],
         p1FaceCards: [],
         scrap: [Card.TWO_OF_CLUBS, Card.KING_OF_CLUBS],
       });

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -95,7 +95,7 @@ describe('Reconnecting to a game', () => {
       });
     });
 
-    it.only('targetedOneOff -- reconnect into cannot counter dialog', () => {
+    it('targetedOneOff -- reconnect into cannot counter dialog', () => {
       cy.setupGameAsP1();
 
       cy.loadGameFixture(1, {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #694

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

Changed the `loadGameFixture` to load a non-winning hand 