### PR TITLE
Only Make text selectable only in History pane & Rules dialog

### DIFF
--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -1176,8 +1176,12 @@ export default {
 // Styles //
 ////////////
 
-#body {
+body {
   user-select: none;
+}
+
+#rulesDialog {
+  user-select: text;
 }
 
 #game-view-wrapper {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #856

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
