### PR TITLE
fid(ScuttleSuitOrder): fix mobile breakpoint to be smAndDown

### DIFF
--- a/src/routes/rules/components/ScuttleSuitOrder.vue
+++ b/src/routes/rules/components/ScuttleSuitOrder.vue
@@ -7,7 +7,7 @@
       role="img"
     />
     &nbsp;
-    <template v-if="!sm">
+    <template v-if="!smAndDown">
       {{ t('rules.actions.clubs') }}
     </template>
     ( {{ t('rules.actions.weakest') }} )
@@ -20,7 +20,7 @@
       role="img"
     />
     &nbsp;
-    <template v-if="!sm">
+    <template v-if="!smAndDown">
       {{ t('rules.actions.diamonds') }}
     </template>
     &lt; &nbsp;
@@ -32,7 +32,7 @@
       role="img"
     />
     &nbsp;
-    <template v-if="!sm">
+    <template v-if="!smAndDown">
       {{ t('rules.actions.hearts') }}
     </template>
     &lt; &nbsp;
@@ -44,7 +44,7 @@
       role="img"
     />
     &nbsp;
-    <template v-if="!sm">
+    <template v-if="!smAndDown">
       {{ t('rules.actions.spades') }}
     </template>
     ( {{ t('rules.actions.strongest') }} )
@@ -57,7 +57,7 @@ import { useDisplay } from 'vuetify/lib/framework.mjs';
 
 const { t } = useI18n();
 
-const { sm } = useDisplay();
+const { smAndDown } = useDisplay();
 </script>
 
 <style scoped>


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes incorrect use of `sm` breakpoint and replaces it with the intended `smAndDown`


## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
