### PR TITLE
Copy Lobby URL to clipboard when clicking "Invite" avatar

### DIFF
--- a/src/components/PlayerReadyIndicator.vue
+++ b/src/components/PlayerReadyIndicator.vue
@@ -36,7 +36,7 @@
       <span class="player-name">{{ playerUsername }}</span>
     </div>
     <div v-else class="player-indicator" :style="{ padding: playerPadding }">
-      <div class="avatar">
+      <div class="avatar" onclick="navigator.clipboard.writeText(window.location.href);this.textContent='Lobby URL Copied to Clipboard!';">
         <h3>
           {{ message }}
         </h3>


### PR DESCRIPTION
This allows anyone in a Lobby to click the "invite" avatar to copy the lobby URL to the user's clipboard:

![image](https://github.com/cuttle-cards/cuttle/assets/10717998/94c25746-a358-459b-9deb-9bfab46c733f)

⬇️------------------------------------------⬇️

![image](https://github.com/cuttle-cards/cuttle/assets/10717998/b39b4c65-ae1f-4d95-9940-1e1dec4c1bc8)


## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Related to #674

## Please check the following

- [?] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [?] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes? No
  - [ ] Has the documentation been updated accordingly? No

## Please describe additional details for testing this change
