### PR TITLE
fix: update test references to ranked icon to use sword-cross

### DIFF
--- a/tests/e2e/specs/out-of-game/lobby.spec.js
+++ b/tests/e2e/specs/out-of-game/lobby.spec.js
@@ -178,7 +178,7 @@ describe('Lobby - P0 Perspective', () => {
     cy.setIsRankedOpponent(true);
 
     checkRanked(true);
-    cy.get('[data-cy=ready-button-trophy-icon]').should('exist');
+    cy.get('[data-cy=ready-button-sword-cross-icon]').should('exist');
   });
 
   it('Game starts when both players are ready - opponent first', function () {

--- a/tests/e2e/specs/out-of-game/lobby.spec.js
+++ b/tests/e2e/specs/out-of-game/lobby.spec.js
@@ -71,7 +71,7 @@ describe('Lobby - Page Content (Ranked)', () => {
   });
 
   it('Displays ranked button', () => {
-    cy.get('[data-cy=ready-button-trophy-icon]').should('exist');
+    cy.get('[data-cy=ready-button-sword-cross-icon]').should('exist');
   });
   
   it('Changes games to ranked and casual from the lobby', () => {
@@ -83,7 +83,7 @@ describe('Lobby - Page Content (Ranked)', () => {
     // Set To Ranked Mode
     cy.toggleInput('[data-cy=edit-game-ranked-switch]');
     checkRanked(true);
-    cy.get('[data-cy=ready-button-trophy-icon]').should('exist');
+    cy.get('[data-cy=ready-button-sword-cross-icon]').should('exist');
   });
 });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number
Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #710 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
