### PR TITLE
fix: prevent NPE by replacing 'function' with () =>

### DIFF
--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -537,7 +537,7 @@ export const useGameStore = defineStore('game', {
         };
       }
       return new Promise((resolve, reject) => {
-        io.socket.get('/game/resolveFour', reqData, function (res, jwres) {
+        io.socket.get('/game/resolveFour', reqData, (res, jwres) => {
           return this.handleGameResponse(jwres, resolve, reject);
         });
       });


### PR DESCRIPTION
Prevents a null pointer exception where `this.handleGameResponse()` is undefined because the `function` keyword creates its own `this` scope
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
