### PR TITLE
fix: mode change type error

### DIFF
--- a/api/controllers/game/set-is-ranked.js
+++ b/api/controllers/game/set-is-ranked.js
@@ -10,13 +10,6 @@ module.exports = async function (req, res) {
     
     sails.sockets.blast('setIsRanked', { gameId: game.id, isRanked: isRanked });
     
-    Game.publish([game.id], {
-      userId: req.session.usr,
-      pNum: req.session.pNum,
-      gameId: game.id,
-      isRanked: isRanked,
-    });
-
     return res.ok();
   } catch (err) {
     return res.badRequest(err);


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number #705 

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #705 

## Please check the following

- [X] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [X] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))

## Summary
- The issue was caused by an unnecessary call to ``` gameStore.resetPNumIfNullThenUpdateGame(evData.game) ``` within the ``` inGameEvents.js ``` method when the ranked was updated. Since changing the game mode was not part of the ``` inGameEvent.js ```, an undefined value was passed, leading to the type error. Removed the call to the ``` game.publish ```  method to resolve the issue.