### PR TITLE
chore: remove stale 'global.collapseMenu' key from all translation files

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10,7 +10,6 @@
     "rank": "Rank",
     "username": "Username",
     "password": "Password",
-    "collapseMenu": "Collapse Menu",
     "cancel": "Cancel",
     "ranked": "Ranked",
     "casual": "Casual",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -10,7 +10,6 @@
     "rank": "Rango",
     "username": "Nombre de usuario",
     "password": "Contraseña",
-    "collapseMenu": "Contraer menú",
     "cancel": "Cancelar",
     "ranked": "Competitivo",
     "casual": "Amistoso",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -10,7 +10,6 @@
     "rank": "Rang",
     "username": "Nom d'utilisateur",
     "password": "Mot de passe",
-    "collapseMenu": "Réduire le menu",
     "cancel": "Annuler",
     "ranked": "Classée",
     "casual": "Classique",


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
A user who is working on creating a Russian translation of the application asked where "collapseMenu" is used and this revealed that the translation key is stale and should be removed.

It was previously used in the navigation side-sheet, but since this component was replaced w/ top + bottom navigation in #530 , the "collapseMenu" string is no longer needed

## Issue number

N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
