### PR TITLE
Feat #845 Auto-generate rematch game names with score

### DIFF
--- a/api/controllers/game/rematch.js
+++ b/api/controllers/game/rematch.js
@@ -65,9 +65,9 @@ module.exports = async function (req, res) {
     const seriesP0 = [p0, p1].find(({ id }) => id === rematchGames[0].p0);
     const seriesP1 = [p0, p1].find(({ id }) => id === rematchGames[0].p1);
     //Get rematchGame win counts
-    let player0Wins = rematchGames.filter(({winner}) => winner === seriesP0.id).length;
-    let player1wins = rematchGames.filter(({winner}) => winner === seriesP1.id).length;
-    let stalemates = rematchGames.filter(({winner}) => winner === null).length;
+    const player0Wins = rematchGames.filter(({winner}) => winner === seriesP0.id).length;
+    const player1wins = rematchGames.filter(({winner}) => winner === seriesP1.id).length;
+    const stalemates = rematchGames.filter(({winner}) => winner === null).length;
     
     const newName = `${seriesP0.username} VS ${seriesP1.username} ${player0Wins}-${player1wins}-${stalemates}`;
     await Game.updateOne({ id: newGame.id }).set({ name: newName });

--- a/api/controllers/game/rematch.js
+++ b/api/controllers/game/rematch.js
@@ -49,24 +49,24 @@ module.exports = async function (req, res) {
     updatedGame.rematchGame = newGame.id;
 
     //Get all exisiting rematchGames
-    let pastGames = [];
-    const getGames = async (gameId) => {
+    let rematchGames = [];
+    const getRematchGames = async (gameId) => {
       const [gameToAdd] = await Game.find({ rematchGame: gameId });
       if (gameToAdd) {
-        pastGames.unshift(gameToAdd);
+        rematchGames.unshift(gameToAdd);
         if (gameToAdd.rematchGame) {
-          await getGames(gameToAdd.id);
+          await getRematchGames(gameToAdd.id);
         }
       }
       return;
     };
-    await getGames(newGame.id);
-    const seriesP0 = [p0, p1].find(({ id }) => id === pastGames[0].p0);
-    const seriesP1 = [p0, p1].find(({ id }) => id === pastGames[0].p1);
+    await getRematchGames(newGame.id);
+    const seriesP0 = [p0, p1].find(({ id }) => id === rematchGames[0].p0);
+    const seriesP1 = [p0, p1].find(({ id }) => id === rematchGames[0].p1);
     //Get rematchGame win counts
-    let player0Wins = pastGames.filter(({winner}) => winner === seriesP0.id).length;
-    let player1wins = pastGames.filter(({winner}) => winner === seriesP1.id).length;
-    let stalemates = pastGames.filter(({winner}) => winner === null).length;
+    let player0Wins = rematchGames.filter(({winner}) => winner === seriesP0.id).length;
+    let player1wins = rematchGames.filter(({winner}) => winner === seriesP1.id).length;
+    let stalemates = rematchGames.filter(({winner}) => winner === null).length;
     
     const newName = `${seriesP0.username} VS ${seriesP1.username} ${player0Wins}-${player1wins}-${stalemates}`;
     await Game.updateOne({ id: newGame.id }).set({ name: newName });

--- a/api/controllers/game/rematch.js
+++ b/api/controllers/game/rematch.js
@@ -49,9 +49,9 @@ module.exports = async function (req, res) {
     updatedGame.rematchGame = newGame.id;
 
     //Get all exisiting rematchGames
-    let rematchGames = [];
+    const rematchGames = [];
     const getRematchGames = async (gameId) => {
-      const [gameToAdd] = await Game.find({ rematchGame: gameId });
+      const gameToAdd = await Game.findOne({ rematchGame: gameId });
       if (gameToAdd) {
         rematchGames.unshift(gameToAdd);
         if (gameToAdd.rematchGame) {

--- a/api/controllers/game/rematch.js
+++ b/api/controllers/game/rematch.js
@@ -52,13 +52,14 @@ module.exports = async function (req, res) {
     const rematchGames = [];
     const getRematchGames = async (gameId) => {
       const gameToAdd = await Game.findOne({ rematchGame: gameId });
-      if (gameToAdd) {
-        rematchGames.unshift(gameToAdd);
-        if (gameToAdd.rematchGame) {
-          await getRematchGames(gameToAdd.id);
-        }
+      if (!gameToAdd) {
+        return;
       }
-      return;
+      rematchGames.unshift(gameToAdd);
+      if (!gameToAdd.rematchGame) {
+        return; 
+      }
+        await getRematchGames(gameToAdd.id);
     };
     await getRematchGames(newGame.id);
     const seriesP0 = [p0, p1].find(({ id }) => id === rematchGames[0].p0);

--- a/api/controllers/game/rematch.js
+++ b/api/controllers/game/rematch.js
@@ -40,13 +40,36 @@ module.exports = async function (req, res) {
       shouldNewGameBeRanked,
       gameService.GameStatus.STARTED,
     );
-    await Promise.all([
+    const [ , , p0, p1] = await Promise.all([
       Game.updateOne({ id: updatedGame.id }).set({ rematchGame: newGame.id }),
       Game.replaceCollection(newGame.id, 'players').members([newP0Id, newP1Id]),
       User.updateOne({ id: newP0Id }).set({ pNum: 0 }),
       User.updateOne({ id: newP1Id }).set({ pNum: 1 }),
     ]);
     updatedGame.rematchGame = newGame.id;
+
+    //Get all exisiting rematchGames
+    let pastGames = [];
+    const getGames = async (gameId) => {
+      const [gameToAdd] = await Game.find({ rematchGame: gameId });
+      if (gameToAdd) {
+        pastGames.unshift(gameToAdd);
+        if (gameToAdd.rematchGame) {
+          await getGames(gameToAdd.id);
+        }
+      }
+      return;
+    };
+    await getGames(newGame.id);
+    const seriesP0 = [p0, p1].find(({ id }) => id === pastGames[0].p0);
+    const seriesP1 = [p0, p1].find(({ id }) => id === pastGames[0].p1);
+    //Get rematchGame win counts
+    let player0Wins = pastGames.filter(({winner}) => winner === seriesP0.id).length;
+    let player1wins = pastGames.filter(({winner}) => winner === seriesP1.id).length;
+    let stalemates = pastGames.filter(({winner}) => winner === null).length;
+    
+    const newName = `${seriesP0.username} VS ${seriesP1.username} ${player0Wins} - ${player1wins} - ${stalemates}`;
+    await Game.updateOne({ id: newGame.id }).set({ name: newName });
 
     const newGame2 = await Game.findOne({ id: newGame.id }).populate('players');
     // Create Cards

--- a/api/controllers/game/rematch.js
+++ b/api/controllers/game/rematch.js
@@ -68,7 +68,7 @@ module.exports = async function (req, res) {
     let player1wins = pastGames.filter(({winner}) => winner === seriesP1.id).length;
     let stalemates = pastGames.filter(({winner}) => winner === null).length;
     
-    const newName = `${seriesP0.username} VS ${seriesP1.username} ${player0Wins} - ${player1wins} - ${stalemates}`;
+    const newName = `${seriesP0.username} VS ${seriesP1.username} ${player0Wins}-${player1wins}-${stalemates}`;
     await Game.updateOne({ id: newGame.id }).set({ name: newName });
 
     const newGame2 = await Game.findOne({ id: newGame.id }).populate('players');

--- a/api/controllers/game/rematch.js
+++ b/api/controllers/game/rematch.js
@@ -59,7 +59,7 @@ module.exports = async function (req, res) {
       if (!gameToAdd.rematchGame) {
         return; 
       }
-        await getRematchGames(gameToAdd.id);
+      await getRematchGames(gameToAdd.id);
     };
     await getRematchGames(newGame.id);
     const seriesP0 = [p0, p1].find(({ id }) => id === rematchGames[0].p0);

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -1077,7 +1077,9 @@ describe('Creating And Updating Unranked Matches With Rematch', () => {
     assertLoss();
 
     cy.log('Opponent requests rematch first');
-
+    cy.window().its('cuttle.gameStore').then((game) => {
+      cy.expect(game.name).to.eq('Player1 VS Player2 1-0-0');
+    });
     cy.url().then((url) => {
       const oldGameId = url.split('/').pop();
       cy.rematchOpponent({ gameId: oldGameId, rematch: true });
@@ -1088,10 +1090,6 @@ describe('Creating And Updating Unranked Matches With Rematch', () => {
         .get('[data-cy=gameover-rematch]')
         .click();
       cy.log('Opponent then joins new game');
-
-      cy.window().its('cuttle.gameStore').then((game) => {
-        cy.expect(game.name).to.eq('Player1 VS Player2 1-0-0');
-      });
       cy.joinRematchOpponent({ oldGameId });
     });
 

--- a/tests/e2e/specs/in-game/gameOver.spec.js
+++ b/tests/e2e/specs/in-game/gameOver.spec.js
@@ -1089,6 +1089,9 @@ describe('Creating And Updating Unranked Matches With Rematch', () => {
         .click();
       cy.log('Opponent then joins new game');
 
+      cy.window().its('cuttle.gameStore').then((game) => {
+        cy.expect(game.name).to.eq('Player1 VS Player2 1-0-0');
+      });
       cy.joinRematchOpponent({ oldGameId });
     });
 
@@ -1109,6 +1112,7 @@ describe('Creating And Updating Unranked Matches With Rematch', () => {
     cy.window()
       .its('cuttle.gameStore')
       .then((game) => {
+        cy.expect(game.name).to.eq('Player1 VS Player2 1-1-0');
         cy.rematchAndJoinRematchOpponent({ gameId: game.id });
       });
     cy.url().should('include', '/game');
@@ -1122,6 +1126,7 @@ describe('Creating And Updating Unranked Matches With Rematch', () => {
     cy.window()
       .its('cuttle.gameStore')
       .then((game) => {
+        cy.expect(game.name).to.eq('Player1 VS Player2 1-1-1');
         cy.rematchAndJoinRematchOpponent({ gameId: game.id });
       });
     cy.url().should('include', '/game');


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #845 

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

- Added functions to make an array of all previous rematch games
- Got the count of all wins and stalemates (p0 is based off p0 of game 1 in the series)
- Added assertions to check for correct game names