### PR TITLE
Chane opponent card border radius to match primary player's

### DIFF
--- a/src/routes/game/components/GameCard.vue
+++ b/src/routes/game/components/GameCard.vue
@@ -227,7 +227,7 @@ export default {
   z-index: 1;
 }
 .opponent-card-back {
-  border-radius: 5px;
+  border-radius: 10px;
 }
 
 .selected {


### PR DESCRIPTION
Simple fix to make opponent card border radius match primary player's card border radius
