### PR TITLE
Bug/ overlaping of GameCardName component in dialogs(https://github.c…

### DIFF
--- a/src/routes/game/components/GameCardName.vue
+++ b/src/routes/game/components/GameCardName.vue
@@ -1,5 +1,7 @@
 <template>
-  <strong class="card-name">{{ cardName }}</strong>
+  <div class="card-name">
+    {{ cardName }}
+  </div> 
 </template>
 
 <script>
@@ -27,5 +29,6 @@ export default {
   border-radius: 8px;
   margin-right: 4px;
   margin-left: 4px;
+  display:inline-block;
 }
 </style>


### PR DESCRIPTION
…om/cuttle-cards/cuttle/issues/881)

<!-- Thanks for contributing to Cuttle! 🎉 -->

## 881

Relevant 881 (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #881

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Steps to Reproduce
Enter a game
Play a royal
Have opponent play a 2 on your royal
Shrink your window size down so that the dialog text wraps
Observe the GameCardName component not overlapping the other text