### PR TITLE
fix(RulesView): replace mid-crown icon with mdi-crown

### DIFF
--- a/src/routes/rules/RulesView.vue
+++ b/src/routes/rules/RulesView.vue
@@ -86,7 +86,7 @@
             size="x-large"
             color="black"
             class="mr-4"
-            icon="mid-crown"
+            icon="mdi-crown"
             aria-label="crown icon"
             aria-hidden="false"
             role="img"


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
This fixes a broken icon in the rules page
## Issue number

N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
