### PR TITLE
 programmatically scroll the top nav when highlighting its jump link

### DIFF
--- a/src/routes/rules/RulesView.vue
+++ b/src/routes/rules/RulesView.vue
@@ -8,7 +8,7 @@
           md="3"
           sm="12"
         >
-          <ul class="ms-5 sidebar-title mt-8">
+          <ul ref="sidebarContainer" class="ms-5 sidebar-title mt-8">
             <li
               v-for="{ title, href, id } in sectionTitles"
               :id="'listItem_' + id"
@@ -402,6 +402,7 @@ export default {
           this.activeTitle = entry.target.id;
         }
       });
+      this.goTo.horizontal('#listItem_' + this.activeTitle ,{ container: this.$refs.sidebarContainer });
     };
 
     this.intersectConfig = {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## 915

Relevant 915(https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #915

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Go to the rules page, on a mobile vue, try scrolling the page and see that the nav bar scrolls so that the newly highlighted jump link is visible