### PR TITLE
Fix/rules navigation highlight

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -153,7 +153,7 @@ if (initialPath) {
 const router = createRouter({
   history: createWebHistory(),
   routes,
-  scrollBehavior(to, from, savedPosition) {
+  scrollBehavior(to, _from, savedPosition) {
     if (to.hash) {
       return { el: to.hash, behavior: 'smooth' };
     } else if (savedPosition) {

--- a/src/routes/rules/RulesView.vue
+++ b/src/routes/rules/RulesView.vue
@@ -392,7 +392,7 @@ export default {
         handler: this.onIntersect,
         options: {
           threshhold: 0,
-          rootMargin: '0px 0px -300px 0px',
+          rootMargin: '-150px 0px -300px 0px',
         }
       };
     }

--- a/src/routes/rules/RulesView.vue
+++ b/src/routes/rules/RulesView.vue
@@ -362,11 +362,6 @@ export default {
   },
     data() {
     return {
-      scrollOptions:{
-        duration: 1000,
-        offset: -100,
-        easing: 'easeInOutCubic',
-      },
       activeTitle: 'introduction',
       previewDialog: false,
       imageUrl: '',
@@ -387,33 +382,41 @@ export default {
     theme() {
       return this.$vuetify.theme.themes.cuttleTheme.colors;
     },
-    intersectConfig() {
-      return {
-        handler: this.onIntersect,
-        options: {
-          threshhold: 0,
-          rootMargin: '-150px 0px -300px 0px',
-        }
-      };
-    }
   },
   created() {
     this.rules = rules;
     this.royals = royals;
     this.oneOffs = oneOffs;
     this.sectionTitles = sectionTitles;
-  },
-  methods: {
-    goToSection(url) {
-      this.goTo(url, this.scrollOptions);
-      window.location.hash = url;
-    },
-    onIntersect(_isIntersecting, entries) {
+
+    // Scrolling
+    this.scrollOptions = {
+      duration: 1000,
+      offset: -100,
+      easing: 'easeInOutCubic',
+    };
+
+    // Intersection
+    const onIntersect = (_isIntersecting, entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           this.activeTitle = entry.target.id;
         }
       });
+    };
+
+    this.intersectConfig = {
+      handler: onIntersect,
+      options: {
+          threshhold: 0,
+          rootMargin: '-150px 0px -300px 0px',
+        }
+    };
+  },
+  methods: {
+    goToSection(url) {
+      this.goTo(url, this.scrollOptions);
+      window.location.hash = url;
     },
     handleAnimate(imageUrl, title) {
       this.imageUrl = imageUrl;

--- a/src/routes/rules/RulesView.vue
+++ b/src/routes/rules/RulesView.vue
@@ -41,9 +41,7 @@
           <section>
             <v-row
               id="introduction"
-              v-intersect="{
-                handler: onIntersect,
-              }"
+              v-intersect="intersectConfig"
               class="flex-column align-start"
             >
               <!-- What is Cuttle? -->
@@ -81,9 +79,7 @@
             <!-- Goal -->
             <v-row
               id="howtoplay"
-              v-intersect="{
-                handler: onIntersect,
-              }"
+              v-intersect="intersectConfig"
               class="flex-column align-start section"
             >
               <h1 class="text-h2 text-surface-2 mb-5 section-title">
@@ -123,13 +119,8 @@
           </section>
 
           <!-- Royals -->
-          <section class="section">
-            <div
-              id="royals"
-              v-intersect="{
-                handler: onIntersect,
-              }"
-            >
+          <section id="royals" v-intersect="intersectConfig" class="section">
+            <div>
               <v-row class="flex-column">
                 <h1 class="text-h2 text-surface-2 mt-5 section-title">
                   {{ t('rules.royals.title') }}
@@ -154,14 +145,9 @@
             </v-row>
           </section>
 
-          <section class="section">
+          <section id="oneoffs" v-intersect="intersectConfig" class="section">
             <!-- One-Offs -->
-            <v-row
-              id="oneoffs"
-              v-intersect="{
-                handler: onIntersect,
-              }"
-            >
+            <v-row>
               <h1 class="text-h2 text-surface-2 mt-5 section-title">
                 {{ t('rules.oneoffs.title') }}
               </h1>
@@ -200,9 +186,7 @@
           <section class="section">
             <v-row
               id="faq"
-              v-intersect="{
-                handler: onIntersect,
-              }"
+              v-intersect="intersectConfig"
               class="d-flex flex-column mb-4"
             >
               <h1 class="text-h2 text-surface-2 my-6 section-title">
@@ -254,9 +238,7 @@
           <section class="section">
             <v-row
               id="tournaments"
-              v-intersect="{
-                handler: onIntersect,
-              }"
+              v-intersect="intersectConfig"
               class="flex-column"
             >
               <h1 class="text-h2 text-surface-2 my-6 section-title">
@@ -405,6 +387,15 @@ export default {
     theme() {
       return this.$vuetify.theme.themes.cuttleTheme.colors;
     },
+    intersectConfig() {
+      return {
+        handler: this.onIntersect,
+        options: {
+          threshhold: 0,
+          rootMargin: '0px 0px -300px 0px',
+        }
+      };
+    }
   },
   created() {
     this.rules = rules;
@@ -417,7 +408,7 @@ export default {
       this.goTo(url, this.scorllOptions);
       window.location.hash = url;
     },
-    onIntersect(isIntersecting, entries) {
+    onIntersect(_isIntersecting, entries) {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           this.activeTitle = entry.target.id;

--- a/src/routes/rules/RulesView.vue
+++ b/src/routes/rules/RulesView.vue
@@ -362,7 +362,7 @@ export default {
   },
     data() {
     return {
-      scorllOptions:{
+      scrollOptions:{
         duration: 1000,
       offset: -100,
       easing: 'easeInOutCubic',
@@ -405,7 +405,7 @@ export default {
   },
   methods: {
     goToSection(url) {
-      this.goTo(url, this.scorllOptions);
+      this.goTo(url, this.scrollOptions);
       window.location.hash = url;
     },
     onIntersect(_isIntersecting, entries) {

--- a/src/routes/rules/RulesView.vue
+++ b/src/routes/rules/RulesView.vue
@@ -364,8 +364,8 @@ export default {
     return {
       scrollOptions:{
         duration: 1000,
-      offset: -100,
-      easing: 'easeInOutCubic',
+        offset: -100,
+        easing: 'easeInOutCubic',
       },
       activeTitle: 'introduction',
       previewDialog: false,

--- a/src/routes/rules/RulesView.vue
+++ b/src/routes/rules/RulesView.vue
@@ -408,7 +408,7 @@ export default {
     this.intersectConfig = {
       handler: onIntersect,
       options: {
-          threshhold: 0,
+          threshhold: .2,
           rootMargin: '-150px 0px -300px 0px',
         }
     };


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes bug in RulesView where clicking on the 'Royals' jump link would highlight the 'One-Offs' section. The issue was due to the IntersectionObservers triggering as soon as any portion of the element came into view. Now using a combination of `rootMargin` and `thresshold` to trigger them only when in the middle-ish of the screen.


Bug:

https://github.com/cuttle-cards/cuttle/assets/6520704/577fc4fd-55a2-4669-97a7-1fc05f75a6bd


## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
