### PR TITLE
style(GameOverDialog): change button color to surface-2

### DIFF
--- a/src/routes/game/components/GameOverDialog.vue
+++ b/src/routes/game/components/GameOverDialog.vue
@@ -76,7 +76,7 @@
           {{ t('game.dialogs.gameOverDialog.goHome') }}
         </v-btn>
         <v-btn
-          color="primary"
+          color="surface-1"
           :disabled="opponentDeclinedRematch"
           variant="flat"
           data-cy="gameover-rematch"


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
This changes the button color of the Rematch button in the `GameOverDialog` to the 'chocolate' surface-1
## Issue number
N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
