### PR TITLE
fix(lock-game): remove conditional populate of gamestates

### DIFF
--- a/api/helpers/lock-game.js
+++ b/api/helpers/lock-game.js
@@ -41,13 +41,10 @@ module.exports = {
         }).set({ lock: uuId, lockedAt: now });
 
         // Re-fetch game and populate players and gamestates
-        const updatedGame = process.env.VITE_USE_GAMESTATE_API ? await Game.findOne({ id: gameId })
+        const updatedGame = await Game.findOne({ id: gameId })
           .populate('p0')
           .populate('p1')
-          .populate('gameStates', { sort: 'createdAt ASC' })
-        : await Game.findOne({ id: gameId })
-          .populate('p0')
-          .populate('p1');
+          .populate('gameStates', { sort: 'createdAt ASC' });
 
         // If we successfully wrote our uuid, resolve
         const newLock = updatedGame?.lock;


### PR DESCRIPTION
Follow up to remove the hack in #1014. Now that the database has been migrated to include the `gamestaterows` table via the following script, we can remove the conditional nature of the `.populate('gamestates')` call:

```
CREATE TABLE gamestaterow (
    id SERIAL PRIMARY KEY,
    "gameId" INTEGER NOT NULL REFERENCES game(id) ON DELETE CASCADE,
    "playedBy" SMALLINT NOT NULL CHECK ("playedBy" IN (0, 1)),
    "moveType" TEXT NOT NULL,
    "playedCard" TEXT,
    "targetCard" TEXT,
    "discardedCards" TEXT[] DEFAULT ARRAY[]::TEXT[],
    turn INTEGER NOT NULL,
    phase SMALLINT NOT NULL CHECK (phase IN (1, 2, 3, 4, 5, 7)),
    "p0Hand" TEXT[] NOT NULL,
    "p1Hand" TEXT[] NOT NULL,
    "p0Points" TEXT[] NOT NULL,
    "p1Points" TEXT[] NOT NULL,
    "p0FaceCards" TEXT[] NOT NULL,
    "p1FaceCards" TEXT[] NOT NULL,
    deck TEXT[] NOT NULL,
    scrap TEXT[] NOT NULL,
    "oneOff" TEXT,
    "oneOffTarget" TEXT,
    twos TEXT[] NOT NULL,
    resolved TEXT,
    "createdAt" TIMESTAMPTZ DEFAULT NOW(),
    "updatedAt" TIMESTAMPTZ DEFAULT NOW()
);

-- Indexes for foreign key fields
CREATE INDEX idx_gameId ON gamestaterow("gameId");
```
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
