### PR TITLE
fix: Prevent scrap from revealing the last-played card unless the last move was a 3

### DIFF
--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -28,6 +28,7 @@ export async function handleInGameEvents(evData) {
       gameStore.setGameOver(evData.victory);
     }, 1000);
   }
+  gameStore.lastEventChange = evData.change;
   switch (evData.change) {
     case SocketEvent.READY: {
       gameStore.updateReady(evData.pNum);

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -420,6 +420,7 @@ import { mapStores } from 'pinia';
 import { useI18n } from 'vue-i18n';
 import { useGameStore } from '@/stores/game';
 import { useAuthStore } from '@/stores/auth';
+import SocketEvent from '_/types/SocketEvent';
 import BaseSnackbar from '@/components/BaseSnackbar.vue';
 import UsernameToolTip from '@/routes/game/components/UsernameToolTip.vue';
 import GameCard from '@/routes/game/components/GameCard.vue';
@@ -544,6 +545,7 @@ export default {
     ///////////////////////////
     showScrapChoice() {
       return (
+        this.gameStore.lastEventChange === SocketEvent.RESOLVE_THREE &&
         this.gameStore.lastEventCardChosen &&
         this.gameStore.scrap?.some(({ id }) => id === this.gameStore.lastEventCardChosen.id)
       );


### PR DESCRIPTION
Now that the `lastEvent` object has been flattened into its individual properties, it's important that various consumers of `lastEvent` data be able to tell which type of move (change) the `lastEvent` was immediately rather than waiting for the change-specific logic to apply.

Additionally, consumers of `lastEventCardChosen` etc should specifically check if the `lastEvent` is a particular change i.e. was a three played vs a four in order to only display their content for the appropriate moves.
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #828 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
