### PR TITLE
Bug #847 Reauthenticate dialog username input

### DIFF
--- a/src/routes/game/components/ReauthenticateDialog.vue
+++ b/src/routes/game/components/ReauthenticateDialog.vue
@@ -77,6 +77,7 @@ export default {
   },
   data() {
     return {
+      username: '',
       password: '',
       isLoggingIn: false,
       showSnackBar: false,
@@ -85,9 +86,6 @@ export default {
   },
   computed: {
     ...mapStores(useAuthStore),
-    username() {
-      return this.authStore.username;
-    },
     show: {
       get() {
         return this.modelValue;

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -1,5 +1,5 @@
 import { assertGameState, assertVictory } from '../../support/helpers';
-import { opponentOne } from '../../fixtures/userFixtures';
+import { myUser, opponentOne } from '../../fixtures/userFixtures';
 import { Card } from '../../fixtures/cards';
 
 describe('Reconnecting to a game', () => {
@@ -682,5 +682,20 @@ describe('Display correct dialog for unavailable game', () => {
     //go to random url
     cy.visit('#/game/12345');
     cy.get("[data-cy='unavailable-game-overlay']").should('be.visible');
+  });
+});
+
+describe('Reauthenticating in game', () => {
+  beforeEach(() => {
+    cy.setupGameAsP0();
+  });
+
+  it('Re-login using reauthenticate dialog', () => {
+    cy.clearCookies();
+    cy.reload();
+    cy.get('[data-cy=username]').click().type(myUser.username);
+    cy.get('[data-cy=password]').click().type(myUser.password);
+    cy.get('[data-cy=login]').click();
+    cy.get('#deck').should('be.visible');
   });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #847 

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

- Changed initial v-model value to be a data variable set to an empty string
- Wrote corresponding test to check that reauthenticate dialog works