### PR TITLE
fix(LobbyView): play join sound when game starts 

### DIFF
--- a/src/routes/lobby/LobbyView.vue
+++ b/src/routes/lobby/LobbyView.vue
@@ -169,18 +169,16 @@ onMounted(() => {
   playAudio(joinAudio);
 });
 
-onUnmounted(() => {
-  playAudio(leaveAudio);
-});
-
 // Router
 onBeforeRouteLeave((to, from, next) => {
   if (to.name === 'Game') {
     gameStarted.value = true;
+    playAudio(joinAudio);
     setTimeout(() => {
       next();
     }, 2000);
   } else {
+    playAudio(leaveAudio);
     next();
   }
 });

--- a/src/routes/lobby/LobbyView.vue
+++ b/src/routes/lobby/LobbyView.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, computed, watch } from 'vue';
+import { onMounted, ref, computed, watch } from 'vue';
 import { useRouter, onBeforeRouteLeave } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { useGameStore } from '@/stores/game';


### PR DESCRIPTION
Fixes bug where lobby would play 'leave' sound when the game starts (because the component unmounted). Now plays join sound when game starts and leave sound when exiting

<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #906 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
