### PR TITLE
handled snackbar emit for closing

### DIFF
--- a/src/routes/lobby/LobbyView.vue
+++ b/src/routes/lobby/LobbyView.vue
@@ -91,6 +91,7 @@
       }`"
       color="surface-1"
       data-cy="edit-snackbar"
+      @clear="gameStore.showIsRankedChangedAlert = false"
     />
   </div>
 </template>


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## #739

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #739

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Handled the snackbar emit to close it when user clicks on close button (take 2)