### PR TITLE
flex and align-center classes added to the v-witch

### DIFF
--- a/src/routes/home/components/CreateGameDialog.vue
+++ b/src/routes/home/components/CreateGameDialog.vue
@@ -36,6 +36,7 @@
         />
         <v-switch
           v-model="isRanked"
+          class="d-flex align-center"
           :label="isRanked ? t('global.ranked') : t('global.casual')"
           data-cy="create-game-ranked-switch"
           color="surface-2"


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## #772

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #772

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
I added
```
class="d-flex align-center"
```
on the v-switch.  The same classes were already applied to the form parent element, but the v-switch has a container div that needs to be vertically align as well.
There might be a more 'vuetify-ish' way of handleing this ?

the v-swith component has a center-affix prop:
![image](https://github.com/cuttle-cards/cuttle/assets/73071377/3bc10e18-f107-4515-8968-b45637738490)

It's true by default, so I thaought it would be centering its content, but maybe I misunderstand this...