### PR TITLE
Fix/heap memory crashes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: node app.js
+worker: node --max-old-space-size=460 app.js

--- a/api/controllers/StatsController.js
+++ b/api/controllers/StatsController.js
@@ -141,14 +141,19 @@ module.exports = {
     try {
       const seasons = await sails.helpers.getSeasonsWithoutRankings();
       const [currentSeason] = seasons;
-      const allUsers = User.find({});
+      const allUsers = User.find({
+        select: ['id', 'username'],
+      });
       const currentSeasonMatches = Match.find({
         startTime: { '>': currentSeason.startTime },
         endTime: { '<': currentSeason.endTime },
       });
       const currentSeasonGames = Game.find({
-        status: gameService.GameStatus.FINISHED,
-        updatedAt: { '>': currentSeason.startTime, '<': currentSeason.endTime },
+        select: ['updatedAt', 'p0', 'p1'],
+        where: {
+          status: gameService.GameStatus.FINISHED,
+          updatedAt: { '>': currentSeason.startTime, '<': currentSeason.endTime },
+        },
       });
       const [users, matches, games] = await Promise.all([allUsers, currentSeasonMatches, currentSeasonGames]);
       updateRankingsFromMatches(users, matches, currentSeason);
@@ -163,14 +168,19 @@ module.exports = {
     const seasonId = parseInt(req.params.seasonId);
     try {
       const [requestedSeason] = await sails.helpers.getSeasonsWithoutRankings(seasonId);
-      const allUsers = User.find({});
+      const allUsers = User.find({
+        select: ['id', 'username'],
+      });
       const requestedSeasonMatches = Match.find({
         startTime: { '>': requestedSeason.startTime },
         endTime: { '<': requestedSeason.endTime },
       });
       const requestedSeasonGames = Game.find({
-        status: gameService.GameStatus.FINISHED,
-        updatedAt: { '>': requestedSeason.startTime, '<': requestedSeason.endTime },
+        select: ['updatedAt', 'p0', 'p1'],
+        where: {
+          status: gameService.GameStatus.FINISHED,
+          updatedAt: { '>': requestedSeason.startTime, '<': requestedSeason.endTime },
+        },
       });
       const [users, matches, games] = await Promise.all([
         allUsers,

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -11,20 +11,15 @@
  */
 
 module.exports = {
-  /***************************************************************************
-   * Set the default database connection for models in the development       *
-   * environment (see config/connections.js and config/models.js )           *
-   ***************************************************************************/
-  // models: {
-  //   connection: 'someMongodbServer'
-  // }
   log: {
     level: 'debug'
   },
+  // Disable default endpoints for each model e.g. GET /game/:id
   blueprints: {
     rest: false,
     shortcuts: false,
   },
+  // Needed to use custom 'select' statements using sails-disk
   models: {
     schema: true,
   }

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -25,4 +25,7 @@ module.exports = {
     rest: false,
     shortcuts: false,
   },
+  models: {
+    schema: true,
+  }
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

This fixes a critical bug where the amount of data processed by the `StatsController` endpoints was far more than needed and therefore in the production environment the app would crash whenever a single user visited the /stats page.

This partial fix is to use `select` statements to project the queries for games and users down to just the ones necessary for the computation. That is to say we no longer load all the fields for all users and the relevant games into memory, just the users' `id` + `usernames`, and the games `updatedAt` + `p0` and `p1` fields.

Performance wise, besides the crash, this improves performance of the stats page by an order of magnitude. That said, it is still an incomplete fix because if enough users play enough games, we will hit the same limit memory issue, even with the omitted fields. We should write up an issue to use the `.steam()` api for sails' waterline so that the records can be processed in manageable batch sizes.

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
