### PR TITLE
style: revise counter and resolve buttons

### DIFF
--- a/src/routes/game/components/CannotCounterDialog.vue
+++ b/src/routes/game/components/CannotCounterDialog.vue
@@ -50,7 +50,6 @@
         data-cy="cannot-counter-counter"
         variant="flat"
         disabled
-        prepend-icon="mdi-close-circle"
       >
         {{ t('game.dialogs.counterDialogs.counter') }}
       </v-btn>
@@ -58,7 +57,6 @@
         data-cy="cannot-counter-resolve"
         color="surface-1"
         class="ml-4"
-        prepend-icon="mdi-check-circle"
         variant="flat"
         @click="$emit('resolve')"
       >

--- a/src/routes/game/components/CannotCounterDialog.vue
+++ b/src/routes/game/components/CannotCounterDialog.vue
@@ -47,8 +47,18 @@
 
     <template #actions>
       <v-btn
+        data-cy="cannot-counter-counter"
+        variant="flat"
+        disabled
+        prepend-icon="mdi-close-circle"
+      >
+        {{ t('game.dialogs.counterDialogs.counter') }}
+      </v-btn>
+      <v-btn
         data-cy="cannot-counter-resolve"
         color="surface-1"
+        class="ml-4"
+        prepend-icon="mdi-check-circle"
         variant="flat"
         @click="$emit('resolve')"
       >

--- a/src/routes/game/components/ChooseWhetherToCounterDialog.vue
+++ b/src/routes/game/components/ChooseWhetherToCounterDialog.vue
@@ -45,7 +45,6 @@
         data-cy="counter"
         color="newPrimary"
         variant="flat"
-        prepend-icon="mdi-close-circle"
         @click="$emit('choose-to-counter')"
       >
         {{ t('game.dialogs.counterDialogs.counter') }}
@@ -54,7 +53,6 @@
         data-cy="decline-counter-resolve"
         color="surface-1"
         variant="flat"
-        prepend-icon="mdi-check-circle"
         class="ml-4"
         @click="resolve"
       >

--- a/src/routes/game/components/ChooseWhetherToCounterDialog.vue
+++ b/src/routes/game/components/ChooseWhetherToCounterDialog.vue
@@ -42,21 +42,23 @@
 
     <template #actions>
       <v-btn
-        data-cy="decline-counter-resolve"
-        color="surface-1"
-        variant="outlined"
-        class="mr-4"
-        @click="resolve"
-      >
-        {{ t('game.resolve') }}
-      </v-btn>
-      <v-btn
         data-cy="counter"
-        color="surface-1"
+        color="newPrimary"
         variant="flat"
+        prepend-icon="mdi-close-circle"
         @click="$emit('choose-to-counter')"
       >
         {{ t('game.dialogs.counterDialogs.counter') }}
+      </v-btn>
+      <v-btn
+        data-cy="decline-counter-resolve"
+        color="surface-1"
+        variant="flat"
+        prepend-icon="mdi-check-circle"
+        class="ml-4"
+        @click="resolve"
+      >
+        {{ t('game.resolve') }}
       </v-btn>
     </template>
   </BaseDialog>


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Restyles the counter and resolve buttons
## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #767 
1. `CannotCounterDialog` now displays the a permanently disabled "Counter" button
2. The Counter button has been moved to the left and has been given the "newPrimary" pink color

Cannot Counter Dialog:
![image](https://github.com/cuttle-cards/cuttle/assets/6520704/8b07845f-4041-4b30-aaea-8e8a89d87499)



Counter Dialog:
![image](https://github.com/cuttle-cards/cuttle/assets/6520704/dd316eea-796b-4241-af1a-e068b4c72328)



## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
