### PR TITLE
Feature #723 - Animate when players leaves the lobby

### DIFF
--- a/src/routes/lobby/LobbyView.vue
+++ b/src/routes/lobby/LobbyView.vue
@@ -20,11 +20,14 @@
           <img src="/img/logo-stalemate.svg" class="vs-logo" alt="stalemate logo">
         </v-col>
         <v-col md="4" cols="12">
-          <LobbyPlayerIndicator
-            :player-username="gameStore.opponentUsername"
-            :player-ready="gameStore.opponentIsReady"
-            data-cy="opponent-indicator"
-          />
+          <Transition>
+            <LobbyPlayerIndicator
+              v-if="gameStore.opponentUsername"
+              :player-username="gameStore.opponentUsername"
+              :player-ready="gameStore.opponentIsReady"
+              data-cy="opponent-indicator"
+            />
+          </Transition>
         </v-col>
       </v-row>
       <v-row>
@@ -224,6 +227,26 @@ h5 {
   line-height: 5rem;
   margin: auto auto 16px auto;
 }
+
+.v-leave-active {
+  animation: burst-bubble 0.5s ease;
+}
+
+@keyframes burst-bubble {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(0.8);
+  }
+  75% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
 @media (min-width: 980px) {
   .rank-switch {
     padding: 0;

--- a/src/routes/lobby/LobbyView.vue
+++ b/src/routes/lobby/LobbyView.vue
@@ -20,14 +20,11 @@
           <img src="/img/logo-stalemate.svg" class="vs-logo" alt="stalemate logo">
         </v-col>
         <v-col md="4" cols="12">
-          <Transition>
-            <LobbyPlayerIndicator
-              v-if="gameStore.opponentUsername"
-              :player-username="gameStore.opponentUsername"
-              :player-ready="gameStore.opponentIsReady"
-              data-cy="opponent-indicator"
-            />
-          </Transition>
+          <LobbyPlayerIndicator
+            :player-username="gameStore.opponentUsername"
+            :player-ready="gameStore.opponentIsReady"
+            data-cy="opponent-indicator"
+          />
         </v-col>
       </v-row>
       <v-row>
@@ -226,25 +223,6 @@ h5 {
   font-weight: 400;
   line-height: 5rem;
   margin: auto auto 16px auto;
-}
-
-.v-leave-active {
-  animation: burst-bubble 0.5s ease;
-}
-
-@keyframes burst-bubble {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(0.8);
-  }
-  75% {
-    transform: scale(1.1);
-  }
-  100% {
-    transform: scale(1);
-  }
 }
 
 @media (min-width: 980px) {

--- a/src/routes/lobby/components/LobbyPlayerIndicator.vue
+++ b/src/routes/lobby/components/LobbyPlayerIndicator.vue
@@ -145,7 +145,7 @@ export default {
   height: 800px;
   background-image: url('/img/waves.svg');
   background-repeat: no-repeat;
-  background-size: contain;
+  background-size: cover;
   position: relative;
   animation: waving 5s;
   animation-fill-mode: forwards;
@@ -153,8 +153,10 @@ export default {
 }
 
 @keyframes waving {
-  0%{ right: 3000px; top: -120px; }
-  100%{ right: 0; top: 400px; }
+  0%{ right: 3000px; top: -120px; opacity: 1; }
+  50%{ opacity: 1; }
+  80%{ opacity: 1; }
+  100%{ right: 0; top: 500px; opacity: 0; }
 }
 
 @media (min-width: 1920px) {

--- a/src/routes/lobby/components/LobbyPlayerIndicator.vue
+++ b/src/routes/lobby/components/LobbyPlayerIndicator.vue
@@ -1,33 +1,35 @@
 <template>
-  <div v-if="playerUsername" class="player-card">
-    <span class="player-name">{{ playerUsername }}</span>
-    <div class="card-container">
-      <img
-        src="/img/cards/card-ready.png"
-        class="card-front"
-        :class="{ 'ready': playerReady }"
-        alt="card front"
-        data-cy="lobby-ready-card"
-      >
-      <img
-        src="/img/cards/card-back.png"
-        class="card-back"
-        :class="{ 'ready': playerReady }"
-        alt="card back"
-        data-cy="lobby-back-card"
-      >
-      <div class="water-container">
-        <div class="water" />
+  <Transition name="cards" mode="out-in">
+    <div v-if="playerUsername" class="player-card">
+      <span class="player-name">{{ playerUsername }}</span>
+      <div class="card-container">
+        <img
+          src="/img/cards/card-ready.png"
+          class="card-front"
+          :class="{ 'ready': playerReady }"
+          alt="card front"
+          data-cy="lobby-ready-card"
+        >
+        <img
+          src="/img/cards/card-back.png"
+          class="card-back"
+          :class="{ 'ready': playerReady }"
+          alt="card back"
+          data-cy="lobby-back-card"
+        >
+        <div class="water-container">
+          <div class="water" />
+        </div>
       </div>
     </div>
-  </div>
-  <div v-else class="player-indicator" :style="{ padding: playerPadding }">
-    <div class="avatar">
-      <h3>
-        {{ message }}
-      </h3>
+    <div v-else class="player-indicator" :style="{ padding: playerPadding }">
+      <div class="avatar">
+        <h3>
+          {{ message }}
+        </h3>
+      </div>
     </div>
-  </div>
+  </Transition>
 </template>
 
 <script>
@@ -157,6 +159,25 @@ export default {
   50%{ opacity: 1; }
   80%{ opacity: 1; }
   100%{ right: 0; top: 500px; opacity: 0; }
+}
+
+.cards-leave-active {
+  animation: burst-bubble 0.5s ease;
+}
+
+@keyframes burst-bubble {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(0.8);
+  }
+  75% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 @media (min-width: 1920px) {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #723 
- Resolves #729  

## Please check the following

- [X] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [X] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
A new animation is added for an opponent leaving the lobby, the animation is a pulse which goes well with the leave-lobby.mp3 available in the project sounds.

https://github.com/cuttle-cards/cuttle/assets/36615882/b979e113-e5e1-4666-b797-45eba0258b0c

This animation triggers for your opponent when it leaves the lobby and when you exit the lobby

<hr />
The other change, in LobbyPlayerIndicator fixes the wave animation and resolves #729. For testing, you can see how the animation react on three different breakpoints 540px - 1240px - 1920px. 
