### PR TITLE
vue warning about `parentModalId` type

### DIFF
--- a/src/routes/rules/RulesView.vue
+++ b/src/routes/rules/RulesView.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="[ isInModal ? 'bg-surface-1 text-surface-2' : 'pa-4 bg-surface-1 text-surface-2' ]">
     <v-container>
-      <BackToTop :parent-modal-id="isInModal && parentModalId" />
+      <BackToTop :parent-modal-id="isInModal ? parentModalId : ''" />
 
       <v-row>
         <RulesNav 


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## 1006

Resolves #1006

The problem fixed by preventing boolean type to be passed to parentModalId prop