### PR TITLE
chooseWeatherToCounter message split in two t() functions

### DIFF
--- a/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
+++ b/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
@@ -45,7 +45,8 @@
         data-cy="counter" 
         color="newPrimary" 
         variant="flat" 
-        @click="$emit('choose-to-counter')">
+        @click="$emit('choose-to-counter')"
+      >
         {{ t('game.dialogs.counterDialogs.counter') }}
       </v-btn>
       <v-btn 

--- a/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
+++ b/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
@@ -27,7 +27,7 @@
         </p>
         <div v-if="target" id="target-wrapper">
           <span id="target-icon-wrapper" class="d-flex justify-center align-center">
-            <v-icon 
+            <v-icon
               size="x-large"
               color="red"
               icon="mdi-target"
@@ -42,14 +42,14 @@
 
     <template #actions>
       <v-btn 
-        data-cy="counter" 
-        color="newPrimary" 
-        variant="flat" 
+        data-cy="counter"
+        color="newPrimary"
+        variant="flat"
         @click="$emit('choose-to-counter')"
       >
         {{ t('game.dialogs.counterDialogs.counter') }}
       </v-btn>
-      <v-btn 
+      <v-btn
         data-cy="decline-counter-resolve"
         color="surface-1"
         variant="flat"

--- a/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
+++ b/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
@@ -6,8 +6,7 @@
         <GameCardName :card-name="oneOff.name" />
         {{ t('game.dialogs.counterDialogs.oneOff') }}
         <span v-if="target" class="test">
-          {{ t('game.dialogs.counterDialogs.target') }} 
-          {{ t('global.your') }}
+          {{ `${t('game.dialogs.counterDialogs.target')} ${t('global.your')}` }}
           <GameCardName :card-name="target.name" />
         </span>
       </div>

--- a/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
+++ b/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
@@ -41,7 +41,7 @@
     </template>
 
     <template #actions>
-      <v-btn 
+      <v-btn
         data-cy="counter"
         color="newPrimary"
         variant="flat"

--- a/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
+++ b/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
@@ -27,7 +27,12 @@
         </p>
         <div v-if="target" id="target-wrapper">
           <span id="target-icon-wrapper" class="d-flex justify-center align-center">
-            <v-icon size="x-large" color="red" icon="mdi-target" aria-hidden="true" />
+            <v-icon 
+              size="x-large" 
+              color="red" 
+              icon="mdi-target" 
+              aria-hidden="true" 
+            />
           </span>
           <GameCard :suit="target.suit" :rank="target.rank" />
         </div>
@@ -36,10 +41,20 @@
     </template>
 
     <template #actions>
-      <v-btn data-cy="counter" color="newPrimary" variant="flat" @click="$emit('choose-to-counter')">
+      <v-btn 
+        data-cy="counter" 
+        color="newPrimary" 
+        variant="flat" 
+        @click="$emit('choose-to-counter')">
         {{ t('game.dialogs.counterDialogs.counter') }}
       </v-btn>
-      <v-btn data-cy="decline-counter-resolve" color="surface-1" variant="flat" class="ml-4" @click="resolve">
+      <v-btn 
+        data-cy="decline-counter-resolve" 
+        color="surface-1" 
+        variant="flat" 
+        class="ml-4" 
+        @click="resolve"
+      >
         {{ t('game.resolve') }}
       </v-btn>
     </template>

--- a/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
+++ b/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
@@ -5,8 +5,9 @@
         {{ t('game.dialogs.counterDialogs.opponentPlayed') }}
         <GameCardName :card-name="oneOff.name" />
         {{ t('game.dialogs.counterDialogs.oneOff') }}
-        <span v-if="target"> 
-          {{ t('game.dialogs.counterDialogs.target' + 'global.your') }} 
+        <span v-if="target" class="test">
+          {{ t('game.dialogs.counterDialogs.target') }} 
+          {{ t('global.your') }}
           <GameCardName :card-name="target.name" />
         </span>
       </div>
@@ -14,7 +15,7 @@
         {{ t('game.dialogs.counterDialogs.opponentPlayed') }}
         <GameCardName :card-name="opponentLastTwo.name" />
 
-        {{ t('game.dialogs.counterDialogs.toCounter') }} 
+        {{ t('game.dialogs.counterDialogs.toCounter') }}
         <span v-if="playerLastTwo">
           {{ t('global.your') }}
           <GameCardName :card-name="playerLastTwo.name" />
@@ -27,12 +28,7 @@
         </p>
         <div v-if="target" id="target-wrapper">
           <span id="target-icon-wrapper" class="d-flex justify-center align-center">
-            <v-icon
-              size="x-large"
-              color="red"
-              icon="mdi-target" 
-              aria-hidden="true"           
-            />
+            <v-icon size="x-large" color="red" icon="mdi-target" aria-hidden="true" />
           </span>
           <GameCard :suit="target.suit" :rank="target.rank" />
         </div>
@@ -41,21 +37,10 @@
     </template>
 
     <template #actions>
-      <v-btn
-        data-cy="counter"
-        color="newPrimary"
-        variant="flat"
-        @click="$emit('choose-to-counter')"
-      >
+      <v-btn data-cy="counter" color="newPrimary" variant="flat" @click="$emit('choose-to-counter')">
         {{ t('game.dialogs.counterDialogs.counter') }}
       </v-btn>
-      <v-btn
-        data-cy="decline-counter-resolve"
-        color="surface-1"
-        variant="flat"
-        class="ml-4"
-        @click="resolve"
-      >
+      <v-btn data-cy="decline-counter-resolve" color="surface-1" variant="flat" class="ml-4" @click="resolve">
         {{ t('game.resolve') }}
       </v-btn>
     </template>

--- a/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
+++ b/src/routes/game/components/dialogs/components/ChooseWhetherToCounterDialog.vue
@@ -28,10 +28,10 @@
         <div v-if="target" id="target-wrapper">
           <span id="target-icon-wrapper" class="d-flex justify-center align-center">
             <v-icon 
-              size="x-large" 
-              color="red" 
-              icon="mdi-target" 
-              aria-hidden="true" 
+              size="x-large"
+              color="red"
+              icon="mdi-target"
+              aria-hidden="true"
             />
           </span>
           <GameCard :suit="target.suit" :rank="target.rank" />
@@ -50,10 +50,10 @@
         {{ t('game.dialogs.counterDialogs.counter') }}
       </v-btn>
       <v-btn 
-        data-cy="decline-counter-resolve" 
-        color="surface-1" 
-        variant="flat" 
-        class="ml-4" 
+        data-cy="decline-counter-resolve"
+        color="surface-1"
+        variant="flat"
+        class="ml-4"
         @click="resolve"
       >
         {{ t('game.resolve') }}


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## 882

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #882

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

Created two t() functions to fix the display problem.
