### PR TITLE
Bug#877 Reconnecting after game over

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -60,12 +60,12 @@ module.exports = {
       // Validate password if not logged in -- will error if incorrect
       if (!loggedIn) {
         await passwordAPI.checkPass(password, user.encryptedPassword);
-      } 
+      }
       // Query for game if user is in one
-      const gameId = user.game ?? req.session.game;
+      const gameId = (user.game || req.session.game) ?? null;
       const unpopulatedGame = gameId ? await gameService.findGame({ gameId }) : null;
       //Dont populate if game over
-      const gameIsFinished = unpopulatedGame.status === 3;
+      const gameIsFinished = unpopulatedGame?.status === 3;
       // Get populated game if game has started
       const populatedGame =
         !gameIsFinished && unpopulatedGame && unpopulatedGame.p0Ready && unpopulatedGame.p1Ready

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -65,7 +65,7 @@ module.exports = {
       const gameId = (user.game ?? req.session.game) ?? null;
       const unpopulatedGame = gameId ? await gameService.findGame({ gameId }) : null;
       const populatedGame =
-        unpopulatedGame.status === GameStatus.STARTED
+        unpopulatedGame?.status === GameStatus.STARTED
           ? await gameService.populateGame({ gameId })
           : null;
       req.session.loggedIn = true;

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -75,19 +75,19 @@ module.exports = {
         req.session.game = unpopulatedGame.id;
         req.session.pNum = user.pNum ?? undefined;
       }
-
-      if (populatedGame) {
-        Game.publish([populatedGame.id], {
-          ...populatedGame.lastEvent,
-          game: populatedGame,
-        });
-      }
-
+      
       if (unpopulatedGame?.lastEvent?.victory) {
         Game.publish([unpopulatedGame.id], {
           change: unpopulatedGame.lastEvent.change,
           game: unpopulatedGame.lastEvent.game,
           victory: unpopulatedGame.lastEvent.victory
+        });
+      }
+      
+      if (populatedGame) {
+        Game.publish([populatedGame.id], {
+          ...populatedGame.lastEvent,
+          game: populatedGame,
         });
       }
 

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -68,8 +68,10 @@ module.exports = {
         unpopulatedGame?.status === GameStatus.STARTED
           ? await gameService.populateGame({ gameId })
           : null;
+      
       req.session.loggedIn = true;
       req.session.usr = user.id;
+     
       if (unpopulatedGame) {
         Game.subscribe(req, [unpopulatedGame.id]);
         req.session.game = unpopulatedGame.id;
@@ -83,7 +85,15 @@ module.exports = {
         });
       }
 
-      const game = populatedGame ?? unpopulatedGame;
+      if (unpopulatedGame && unpopulatedGame.lastEvent.victory) {
+        Game.publish([unpopulatedGame.id], {
+          change: unpopulatedGame.lastEvent.change,
+          game: unpopulatedGame.lastEvent.game,
+          victory: unpopulatedGame.lastEvent.victory
+        });
+      }
+
+      const game = unpopulatedGame.lastEvent?.game ?? (populatedGame ?? unpopulatedGame);
       return res.ok({
         game,
         username: user.username,

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -68,7 +68,6 @@ module.exports = {
         unpopulatedGame.status === GameStatus.STARTED
           ? await gameService.populateGame({ gameId })
           : null;
-      
       req.session.loggedIn = true;
       req.session.usr = user.id;
       

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -100,7 +100,6 @@ module.exports = {
         pNum: user.pNum,
       });
     } catch (err) {
-      console.log(err);
       return res.badRequest(err);
     }
   },

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -72,7 +72,6 @@ module.exports = {
           ? await gameService.populateGame({ gameId })
           : null;
       
-
       req.session.loggedIn = true;
       req.session.usr = user.id;
 

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -93,13 +93,14 @@ module.exports = {
         });
       }
 
-      const game = unpopulatedGame.lastEvent?.game ?? (populatedGame ?? unpopulatedGame);
+      const game = unpopulatedGame?.lastEvent?.game ?? (populatedGame ?? unpopulatedGame);
       return res.ok({
         game,
         username: user.username,
         pNum: user.pNum,
       });
     } catch (err) {
+      console.log(err);
       return res.badRequest(err);
     }
   },

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -71,7 +71,6 @@ module.exports = {
       
       req.session.loggedIn = true;
       req.session.usr = user.id;
-     
       if (unpopulatedGame) {
         Game.subscribe(req, [unpopulatedGame.id]);
         req.session.game = unpopulatedGame.id;

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -70,7 +70,6 @@ module.exports = {
           : null;
       req.session.loggedIn = true;
       req.session.usr = user.id;
-      
       if (unpopulatedGame) {
         Game.subscribe(req, [unpopulatedGame.id]);
         req.session.game = unpopulatedGame.id;

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -85,13 +85,6 @@ module.exports = {
         });
       }
 
-      if (unpopulatedGame.status === GameStatus.FINISHED) {
-        Game.publish([unpopulatedGame.id], {
-          change: unpopulatedGame.lastEvent.change,
-          victory: unpopulatedGame.lastEvent.victory,
-          game: unpopulatedGame.lastEvent.game
-        });
-      }
       const game = populatedGame ?? unpopulatedGame;
       return res.ok({
         game,

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -85,7 +85,7 @@ module.exports = {
         });
       }
 
-      if (unpopulatedGame && unpopulatedGame.lastEvent.victory) {
+      if (unpopulatedGame?.lastEvent?.victory) {
         Game.publish([unpopulatedGame.id], {
           change: unpopulatedGame.lastEvent.change,
           game: unpopulatedGame.lastEvent.game,

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -68,7 +68,6 @@ module.exports = {
         unpopulatedGame?.status === GameStatus.STARTED
           ? await gameService.populateGame({ gameId })
           : null;
-      
       req.session.loggedIn = true;
       req.session.usr = user.id;
       if (unpopulatedGame) {

--- a/api/controllers/game/concede.js
+++ b/api/controllers/game/concede.js
@@ -27,10 +27,10 @@ module.exports = async function (req, res) {
       game,
       victory,
     });
-    
+     // Set lastEvent in db with full game state + victory status  
     await Game.updateOne(req.session.game).set({
       lastEvent: {
-        change: 'conceded',
+        change: 'concede',
         game,
         victory
       }

--- a/api/controllers/game/concede.js
+++ b/api/controllers/game/concede.js
@@ -21,7 +21,13 @@ module.exports = async function (req, res) {
       conceded: true,
       currentMatch,
     };
-
+    
+    Game.publish([game.id], {
+      change: 'concede',
+      game,
+      victory,
+    });
+    
     await Game.updateOne(req.session.game).set({
       lastEvent: {
         change: 'conceded',
@@ -29,13 +35,6 @@ module.exports = async function (req, res) {
         victory
       }
     });
-
-    Game.publish([game.id], {
-      change: 'concede',
-      game,
-      victory,
-    });
-
     return res.ok();
   } catch (err) {
     return res.badRequest(err);

--- a/api/controllers/game/face-card.js
+++ b/api/controllers/game/face-card.js
@@ -66,6 +66,13 @@ module.exports = function (req, res) {
       });
       // If the game is over, clean it up
       if (victory.gameOver) {
+        await Game.updateOne({ id: fullGame.id }).set({
+          lastEvent: {
+            change: 'winByPointsJack',
+            game: fullGame,
+            victory
+          }
+        });
         await gameService.clearGame({ userId: req.session.usr });
       }
       return res.ok();

--- a/api/controllers/game/face-card.js
+++ b/api/controllers/game/face-card.js
@@ -68,7 +68,7 @@ module.exports = function (req, res) {
       if (victory.gameOver) {
         await Game.updateOne({ id: fullGame.id }).set({
           lastEvent: {
-            change: 'winByPointsJack',
+            change: 'faceCard',
             game: fullGame,
             victory
           }

--- a/api/controllers/game/jack.js
+++ b/api/controllers/game/jack.js
@@ -83,7 +83,7 @@ module.exports = function (req, res) {
       if (victory.gameOver) {
         await Game.updateOne({ id: fullGame.id }).set({
           lastEvent: {
-            change: 'winByPointsJack',
+            change: 'jack',
             game: fullGame,
             victory
           }

--- a/api/controllers/game/jack.js
+++ b/api/controllers/game/jack.js
@@ -73,7 +73,6 @@ module.exports = function (req, res) {
         game: fullGame,
         gameModel,
       });
-      
       Game.publish([fullGame.id], {
         change: 'jack',
         game: fullGame,

--- a/api/controllers/game/jack.js
+++ b/api/controllers/game/jack.js
@@ -86,7 +86,7 @@ module.exports = function (req, res) {
       }
 
       Game.publish([fullGame.id], {
-        change: victory.gameIsOver ? 'winByPointsJack' :'jack',
+        change: 'jack',
         game: fullGame,
         victory,
       });

--- a/api/controllers/game/jack.js
+++ b/api/controllers/game/jack.js
@@ -73,6 +73,12 @@ module.exports = function (req, res) {
         game: fullGame,
         gameModel,
       });
+      
+      Game.publish([fullGame.id], {
+        change: 'jack',
+        game: fullGame,
+        victory,
+      });
       // If the game is over, clean it up
       if (victory.gameOver) {
         await Game.updateOne({ id: fullGame.id }).set({
@@ -84,12 +90,6 @@ module.exports = function (req, res) {
         });
         await gameService.clearGame({ userId: req.session.usr });
       }
-
-      Game.publish([fullGame.id], {
-        change: 'jack',
-        game: fullGame,
-        victory,
-      });
       return res.ok();
     })
     .catch(function failed(err) {

--- a/api/controllers/game/pass.js
+++ b/api/controllers/game/pass.js
@@ -63,7 +63,7 @@ module.exports = function (req, res) {
         fullGame = await gameService.populateGame({ gameId: game.id });
         await Game.updateOne({ id: game.id }).set({
           lastEvent: {
-            change: 'stalemate by passing',
+            change: 'stalemateByPassing',
             game: fullGame,
             victory
           }
@@ -71,7 +71,7 @@ module.exports = function (req, res) {
         await gameService.clearGame({ userId: req.session.usr });
       }
       Game.publish([game.id], {
-        change: victory.gameOver ? 'stalemateByPassing' : 'pass',
+        change: 'pass',
         game: fullGame ?? game,
         victory,
       });

--- a/api/controllers/game/pass.js
+++ b/api/controllers/game/pass.js
@@ -65,7 +65,7 @@ module.exports = function (req, res) {
         
         await Game.updateOne({ id: game.id }).set({
           lastEvent: {
-            change: 'stalemateByPassing',
+            change: 'pass',
             game: fullGame,
             victory
           }

--- a/api/controllers/game/pass.js
+++ b/api/controllers/game/pass.js
@@ -48,7 +48,7 @@ module.exports = function (req, res) {
         currentMatch: null,
       };
       // Game ends in stalemate if 3 passes are made consecutively
-      let fullGame = null;
+      let finishedGame = null;
       if (game.passes > 2) {
         victory.gameOver = true;
         const { players } = game;
@@ -60,13 +60,13 @@ module.exports = function (req, res) {
         };
         await Game.updateOne({ id: game.id }).set(gameUpdates);
         
-        fullGame = await gameService.populateGame({ gameId: game.id });
-        victory.currentMatch = await sails.helpers.addGameToMatch(fullGame);
+        finishedGame = await gameService.populateGame({ gameId: game.id });
+        victory.currentMatch = await sails.helpers.addGameToMatch(finishedGame);
         
         await Game.updateOne({ id: game.id }).set({
           lastEvent: {
             change: 'pass',
-            game: fullGame,
+            game: finishedGame,
             victory
           }
         });
@@ -74,7 +74,7 @@ module.exports = function (req, res) {
       }
       Game.publish([game.id], {
         change: 'pass',
-        game: fullGame ?? game,
+        game,
         victory,
       });
       return res.ok();

--- a/api/controllers/game/pass.js
+++ b/api/controllers/game/pass.js
@@ -50,7 +50,6 @@ module.exports = function (req, res) {
       // Game ends in stalemate if 3 passes are made consecutively
       let fullGame = null;
       if (game.passes > 2) {
-        victory.currentMatch = await sails.helpers.addGameToMatch(game);
         victory.gameOver = true;
         const { players } = game;
         const gameUpdates = {
@@ -60,7 +59,10 @@ module.exports = function (req, res) {
           winner: null
         };
         await Game.updateOne({ id: game.id }).set(gameUpdates);
+        
         fullGame = await gameService.populateGame({ gameId: game.id });
+        victory.currentMatch = await sails.helpers.addGameToMatch(fullGame);
+        
         await Game.updateOne({ id: game.id }).set({
           lastEvent: {
             change: 'stalemateByPassing',

--- a/api/controllers/game/pass.js
+++ b/api/controllers/game/pass.js
@@ -48,7 +48,6 @@ module.exports = function (req, res) {
         currentMatch: null,
       };
       // Game ends in stalemate if 3 passes are made consecutively
-      let finishedGame = null;
       if (game.passes > 2) {
         victory.gameOver = true;
         const { players } = game;
@@ -60,13 +59,13 @@ module.exports = function (req, res) {
         };
         await Game.updateOne({ id: game.id }).set(gameUpdates);
         
-        finishedGame = await gameService.populateGame({ gameId: game.id });
-        victory.currentMatch = await sails.helpers.addGameToMatch(finishedGame);
+        game = await gameService.populateGame({ gameId: game.id });
+        victory.currentMatch = await sails.helpers.addGameToMatch(game);
         
         await Game.updateOne({ id: game.id }).set({
           lastEvent: {
             change: 'pass',
-            game: finishedGame,
+            game: game,
             victory
           }
         });

--- a/api/controllers/game/points.js
+++ b/api/controllers/game/points.js
@@ -51,6 +51,11 @@ module.exports = function (req, res) {
         game: fullGame,
         gameModel,
       });
+      Game.publish([fullGame.id], {
+        change: 'points',
+        game: fullGame,
+        victory,
+      });
       // If the game is over,store game in last event, then clean it up
       if (victory.gameOver) {
         await Game.updateOne({ id: fullGame.id }).set({
@@ -62,11 +67,6 @@ module.exports = function (req, res) {
         });
         await gameService.clearGame({ userId: req.session.usr });
       }
-      Game.publish([fullGame.id], {
-        change: 'points',
-        game: fullGame,
-        victory,
-      });
       return res.ok();
     })
     .catch(function failed(err) {

--- a/api/controllers/game/points.js
+++ b/api/controllers/game/points.js
@@ -60,7 +60,7 @@ module.exports = function (req, res) {
       if (victory.gameOver) {
         await Game.updateOne({ id: fullGame.id }).set({
           lastEvent: {
-            change: 'winByPoints',
+            change: 'points',
             game: fullGame,
             victory,
           }

--- a/api/controllers/game/points.js
+++ b/api/controllers/game/points.js
@@ -63,7 +63,7 @@ module.exports = function (req, res) {
         await gameService.clearGame({ userId: req.session.usr });
       }
       Game.publish([fullGame.id], {
-        change: victory.gameOver ? 'winByPoints' : 'points',
+        change: 'points',
         game: fullGame,
         victory,
       });

--- a/api/controllers/game/rematch.js
+++ b/api/controllers/game/rematch.js
@@ -21,11 +21,12 @@ module.exports = async function (req, res) {
 
     // Determine whether to start new game
     const oldPNum = game.p0 === userId ? 0 : 1;
+    const rematchVal = { [`p${oldPNum}Rematch`]: rematch };
     const gameUpdates = {
-      [`p${oldPNum}Rematch`]: rematch,
+      ...rematchVal,
       lastEvent: {
         change: 'rematch',
-        game: { ...game.lastEvent.game, [`p${oldPNum}Rematch`]: rematch },
+        game: { ...game.lastEvent.game, ...rematchVal},
         victory: game.lastEvent.victory
       }
     };

--- a/api/controllers/game/resolve.js
+++ b/api/controllers/game/resolve.js
@@ -358,7 +358,6 @@ module.exports = function (req, res) {
         game: fullGame,
         gameModel,
       });
-      
       Game.publish([fullGame.id], {
         change: 'resolve',
         oneOff,
@@ -371,7 +370,7 @@ module.exports = function (req, res) {
       if (victory.gameOver) {
         await Game.updateOne({ id: fullGame.id }).set({
           lastEvent: {
-            change: 'winByResolvingOneOff',
+            change: 'resolve',
             game: fullGame,
             victory
           }

--- a/api/controllers/game/resolve.js
+++ b/api/controllers/game/resolve.js
@@ -358,7 +358,7 @@ module.exports = function (req, res) {
         game: fullGame,
         gameModel,
       });
-
+      
       Game.publish([fullGame.id], {
         change: 'resolve',
         oneOff,
@@ -369,6 +369,13 @@ module.exports = function (req, res) {
       });
       // If the game is over, clean it up
       if (victory.gameOver) {
+        await Game.updateOne({ id: fullGame.id }).set({
+          lastEvent: {
+            change: 'winByResolvingOneOff',
+            game: fullGame,
+            victory
+          }
+        });
         await gameService.clearGame({ userId: req.session.usr });
       }
       return res.ok();

--- a/api/controllers/game/seven/face-card.js
+++ b/api/controllers/game/seven/face-card.js
@@ -69,6 +69,13 @@ module.exports = function (req, res) {
       });
       // If the game is over, clean it up
       if (victory.gameOver) {
+        await Game.updateOne({ id: fullGame.id }).set({
+          lastEvent: {
+            change: 'winBySevenFaceCard',
+            game: fullGame,
+            victory,
+          }
+        });
         await gameService.clearGame({ userId: req.session.usr });
       }
       return res.ok();

--- a/api/controllers/game/seven/face-card.js
+++ b/api/controllers/game/seven/face-card.js
@@ -71,7 +71,7 @@ module.exports = function (req, res) {
       if (victory.gameOver) {
         await Game.updateOne({ id: fullGame.id }).set({
           lastEvent: {
-            change: 'winBySevenFaceCard',
+            change: 'sevenFaceCard',
             game: fullGame,
             victory,
           }

--- a/api/controllers/game/seven/jack.js
+++ b/api/controllers/game/seven/jack.js
@@ -116,6 +116,13 @@ module.exports = function (req, res) {
       });
       // If the game is over, clean it up
       if (victory.gameOver) {
+        await Game.updateOne({ id: fullGame.id }).set({
+          lastEvent: {
+            change: 'winBySevenJack',
+            game: fullGame,
+            victory,
+          }
+        });
         await gameService.clearGame({ userId: req.session.usr });
       }
       return res.ok();

--- a/api/controllers/game/seven/jack.js
+++ b/api/controllers/game/seven/jack.js
@@ -118,7 +118,7 @@ module.exports = function (req, res) {
       if (victory.gameOver) {
         await Game.updateOne({ id: fullGame.id }).set({
           lastEvent: {
-            change: 'winBySevenJack',
+            change: 'sevenJack',
             game: fullGame,
             victory,
           }

--- a/api/controllers/game/seven/points.js
+++ b/api/controllers/game/seven/points.js
@@ -61,7 +61,7 @@ module.exports = function (req, res) {
       if (victory.gameOver) {
         await Game.updateOne({ id: fullGame.id }).set({
           lastEvent: {
-            change: 'winBySevenPoints',
+            change: 'sevenPoints',
             game: fullGame,
             victory,
           }

--- a/api/controllers/game/seven/points.js
+++ b/api/controllers/game/seven/points.js
@@ -59,6 +59,13 @@ module.exports = function (req, res) {
       });
       // If the game is over, clean it up
       if (victory.gameOver) {
+        await Game.updateOne({ id: fullGame.id }).set({
+          lastEvent: {
+            change: 'winBySevenPoints',
+            game: fullGame,
+            victory,
+          }
+        });
         await gameService.clearGame({ userId: req.session.usr });
       }
       return res.ok();

--- a/api/controllers/game/stalemate.js
+++ b/api/controllers/game/stalemate.js
@@ -52,7 +52,7 @@ module.exports = async function (req, res) {
     }
     
     Game.publish([game.id], {
-      change: victory.gameOver ? 'requestStalemate' : 'stalemate',
+      change:'requestStalemate',
       game: fullGame ?? game,
       victory,
       requestedByPNum: pNum,

--- a/api/controllers/game/stalemate.js
+++ b/api/controllers/game/stalemate.js
@@ -53,7 +53,7 @@ module.exports = async function (req, res) {
     }
     Game.publish([game.id], {
       change: 'requestStalemate',
-      game: game,
+      game,
       victory,
       requestedByPNum: pNum,
     });

--- a/api/controllers/game/stalemate.js
+++ b/api/controllers/game/stalemate.js
@@ -24,7 +24,6 @@ module.exports = async function (req, res) {
     };
 
     gameUpdates.lastEvent = { change: 'requestStalemate', requestedByPNum: pNum };
-    
     // End in stalemate if both players requested stalemate this turn
     if (playerStalemateVal === opponentStalemateVal && opponentStalemateVal === game.turn) {
       gameUpdates = {
@@ -43,7 +42,7 @@ module.exports = async function (req, res) {
       
       await Game.updateOne({ id: gameId }).set({
         lastEvent: {
-          change: 'stalemate',
+          change: 'requestStalemate',
           game: game,
           victory
         }

--- a/api/controllers/game/stalemate.js
+++ b/api/controllers/game/stalemate.js
@@ -52,7 +52,6 @@ module.exports = async function (req, res) {
     } else {
       await Game.updateOne({ id: gameId }).set(gameUpdates);
     }
-    
     Game.publish([game.id], {
       change: 'requestStalemate',
       game: game,

--- a/api/controllers/game/stalemate.js
+++ b/api/controllers/game/stalemate.js
@@ -54,7 +54,7 @@ module.exports = async function (req, res) {
     }
     
     Game.publish([game.id], {
-      change:'requestStalemate',
+      change: 'requestStalemate',
       game: game,
       victory,
       requestedByPNum: pNum,

--- a/src/plugins/sockets/connectivityEvents.js
+++ b/src/plugins/sockets/connectivityEvents.js
@@ -7,10 +7,10 @@ export function handleConnect() {
   const authStore = useAuthStore();
   const gameStore = useGameStore();
   // Request latest game state if socket reconnects during game
-  const { username } = authStore;
   switch (router.currentRoute.value.name) {
     case ROUTE_NAME_GAME:
-      return authStore.requestReauthenticate({ username });
+      authStore.authenticated = null;
+      return authStore.requestStatus(router.currentRoute.value);
     case ROUTE_NAME_SPECTATE: {
       const gameId = Number(router.currentRoute.value.params.gameId);
       if (!Number.isInteger(gameId)) {

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -3,7 +3,6 @@ import { io, reconnectSockets } from '@/plugins/sails.js';
 import { ROUTE_NAME_LOBBY, ROUTE_NAME_GAME, ROUTE_NAME_SPECTATE } from '@/router';
 import { getLocalStorage, setLocalStorage, LS_IS_RETURNING_USER_NAME } from '_/utils/local-storage-utils.js';
 import { useGameStore } from '@/stores/game';
-import  GameStatus  from '_/utils/GameStatus.json';
 
 // TODO Figure out how to reconsolidate this with backend
 const getPlayerPnumByUsername = (players, username) => {
@@ -80,7 +79,7 @@ export const useAuthStore = defineStore('auth', {
         return;
       }
 
-      const { name, params } = route;
+      const { name } = route;
       const isLobby = name === ROUTE_NAME_LOBBY;
       const isGame = name === ROUTE_NAME_GAME;
       const isSpectating = name === ROUTE_NAME_SPECTATE;
@@ -100,9 +99,6 @@ export const useAuthStore = defineStore('auth', {
         if (username) {
           this.authSuccess(username);
         }
-        if (isGame && +params.gameId !== gameId) {
-          this.$router.push(`/game/${gameId}`);
-        }
         // If the user is currently authenticated and part of a game, we need to resubscribe them
         // The sequencing here is a little interesting, but this is what happens to get a user back
         // in to a game in progress:
@@ -121,11 +117,7 @@ export const useAuthStore = defineStore('auth', {
         }
         if (gameId && (isGame || isLobby)) {
           await this.requestReauthenticate({ username }).then(({ game }) => {
-            if (game.status === GameStatus.FINISHED) {
-              gameStore.updateGame(game.lastEvent.game);
-              gameStore.setGameOver(game.lastEvent.victory);
-              return;
-            }
+            console.log(game);
             gameStore.updateGame(game);
           });
         }

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -80,7 +80,7 @@ export const useAuthStore = defineStore('auth', {
         return;
       }
 
-      const { name } = route;
+      const { name, params } = route;
       const isLobby = name === ROUTE_NAME_LOBBY;
       const isGame = name === ROUTE_NAME_GAME;
       const isSpectating = name === ROUTE_NAME_SPECTATE;
@@ -92,6 +92,9 @@ export const useAuthStore = defineStore('auth', {
         const status = await response.json();
         const { authenticated, username, gameId } = status;
         // If the user is not authenticated, we're done here
+        if (isGame && +params.gameId !== gameId) {
+          this.$router.push(`/game/${gameId}`);
+        }
         if (!authenticated) {
           this.clearAuth();
           return;

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -119,7 +119,7 @@ export const useAuthStore = defineStore('auth', {
         if (gameId && (isGame || isLobby)) {
           await this.requestReauthenticate({ username }).then(({ game }) => {
             gameStore.updateGame(game);
-            if (+router.currentRoute.value.params.gameId !== game.id) {
+            if (Number(router.currentRoute.value.params.gameId !== game.id)) {
               router.push(`${isGame ? '/game/' : '/lobby/'}${game.id}`);
             }
           });

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -3,6 +3,7 @@ import { io, reconnectSockets } from '@/plugins/sails.js';
 import { ROUTE_NAME_LOBBY, ROUTE_NAME_GAME, ROUTE_NAME_SPECTATE } from '@/router';
 import { getLocalStorage, setLocalStorage, LS_IS_RETURNING_USER_NAME } from '_/utils/local-storage-utils.js';
 import { useGameStore } from '@/stores/game';
+import router from '@/router.js';
 
 // TODO Figure out how to reconsolidate this with backend
 const getPlayerPnumByUsername = (players, username) => {
@@ -118,6 +119,9 @@ export const useAuthStore = defineStore('auth', {
         if (gameId && (isGame || isLobby)) {
           await this.requestReauthenticate({ username }).then(({ game }) => {
             gameStore.updateGame(game);
+            if (+router.currentRoute.value.params.gameId !== game.id) {
+              router.push(`${isGame ? '/game/' : '/lobby/'}${game.id}`);
+            }
           });
         }
 

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -92,9 +92,6 @@ export const useAuthStore = defineStore('auth', {
         const status = await response.json();
         const { authenticated, username, gameId } = status;
         // If the user is not authenticated, we're done here
-        if (isGame && +params.gameId !== gameId) {
-          this.$router.push(`/game/${gameId}`);
-        }
         if (!authenticated) {
           this.clearAuth();
           return;
@@ -103,7 +100,9 @@ export const useAuthStore = defineStore('auth', {
         if (username) {
           this.authSuccess(username);
         }
-
+        if (isGame && +params.gameId !== gameId) {
+          this.$router.push(`/game/${gameId}`);
+        }
         // If the user is currently authenticated and part of a game, we need to resubscribe them
         // The sequencing here is a little interesting, but this is what happens to get a user back
         // in to a game in progress:

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -117,12 +117,10 @@ export const useAuthStore = defineStore('auth', {
           const { gameId } = route.params;
           gameStore.requestSpectate(Number(gameId));
         }
-        
         if (gameId && (isGame || isLobby)) {
           await this.requestReauthenticate({ username }).then(({ game }) => {
             if (game.status === GameStatus.FINISHED) {
               gameStore.updateGame(game.lastEvent.game);
-              gameStore.setGameOver(game.lastEvent.victory);
               return;
             }
             gameStore.updateGame(game);

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -117,7 +117,6 @@ export const useAuthStore = defineStore('auth', {
         }
         if (gameId && (isGame || isLobby)) {
           await this.requestReauthenticate({ username }).then(({ game }) => {
-            console.log(game);
             gameStore.updateGame(game);
           });
         }

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -121,6 +121,7 @@ export const useAuthStore = defineStore('auth', {
           await this.requestReauthenticate({ username }).then(({ game }) => {
             if (game.status === GameStatus.FINISHED) {
               gameStore.updateGame(game.lastEvent.game);
+              gameStore.setGameOver(game.lastEvent.victory);
               return;
             }
             gameStore.updateGame(game);

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -973,7 +973,7 @@ describe('Reconnecting after game is over', () => {
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });
 
-  it('Brings player to the rematch game when player hits rematch, disconnects, then reconnects socket after opponent hit rematch and started game', function () {
+  it.only('Brings player to the rematch game when player hits rematch, disconnects, then reconnects socket after opponent hit rematch and started game', function () {
     cy.concedeOpponent();
 
     cy.get('[data-cy=gameover-rematch')
@@ -1022,6 +1022,7 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
+    cy.wait(5000);
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -969,6 +969,7 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
+    cy.wait(5000);
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -705,7 +705,7 @@ describe('Reconnecting after game is over', () => {
     cy.setupGameAsP0();
   });
   
-  it('Dialogs persist after refreshing when game is over by conceded and opponent request rematch', () => {
+  it.only('Dialogs persist after refreshing when game is over by conceded and opponent request rematch', () => {
     cy.concedeOpponent();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.url().then((url) => {

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -945,7 +945,6 @@ describe('Reconnecting after game is over', () => {
       const oldGameId = Number(url.split('/').pop());
       cy.wrap(oldGameId).as('oldGameId');
       cy.rematchOpponent({ gameId: oldGameId, rematch: true, skipDomAssertion: true });
-
       cy.joinRematchOpponent({ oldGameId });
     });
 
@@ -962,12 +961,9 @@ describe('Reconnecting after game is over', () => {
 
     cy.url().then((url) => {
       cy.get('@oldGameId').then((oldGameId) => {
-
         const currentGameId = Number(url.split('/').pop());
-        cy.log(oldGameId);
-        cy.log(typeof oldGameId);
         const expectedGameId = oldGameId + 1;
-        cy.log(expectedGameId);
+
         expect(currentGameId).to.eq(expectedGameId, 'Expected current url to point to new game id, but it did not');
       });
     });
@@ -996,7 +992,6 @@ describe('Reconnecting after game is over', () => {
       const oldGameId = Number(url.split('/').pop());
       cy.wrap(oldGameId).as('oldGameId');
       cy.rematchOpponent({ gameId: oldGameId, rematch: true, skipDomAssertion: true });
-
       cy.joinRematchOpponent({ oldGameId });
     });
 

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -1024,6 +1024,7 @@ describe('Reconnecting after game is over', () => {
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
     cy.get('#deck').should('contain', '41');
+    cy.wait(5000);
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -705,7 +705,7 @@ describe('Reconnecting after game is over', () => {
     cy.setupGameAsP0();
   });
   
-  it('Dialogs persist after refreshing when game is over by conceded', () => {
+  it('Dialogs persist after refreshing when game is over by conceded and opponent request rematch', () => {
     cy.concedeOpponent();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.url().then((url) => {
@@ -716,6 +716,16 @@ describe('Reconnecting after game is over', () => {
     cy.reload();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.get('[data-cy=match-score-counter-wins]').should('contain', 'W: 1');
+    cy.get('[data-cy=lobby-ready-card]').should('exist');
+  });
+
+  it('Dialogs persist after refreshing when game is over by conceded and player request rematch', () => {
+    cy.concedeOpponent();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+    cy.get('[data-cy=gameover-rematch]').click();
+    cy.get('[data-cy=lobby-ready-card]').should('be.visible');
+    cy.reload();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.get('[data-cy=lobby-ready-card]').should('exist');
   });
   
@@ -809,7 +819,7 @@ describe('Reconnecting after game is over', () => {
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
   });
 
-  it.only('Dialogs persist after refreshing when game is over by resolving one-off', () => {
+  it('Dialogs persist after refreshing when game is over by resolving one-off', () => {
     cy.loadGameFixture(0, {
       p0Hand: [Card.SIX_OF_DIAMONDS, Card.SEVEN_OF_SPADES],
       p0Points: [Card.SEVEN_OF_DIAMONDS, Card.SEVEN_OF_HEARTS],
@@ -820,7 +830,6 @@ describe('Reconnecting after game is over', () => {
       deck:[]
     });
 
-
     cy.get('#deck').click();
     cy.playJackOpponent(Card.JACK_OF_CLUBS, Card.SEVEN_OF_HEARTS);
     cy.get('[data-player-hand-card=7-3]').click();
@@ -829,6 +838,77 @@ describe('Reconnecting after game is over', () => {
     cy.get('[data-player-hand-card=6-1]').click();
     cy.get('[data-move-choice=oneOff]').should('be.visible').click();
     cy.resolveOpponent();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+    cy.reload();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+  });
+
+  it('Dialogs persist after refreshing when game is over by resolving one-off from a seven', () => {
+    cy.loadGameFixture(0, {
+      p0Hand: [Card.SIX_OF_DIAMONDS, Card.SEVEN_OF_SPADES],
+      p0Points: [Card.SEVEN_OF_DIAMONDS, Card.SEVEN_OF_HEARTS],
+      p0FaceCards: [],
+      p1Hand: [Card.JACK_OF_CLUBS],
+      p1Points: [],
+      p1FaceCards: [],
+      topCard: Card.KING_OF_DIAMONDS,
+      secondCard: Card.TEN_OF_CLUBS,
+      deck:[]
+    });
+
+    cy.get('[data-player-hand-card=6-1]').click();
+    cy.get('[data-move-choice=points]').should('be.visible').click();
+    cy.playJackOpponent(Card.JACK_OF_CLUBS, Card.SIX_OF_DIAMONDS);
+    cy.get('[data-player-hand-card=7-3]').click();
+    cy.get('[data-move-choice=oneOff]').should('be.visible').click();
+    cy.resolveOpponent();
+    cy.get('[data-top-card=13-1]').click();
+    cy.get('[data-move-choice=faceCard]').should('be.visible').click();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+    cy.reload();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+  });
+
+  it('Dialogs persist after refreshing when game is over by playing jack from a seven', () => {
+    cy.loadGameFixture(0, {
+      p0Hand: [Card.SIX_OF_DIAMONDS, Card.SEVEN_OF_SPADES],
+      p0Points: [Card.SEVEN_OF_HEARTS, Card.SEVEN_OF_DIAMONDS],
+      p0FaceCards: [],
+      p1Hand: [],
+      p1Points: [Card.SEVEN_OF_SPADES,],
+      p1FaceCards: [],
+      topCard: Card.JACK_OF_DIAMONDS,
+      deck:[]
+    });
+
+    cy.get('[data-player-hand-card=7-3]').click();
+    cy.get('[data-move-choice=oneOff]').should('be.visible').click();
+    cy.resolveOpponent();
+    cy.get('[data-top-card=11-1]').should('be.visible').click();
+    cy.get('[data-move-choice=jack]').should('be.visible').click();
+    cy.get('[data-opponent-point-card=7-3]').should('be.visible').click();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+    cy.reload();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+  });
+
+  it('Dialogs persist after refreshing when game is over by playing points from a seven', () => {
+    cy.loadGameFixture(0, {
+      p0Hand: [Card.SIX_OF_DIAMONDS, Card.SEVEN_OF_SPADES],
+      p0Points: [Card.SEVEN_OF_HEARTS, Card.SEVEN_OF_DIAMONDS],
+      p0FaceCards: [],
+      p1Hand: [],
+      p1Points: [],
+      p1FaceCards: [],
+      topCard: Card.SEVEN_OF_SPADES,
+      deck:[]
+    });
+
+    cy.get('[data-player-hand-card=7-3]').click();
+    cy.get('[data-move-choice=oneOff]').should('be.visible').click();
+    cy.resolveOpponent();
+    cy.get('[data-top-card=7-3]').click();
+    cy.get('[data-move-choice=points]').should('be.visible').click();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.reload();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -705,7 +705,7 @@ describe('Reconnecting after game is over', () => {
     cy.setupGameAsP0();
   });
   
-  it.only('Dialogs persist after refreshing when game is over by conceded', () => {
+  it('Dialogs persist after refreshing when game is over by conceded', () => {
     cy.concedeOpponent();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.url().then((url) => {
@@ -772,7 +772,7 @@ describe('Reconnecting after game is over', () => {
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
   });
 
-  it('Dialogs persist after refreshing when game is over by points using Jack', () => {
+  it('Dialogs persist after refreshing when game is over by points playing jack', () => {
     cy.loadGameFixture(0, {
       p0Hand: [Card.JACK_OF_DIAMONDS],
       p0Points: [Card.SEVEN_OF_DIAMONDS, Card.SEVEN_OF_HEARTS],
@@ -786,6 +786,49 @@ describe('Reconnecting after game is over', () => {
     cy.get('[data-player-hand-card=11-1]').click();
     cy.get('[data-move-choice=jack]').should('be.visible').click();
     cy.get('[data-opponent-point-card=7-0]').click();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+    cy.reload();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+  });
+
+  it('Dialogs persist after refreshing when game is over by points playing king', () => {
+    cy.loadGameFixture(0, {
+      p0Hand: [Card.KING_OF_DIAMONDS],
+      p0Points: [Card.SEVEN_OF_DIAMONDS, Card.SEVEN_OF_HEARTS],
+      p0FaceCards: [],
+      p1Hand: [],
+      p1Points: [],
+      p1FaceCards: [],
+      deck: [],
+    });
+
+    cy.get('[data-player-hand-card=13-1]').click();
+    cy.get('[data-move-choice=faceCard]').should('be.visible').click();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+    cy.reload();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+  });
+
+  it.only('Dialogs persist after refreshing when game is over by resolving one-off', () => {
+    cy.loadGameFixture(0, {
+      p0Hand: [Card.SIX_OF_DIAMONDS, Card.SEVEN_OF_SPADES],
+      p0Points: [Card.SEVEN_OF_DIAMONDS, Card.SEVEN_OF_HEARTS],
+      p0FaceCards: [],
+      p1Hand: [Card.JACK_OF_CLUBS],
+      p1Points: [],
+      p1FaceCards: [],
+      deck:[]
+    });
+
+
+    cy.get('#deck').click();
+    cy.playJackOpponent(Card.JACK_OF_CLUBS, Card.SEVEN_OF_HEARTS);
+    cy.get('[data-player-hand-card=7-3]').click();
+    cy.get('[data-move-choice=points]').should('be.visible').click();
+    cy.drawCardOpponent();
+    cy.get('[data-player-hand-card=6-1]').click();
+    cy.get('[data-move-choice=oneOff]').should('be.visible').click();
+    cy.resolveOpponent();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.reload();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -705,8 +705,10 @@ describe('Reconnecting after game is over', () => {
     cy.setupGameAsP0();
   });
   
-  it.only('Dialogs persist after refreshing when game is over by conceded and opponent request rematch', () => {
+  it('Dialogs persist after refreshing when game is over by conceded and opponent request rematch', () => {
     cy.concedeOpponent();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
+    cy.reload();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.url().then((url) => {
       const oldGameId = Number(url.split('/').pop());
@@ -716,26 +718,32 @@ describe('Reconnecting after game is over', () => {
     cy.reload();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.get('[data-cy=match-score-counter-wins]').should('contain', 'W: 1');
-    cy.get('[data-cy=lobby-ready-card]').should('exist');
+    cy.get('[data-cy=opponent-rematch-indicator]')  
+    .find('[data-cy="lobby-card-container"]')  
+    .should('have.class', 'ready');
   });
 
   it('Dialogs persist after refreshing when game is over by conceded and player request rematch', () => {
     cy.concedeOpponent();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
+    cy.reload();
+    cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.get('[data-cy=gameover-rematch]').click();
     cy.get('[data-cy=lobby-ready-card]').should('be.visible');
     cy.reload();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
-    cy.get('[data-cy=lobby-ready-card]').should('exist');
+    cy.get('[data-cy=opponent-rematch-indicator]')
+    .find('[data-cy="lobby-card-container"]')
+    .should('have.class', 'ready');
   });
   
   it('Dialogs persist after refreshing when game is over by stalemate', () => {
     cy.get('#game-menu-activator').click();
     cy.get('#game-menu').should('be.visible').get('[data-cy=stalemate-initiate]').click();
     cy.get('#request-gameover-dialog')
-    .should('be.visible')
-    .get('[data-cy=request-gameover-confirm]')
-    .click();
+      .should('be.visible')
+      .get('[data-cy=request-gameover-confirm]')
+      .click();
     cy.stalemateOpponent();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
     cy.reload();

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -944,8 +944,7 @@ describe('Reconnecting after game is over', () => {
     cy.url().then((url) => {
       const oldGameId = Number(url.split('/').pop());
       cy.wrap(oldGameId).as('oldGameId');
-      cy.rematchOpponent({ gameId: oldGameId, rematch: true, skipDomAssertion: true });
-      cy.joinRematchOpponent({ oldGameId });
+      cy.rematchAndJoinRematchOpponent({ gameId: oldGameId });
     });
 
     cy.get('[data-cy=opponent-rematch-indicator]')
@@ -969,7 +968,6 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
-    cy.wait(10000);
     cy.get('#turn-indicator').should('contain', "OPPONENT'S TURN");
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
@@ -997,8 +995,7 @@ describe('Reconnecting after game is over', () => {
     cy.url().then((url) => {
       const oldGameId = Number(url.split('/').pop());
       cy.wrap(oldGameId).as('oldGameId');
-      cy.rematchOpponent({ gameId: oldGameId, rematch: true, skipDomAssertion: true });
-      cy.joinRematchOpponent({ oldGameId });
+      cy.rematchAndJoinRematchOpponent({ gameId: oldGameId });
     });
 
     cy.get('[data-cy=opponent-rematch-indicator]')
@@ -1024,7 +1021,6 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
-    cy.wait(10000);
     cy.get('#turn-indicator').should('contain', "OPPONENT'S TURN");
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -732,7 +732,7 @@ describe('Reconnecting after game is over', () => {
     cy.get('[data-cy=lobby-ready-card]').should('be.visible');
     cy.reload();
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
-    cy.get('[data-cy=opponent-rematch-indicator]')
+    cy.get('[data-cy=my-rematch-indicator]')
     .find('[data-cy="lobby-card-container"]')
     .should('have.class', 'ready');
   });

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -967,6 +967,10 @@ describe('Reconnecting after game is over', () => {
         expect(currentGameId).to.eq(expectedGameId, 'Expected current url to point to new game id, but it did not');
       });
     });
+
+    cy.get('[data-opponent-hand-card]').should('have.length', 5);
+    cy.drawCardOpponent();
+    cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });
 
   it.skip('Brings player to the rematch game when player hits rematch, disconnects, then reconnects socket after opponent hit rematch and started game', function () {
@@ -1016,6 +1020,10 @@ describe('Reconnecting after game is over', () => {
         expect(currentGameId).to.eq(expectedGameId, 'Expected current url to point to new game id, but it did not');
       });
     });
+
+    cy.get('[data-opponent-hand-card]').should('have.length', 5);
+    cy.drawCardOpponent();
+    cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });
 });
 

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -969,7 +969,7 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
-    cy.get('#deck').should('contain', '41');
+    cy.get('#turn-indicator').should('contain', "OPPONENT'S TURN");
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });
@@ -1023,8 +1023,7 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
-    cy.get('#deck').should('contain', '41');
-    cy.wait(5000);
+    cy.get('#turn-indicator').should('contain', "OPPONENT'S TURN");
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -969,12 +969,12 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
-    cy.wait(5000);
+    cy.get('#deck').should('contain', '41');
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });
 
-  it.only('Brings player to the rematch game when player hits rematch, disconnects, then reconnects socket after opponent hit rematch and started game', function () {
+  it('Brings player to the rematch game when player hits rematch, disconnects, then reconnects socket after opponent hit rematch and started game', function () {
     cy.concedeOpponent();
 
     cy.get('[data-cy=gameover-rematch')
@@ -1023,7 +1023,7 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
-    cy.wait(5000);
+    cy.get('#deck').should('contain', '41');
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -969,6 +969,7 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
+    cy.wait(10000);
     cy.get('#turn-indicator').should('contain', "OPPONENT'S TURN");
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
@@ -1023,6 +1024,7 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
+    cy.wait(10000);
     cy.get('#turn-indicator').should('contain', "OPPONENT'S TURN");
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -922,7 +922,7 @@ describe('Reconnecting after game is over', () => {
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
   });
 
-  it.skip('Brings player to the rematch game when player hits rematch, disconnects, then refreshes after opponent hit rematch and started game', function () {
+  it.skip('Brings player to the rematch game when player hits rematch, disconnects, then refreshes after opponent hit rematch and started game', () => {
     cy.concedeOpponent();
 
     cy.get('[data-cy=gameover-rematch')

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -922,7 +922,7 @@ describe('Reconnecting after game is over', () => {
     cy.get('[data-cy=game-over-dialog]').should('be.visible');
   });
 
-  it.skip('Brings player to the rematch game when player hits rematch, disconnects, then refreshes after opponent hit rematch and started game', () => {
+  it('Brings player to the rematch game when player hits rematch, disconnects, then refreshes after opponent hit rematch and started game', () => {
     cy.concedeOpponent();
 
     cy.get('[data-cy=gameover-rematch')
@@ -973,7 +973,7 @@ describe('Reconnecting after game is over', () => {
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });
 
-  it.skip('Brings player to the rematch game when player hits rematch, disconnects, then reconnects socket after opponent hit rematch and started game', function () {
+  it('Brings player to the rematch game when player hits rematch, disconnects, then reconnects socket after opponent hit rematch and started game', function () {
     cy.concedeOpponent();
 
     cy.get('[data-cy=gameover-rematch')

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -973,7 +973,7 @@ describe('Reconnecting after game is over', () => {
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });
 
-  it('Brings player to the rematch game when player hits rematch, disconnects, then reconnects socket after opponent hit rematch and started game', function () {
+  it('Brings player to the rematch game when player hits rematch, disconnects, then reconnects socket after opponent hit rematch and started game', () => {
     cy.concedeOpponent();
 
     cy.get('[data-cy=gameover-rematch')

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -340,7 +340,8 @@ Cypress.Commands.add('drawCardOpponent', () => {
       if (jwres.statusCode === 200) {
         return resolve();
       }
-      return reject(new Error('error requesting opponent draw card' , res));
+      
+      return reject(new Error(res));
     });
   });
 });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -341,7 +341,7 @@ Cypress.Commands.add('drawCardOpponent', () => {
         return resolve();
       }
       
-      return reject(new Error(res));
+      return reject(new Error(jwres));
     });
   });
 });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -340,7 +340,6 @@ Cypress.Commands.add('drawCardOpponent', () => {
       if (jwres.statusCode === 200) {
         return resolve();
       }
-      
       return reject(new Error('error requesting opponent draw card'));
     });
   });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -341,7 +341,7 @@ Cypress.Commands.add('drawCardOpponent', () => {
         return resolve();
       }
       
-      return reject(new Error(jwres.error.message));
+      return reject(new Error('error requesting opponent draw card'));
     });
   });
 });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -336,7 +336,7 @@ Cypress.Commands.add('recoverSessionOpponent', (userFixture) => {
 
 Cypress.Commands.add('drawCardOpponent', () => {
   return new Cypress.Promise((resolve, reject) => {
-    io.socket.get('/game/draw', function handleResponse(res, jwres) {      
+    io.socket.get('/game/draw', function handleResponse(res, jwres) {
       if (jwres.statusCode === 200) {
         return resolve();
       }

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -1295,7 +1295,7 @@ Cypress.Commands.add('rematchAndJoinRematchOpponent', ({ gameId }) => {
  * @param { 'my' | 'opponent' } [data.whichPlayer] - Optionally specify whether this user
  *  is originalP0 ('my') or originalP1 ('opponent'). For use when spectating
  */
-Cypress.Commands.add('rematchOpponent', ({ gameId, rematch, whichPlayer }) => {
+Cypress.Commands.add('rematchOpponent', ({ gameId, rematch, whichPlayer, skipDomAssertion }) => {
   io.socket.get('/game/rematch', { gameId, rematch }, function handleResponse(res, jwres) {
     if (jwres.statusCode !== 200) {
       throw new Error(jwres.body.message);
@@ -1303,6 +1303,11 @@ Cypress.Commands.add('rematchOpponent', ({ gameId, rematch, whichPlayer }) => {
 
     return Promise.resolve(jwres);
   });
+
+  if (skipDomAssertion) {
+    return;
+  }
+
   const cardSelector = whichPlayer ?? 'opponent';
   if (rematch) {
     cy.get(`[data-cy=${cardSelector}-rematch-indicator]`)

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -336,12 +336,12 @@ Cypress.Commands.add('recoverSessionOpponent', (userFixture) => {
 
 Cypress.Commands.add('drawCardOpponent', () => {
   return new Cypress.Promise((resolve, reject) => {
-    io.socket.get('/game/draw', function handleResponse(res, jwres) {
+    io.socket.get('/game/draw', function handleResponse(res, jwres) {      
       if (jwres.statusCode === 200) {
         return resolve();
       }
       
-      return reject(new Error(jwres));
+      return reject(new Error(jwres.error.message));
     });
   });
 });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -340,7 +340,7 @@ Cypress.Commands.add('drawCardOpponent', () => {
       if (jwres.statusCode === 200) {
         return resolve();
       }
-      return reject(new Error('error requesting opponent draw card'));
+      return reject(new Error('error requesting opponent draw card' , res));
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #877 

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [x] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

- Added logic to API endpoints to save the Full game at game over into a `lastEvent` variable
- Added logic to `mustReauthenticate` to pull from the `lastEvent.game` if game is over
- Added test to make sure refresh correctly recovers state through lastEvent