### PR TITLE
Bug #697 Fix player hand sorting

### DIFF
--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -30,7 +30,6 @@ export async function handleInGameEvents(evData) {
     }
     case SocketEvent.INITIALIZE: {
       // Update state
-      gameStore.resetState();
       gameStore.updateGameThenResetPNumIfNull(evData.game);
       if (isSpectating) {
         gameStore.myPNum = 0; // always spectate as p0

--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -30,7 +30,7 @@ export async function handleInGameEvents(evData) {
     }
     case SocketEvent.INITIALIZE: {
       // Update state
-      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
+      gameStore.resetPNumIfNullThenUpdateGame(evData.game);
       if (isSpectating) {
         gameStore.myPNum = 0; // always spectate as p0
       }
@@ -43,7 +43,7 @@ export async function handleInGameEvents(evData) {
     case SocketEvent.LOAD_FIXTURE:
     case SocketEvent.JACK:
     case SocketEvent.DELETE_DECK:
-      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
+      gameStore.resetPNumIfNullThenUpdateGame(evData.game);
       break;
     case SocketEvent.SCUTTLE:
       gameStore.processScuttle(evData);
@@ -55,7 +55,7 @@ export async function handleInGameEvents(evData) {
       gameStore.processFours(evData.discardedCards, evData.game);
       break;
     case SocketEvent.RESOLVE:
-      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
+      gameStore.resetPNumIfNullThenUpdateGame(evData.game);
       gameStore.waitingForOpponentToCounter = false;
       gameStore.myTurnToCounter = false;
       if (evData.happened) {
@@ -89,7 +89,7 @@ export async function handleInGameEvents(evData) {
     case SocketEvent.TARGETED_ONE_OFF:
     case SocketEvent.ONE_OFF:
     case SocketEvent.COUNTER:
-      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
+      gameStore.resetPNumIfNullThenUpdateGame(evData.game);
       if (evData.pNum !== gameStore.myPNum) {
         gameStore.waitingForOpponentToCounter = false;
         gameStore.myTurnToCounter = true;
@@ -103,13 +103,13 @@ export async function handleInGameEvents(evData) {
     case SocketEvent.SEVEN_FACE_CARD:
     case SocketEvent.SEVEN_JACK:
     case SocketEvent.SEVEN_SCUTTLE:
-      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
+      gameStore.resetPNumIfNullThenUpdateGame(evData.game);
       gameStore.playingFromDeck = false;
       gameStore.waitingForOpponentToPlayFromDeck = false;
       break;
     case SocketEvent.SEVEN_ONE_OFF:
     case SocketEvent.SEVEN_TARGETED_ONE_OFF:
-      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
+      gameStore.resetPNumIfNullThenUpdateGame(evData.game);
       gameStore.playingFromDeck = false;
       gameStore.waitingForOpponentToPlayFromDeck = false;
       if (evData.pNum !== gameStore.myPNum) {
@@ -120,7 +120,7 @@ export async function handleInGameEvents(evData) {
     case SocketEvent.RE_LOGIN:
     case SocketEvent.SPECTATOR_JOINED:
     case SocketEvent.SPECTATOR_LEFT:
-      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
+      gameStore.resetPNumIfNullThenUpdateGame(evData.game);
       break;
     case SocketEvent.REQUEST_STALEMATE:
       if (evData.requestedByPNum !== gameStore.myPNum && !evData.victory.gameOver) {

--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -30,7 +30,7 @@ export async function handleInGameEvents(evData) {
     }
     case SocketEvent.INITIALIZE: {
       // Update state
-      gameStore.updateGameThenResetPNumIfNull(evData.game);
+      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
       if (isSpectating) {
         gameStore.myPNum = 0; // always spectate as p0
       }
@@ -43,7 +43,7 @@ export async function handleInGameEvents(evData) {
     case SocketEvent.LOAD_FIXTURE:
     case SocketEvent.JACK:
     case SocketEvent.DELETE_DECK:
-      gameStore.updateGameThenResetPNumIfNull(evData.game);
+      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
       break;
     case SocketEvent.SCUTTLE:
       gameStore.processScuttle(evData);
@@ -55,7 +55,7 @@ export async function handleInGameEvents(evData) {
       gameStore.processFours(evData.discardedCards, evData.game);
       break;
     case SocketEvent.RESOLVE:
-      gameStore.updateGameThenResetPNumIfNull(evData.game);
+      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
       gameStore.waitingForOpponentToCounter = false;
       gameStore.myTurnToCounter = false;
       if (evData.happened) {
@@ -89,7 +89,7 @@ export async function handleInGameEvents(evData) {
     case SocketEvent.TARGETED_ONE_OFF:
     case SocketEvent.ONE_OFF:
     case SocketEvent.COUNTER:
-      gameStore.updateGameThenResetPNumIfNull(evData.game);
+      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
       if (evData.pNum !== gameStore.myPNum) {
         gameStore.waitingForOpponentToCounter = false;
         gameStore.myTurnToCounter = true;
@@ -103,13 +103,13 @@ export async function handleInGameEvents(evData) {
     case SocketEvent.SEVEN_FACE_CARD:
     case SocketEvent.SEVEN_JACK:
     case SocketEvent.SEVEN_SCUTTLE:
-      gameStore.updateGameThenResetPNumIfNull(evData.game);
+      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
       gameStore.playingFromDeck = false;
       gameStore.waitingForOpponentToPlayFromDeck = false;
       break;
     case SocketEvent.SEVEN_ONE_OFF:
     case SocketEvent.SEVEN_TARGETED_ONE_OFF:
-      gameStore.updateGameThenResetPNumIfNull(evData.game);
+      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
       gameStore.playingFromDeck = false;
       gameStore.waitingForOpponentToPlayFromDeck = false;
       if (evData.pNum !== gameStore.myPNum) {
@@ -120,7 +120,7 @@ export async function handleInGameEvents(evData) {
     case SocketEvent.RE_LOGIN:
     case SocketEvent.SPECTATOR_JOINED:
     case SocketEvent.SPECTATOR_LEFT:
-      gameStore.updateGameThenResetPNumIfNull(evData.game);
+      gameStore.resetPNumIfNullThanUpdateGame(evData.game);
       break;
     case SocketEvent.REQUEST_STALEMATE:
       if (evData.requestedByPNum !== gameStore.myPNum && !evData.victory.gameOver) {

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -383,6 +383,7 @@ export const useGameStore = defineStore('game', {
           },
           (res, jwres) => {
             if (jwres.statusCode === 200) {
+              this.resetState();
               this.myPNum = res.pNum;
               this.updateGame(res.game);
               this.successfullyJoined({
@@ -407,8 +408,8 @@ export const useGameStore = defineStore('game', {
           },
           (res, jwres) => {
             if (jwres.statusCode === 200) {
-              this.updateGame(res);
               this.myPNum = 0;
+              this.updateGame(res);
               return resolve();
             }
             return reject(new Error('Unable to spectate game'));

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -301,7 +301,7 @@ export const useGameStore = defineStore('game', {
       const authStore = useAuthStore();
       // Set my pNum if it is null
       if (this.myPNum === null) {
-        let myPNum = game.players.findIndex((player) => player.username === authStore.username);
+        let myPNum = game.players.findIndex(({username}) => username === authStore.username);
         if (myPNum === -1) {
           myPNum = null;
         }

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -294,14 +294,14 @@ export const useGameStore = defineStore('game', {
       this.currentMatch = currentMatch;
     },
     resetPNumIfNullThanUpdateGame(game) {
-      this.resetPNumIfNull();
+      this.resetPNumIfNull(game);
       this.updateGame(game);    
     },
-    resetPNumIfNull() {
+    resetPNumIfNull(game) {
       const authStore = useAuthStore();
       // Set my pNum if it is null
       if (this.myPNum === null) {
-        let myPNum = this.players.findIndex((player) => player.username === authStore.username);
+        let myPNum = game.players.findIndex((player) => player.username === authStore.username);
         if (myPNum === -1) {
           myPNum = null;
         }

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -294,8 +294,8 @@ export const useGameStore = defineStore('game', {
       this.currentMatch = currentMatch;
     },
     updateGameThenResetPNumIfNull(game) {
-      this.updateGame(game);
       this.resetPNumIfNull();
+      this.updateGame(game);    
     },
     resetPNumIfNull() {
       const authStore = useAuthStore();
@@ -383,8 +383,8 @@ export const useGameStore = defineStore('game', {
           },
           (res, jwres) => {
             if (jwres.statusCode === 200) {
-              this.updateGame(res.game);
               this.myPNum = res.pNum;
+              this.updateGame(res.game);
               this.successfullyJoined({
                 username: res.playerUsername,
                 pNum: res.pNum,

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -293,7 +293,7 @@ export const useGameStore = defineStore('game', {
       this.winnerPNum = winner;
       this.currentMatch = currentMatch;
     },
-    updateGameThenResetPNumIfNull(game) {
+    resetPNumIfNullThanUpdateGame(game) {
       this.resetPNumIfNull();
       this.updateGame(game);    
     },
@@ -317,7 +317,7 @@ export const useGameStore = defineStore('game', {
     processScuttle({ game, playedCardId, targetCardId, playedBy }) {
       // Update in one step if this player scuttled or if pNum is not set
       if (!this.player) {
-        this.updateGameThenResetPNumIfNull(game);
+        this.resetPNumIfNullThanUpdateGame(game);
         return;
       }
 
@@ -330,7 +330,7 @@ export const useGameStore = defineStore('game', {
 
       // Update game in one-step if moved cards are not found
       if (playedCardIndex === undefined || targetCardIndex === undefined) {
-        this.updateGameThenResetPNumIfNull(game);
+        this.resetPNumIfNullThanUpdateGame(game);
         return;
       }
 
@@ -340,7 +340,7 @@ export const useGameStore = defineStore('game', {
 
       // Finish complete update of the game state after 1s
       setTimeout(() => {
-        this.updateGameThenResetPNumIfNull(game);
+        this.resetPNumIfNullThanUpdateGame(game);
       }, 1000);
     },
     processThrees(chosenCard, game) {
@@ -349,7 +349,7 @@ export const useGameStore = defineStore('game', {
       this.cardChosenFromScrap = chosenCard;
 
       setTimeout(() => {
-        this.updateGameThenResetPNumIfNull(game);
+        this.resetPNumIfNullThanUpdateGame(game);
       }, 1000);
     },
     processFours(discardedCards, game) {
@@ -358,7 +358,7 @@ export const useGameStore = defineStore('game', {
       this.discardedCards = discardedCards;
 
       setTimeout(() => {
-        this.updateGameThenResetPNumIfNull(game);
+        this.resetPNumIfNullThanUpdateGame(game);
       }, 1000);
     },
     handleGameResponse: (jwres, resolve, reject) => {

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -293,9 +293,9 @@ export const useGameStore = defineStore('game', {
       this.winnerPNum = winner;
       this.currentMatch = currentMatch;
     },
-    resetPNumIfNullThanUpdateGame(game) {
+    resetPNumIfNullThenUpdateGame(game) {
       this.resetPNumIfNull(game);
-      this.updateGame(game);    
+      this.updateGame(game);
     },
     resetPNumIfNull(game) {
       const authStore = useAuthStore();
@@ -317,7 +317,7 @@ export const useGameStore = defineStore('game', {
     processScuttle({ game, playedCardId, targetCardId, playedBy }) {
       // Update in one step if this player scuttled or if pNum is not set
       if (!this.player) {
-        this.resetPNumIfNullThanUpdateGame(game);
+        this.resetPNumIfNullThenUpdateGame(game);
         return;
       }
 
@@ -330,7 +330,7 @@ export const useGameStore = defineStore('game', {
 
       // Update game in one-step if moved cards are not found
       if (playedCardIndex === undefined || targetCardIndex === undefined) {
-        this.resetPNumIfNullThanUpdateGame(game);
+        this.resetPNumIfNullThenUpdateGame(game);
         return;
       }
 
@@ -340,7 +340,7 @@ export const useGameStore = defineStore('game', {
 
       // Finish complete update of the game state after 1s
       setTimeout(() => {
-        this.resetPNumIfNullThanUpdateGame(game);
+        this.resetPNumIfNullThenUpdateGame(game);
       }, 1000);
     },
     processThrees(chosenCard, game) {
@@ -349,7 +349,7 @@ export const useGameStore = defineStore('game', {
       this.cardChosenFromScrap = chosenCard;
 
       setTimeout(() => {
-        this.resetPNumIfNullThanUpdateGame(game);
+        this.resetPNumIfNullThenUpdateGame(game);
       }, 1000);
     },
     processFours(discardedCards, game) {
@@ -358,7 +358,7 @@ export const useGameStore = defineStore('game', {
       this.discardedCards = discardedCards;
 
       setTimeout(() => {
-        this.resetPNumIfNullThanUpdateGame(game);
+        this.resetPNumIfNullThenUpdateGame(game);
       }, 1000);
     },
     handleGameResponse: (jwres, resolve, reject) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #697 

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

- Removed unnecessary `resetState()` from socket call
- Set `myPNum` before `updateGame()` on `requestSubscribe()`
- Reordered and renamed `updateGameThanResetPNumIfNull()`