### PR TITLE
Bug #871 /Game and /Spectate bring you to blank screen

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -46,21 +46,19 @@ const checkAndSubscribeToLobby = async (to) => {
     }
 
     if (!authStore.authenticated) {
-      return {path: `/login/${gameId}` };
+      return { path: `/login/${gameId}` };
     }
 
-    if (gameStore.players.some(({username}) => username === authStore.username)) {
+    if (gameStore.players.some(({ username }) => username === authStore.username)) {
       return true;
     }
 
     await gameStore.requestSubscribe(gameId);
     return true;
-  }
-  catch (err) {
-   return { name: 'Home', query: { gameId: gameId, error: err.message} };
+  } catch (err) {
+    return { name: 'Home', query: { gameId: gameId, error: err.message } };
   }
 };
-
 
 const routes = [
   {
@@ -102,7 +100,7 @@ const routes = [
   },
   {
     name: ROUTE_NAME_LOBBY,
-    path: '/lobby/:gameId',
+    path: '/lobby/:gameId?',
     component: LobbyView,
     // TODO: Add logic to redirect if a given game does not exist
     beforeEnter: checkAndSubscribeToLobby,
@@ -112,7 +110,7 @@ const routes = [
   },
   {
     name: ROUTE_NAME_GAME,
-    path: '/game/:gameId',
+    path: '/game/:gameId?',
     component: GameView,
     // TODO: Add logic to redirect if a given game does not exist
     // mustBeAuthenticated intentionally left off here
@@ -139,9 +137,7 @@ const routes = [
   {
     path: '/:pathMatch(.*)*',
     name: 'Not Found',
-    component: () => import(
-      '@/routes/error/NotFoundView.vue'
-    ),
+    component: () => import('@/routes/error/NotFoundView.vue'),
   },
 ];
 
@@ -167,10 +163,9 @@ const router = createRouter({
       return { el: to.hash, behavior: 'smooth' };
     } else if (savedPosition) {
       return savedPosition;
-    } 
-      return { top: 0 };
-    
-  }
+    }
+    return { top: 0 };
+  },
 });
 
 router.beforeEach(async (to, _from, next) => {

--- a/src/router.js
+++ b/src/router.js
@@ -121,7 +121,7 @@ const routes = [
   },
   {
     name: ROUTE_NAME_SPECTATE,
-    path: '/spectate/:gameId',
+    path: '/spectate/:gameId?',
     component: GameView,
     meta: {
       hideNavigation: true,


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #871

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Navigating to  `/game` or `/spectate` without a gameId will now show the game unavailable view
![image](https://github.com/user-attachments/assets/c604698e-5c0f-4b02-9eac-833b5f2a91d1)


Navigating to the lobby without a gameId will give you a snackbar error 
![image](https://github.com/user-attachments/assets/675798d9-f915-4513-87f8-9627b925ac12)

