### PR TITLE
Chore/update movetype references

### DIFF
--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -514,15 +514,15 @@ export const useGameStore = defineStore('game', {
     ///////////////////
     async requestDrawCard() {
       const moveType = MoveType.DRAW;
-      await this.makeSocketRequest(moveType, { moveType });
+      await this.makeSocketRequest('draw', { moveType });
     },
     async requestPlayPoints(cardId) {
       const moveType = MoveType.POINTS;
-      await this.makeSocketRequest(moveType, { moveType, cardId });
+      await this.makeSocketRequest('points', { moveType, cardId });
     },
     async requestPlayFaceCard(cardId) {
       const moveType = MoveType.FACECARD;
-      await this.makeSocketRequest(moveType, { moveType, cardId });
+      await this.makeSocketRequest('face-card', { moveType, cardId });
     },
     /**
      *
@@ -531,12 +531,12 @@ export const useGameStore = defineStore('game', {
     async requestScuttle(cardData) {
       const moveType = MoveType.SCUTTLE;
       const { cardId, targetId } = cardData;
-      await this.makeSocketRequest(moveType, { moveType, cardId, targetId, opId: this.opponent.id });
+      await this.makeSocketRequest('scuttle', { moveType, cardId, targetId, opId: this.opponent.id });
     },
 
     async requestPlayOneOff(cardId) {
       const moveType = MoveType.UNTARGETED_ONE_OFF;
-      await this.makeSocketRequest(moveType, {
+      await this.makeSocketRequest('untargeted-one-off', {
         moveType,
         cardId,
         opId: this.opponent.id
@@ -547,7 +547,7 @@ export const useGameStore = defineStore('game', {
 
     async requestPlayTargetedOneOff({ cardId, targetId, pointId, targetType }) {
       const moveType = MoveType.TARGETED_ONE_OFF;
-      await this.makeSocketRequest(moveType, {
+      await this.makeSocketRequest('targeted-one-off', {
         moveType,
         cardId,
         targetId,
@@ -561,7 +561,7 @@ export const useGameStore = defineStore('game', {
     async requestPlayJack({ cardId, targetId }) {
 
       const moveType = MoveType.JACK;
-      await this.makeSocketRequest(moveType, {
+      await this.makeSocketRequest('jack', {
         moveType,
         cardId,
         targetId,
@@ -578,20 +578,20 @@ export const useGameStore = defineStore('game', {
       const reqData = cardId2 ? { moveType, cardId1, cardId2 } : { moveType, cardId1 };
 
       const moveType = MoveType.RESOLVE_FOUR;
-      await this.makeSocketRequest(moveType, reqData);
+      await this.makeSocketRequest('resolve-four', reqData);
     },
 
     async requestResolve() {
       this.myTurnToCounter = false;
       const moveType = MoveType.RESOLVE;
-      await this.makeSocketRequest(moveType, { moveType, opId: this.opponent.id });
+      await this.makeSocketRequest('resolve', { moveType, opId: this.opponent.id });
     },
 
     async requestResolveThree(cardId) {
       this.myTurnToCounter = false;
       const moveType = MoveType.RESOLVE_THREE;
 
-      await this.makeSocketRequest(moveType, {
+      await this.makeSocketRequest('resolve-three', {
         moveType,
         cardId,
         opId: this.opponent.id,
@@ -604,14 +604,14 @@ export const useGameStore = defineStore('game', {
       this.waitingForOpponentToCounter = false;
       const moveType = MoveType.RESOLVE_FIVE;
 
-      await this.makeSocketRequest(moveType, { moveType, cardId });
+      await this.makeSocketRequest('resolve-five', { moveType, cardId });
     },
 
     async requestCounter(twoId) {
       this.myTurnToCounter = false;
       const moveType = MoveType.COUNTER;
 
-      await this.makeSocketRequest(moveType, {
+      await this.makeSocketRequest('counter', {
         moveType,
         cardId: twoId,
         opId: this.opponent.id
@@ -695,7 +695,7 @@ export const useGameStore = defineStore('game', {
 
     async requestPass() {
       const moveType = MoveType.PASS;
-      await this.makeSocketRequest(moveType, { moveType });
+      await this.makeSocketRequest('pass', { moveType });
     },
 
     async requestConcede() {

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -522,7 +522,7 @@ export const useGameStore = defineStore('game', {
     },
     async requestPlayFaceCard(cardId) {
       const moveType = MoveType.FACECARD;
-      await this.makeSocketRequest('face-card', { moveType, cardId });
+      await this.makeSocketRequest('faceCard', { moveType, cardId });
     },
     /**
      *
@@ -536,7 +536,7 @@ export const useGameStore = defineStore('game', {
 
     async requestPlayOneOff(cardId) {
       const moveType = MoveType.UNTARGETED_ONE_OFF;
-      await this.makeSocketRequest('untargeted-one-off', {
+      await this.makeSocketRequest('untargetedOneOff', {
         moveType,
         cardId,
         opId: this.opponent.id
@@ -547,7 +547,7 @@ export const useGameStore = defineStore('game', {
 
     async requestPlayTargetedOneOff({ cardId, targetId, pointId, targetType }) {
       const moveType = MoveType.TARGETED_ONE_OFF;
-      await this.makeSocketRequest('targeted-one-off', {
+      await this.makeSocketRequest('targetedOneOff', {
         moveType,
         cardId,
         targetId,
@@ -578,7 +578,7 @@ export const useGameStore = defineStore('game', {
       const reqData = cardId2 ? { moveType, cardId1, cardId2 } : { moveType, cardId1 };
 
       const moveType = MoveType.RESOLVE_FOUR;
-      await this.makeSocketRequest('resolve-four', reqData);
+      await this.makeSocketRequest('resolveFour', reqData);
     },
 
     async requestResolve() {
@@ -591,7 +591,7 @@ export const useGameStore = defineStore('game', {
       this.myTurnToCounter = false;
       const moveType = MoveType.RESOLVE_THREE;
 
-      await this.makeSocketRequest('resolve-three', {
+      await this.makeSocketRequest('resolveThree', {
         moveType,
         cardId,
         opId: this.opponent.id,
@@ -604,7 +604,7 @@ export const useGameStore = defineStore('game', {
       this.waitingForOpponentToCounter = false;
       const moveType = MoveType.RESOLVE_FIVE;
 
-      await this.makeSocketRequest('resolve-five', { moveType, cardId });
+      await this.makeSocketRequest('resolveFive', { moveType, cardId });
     },
 
     async requestCounter(twoId) {

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { useAuthStore } from '@/stores/auth';
 import { cloneDeep } from 'lodash';
 import { io } from '@/plugins/sails.js';
-import { MoveType } from '../../utils/MoveType.json';
+import MoveType from '../../utils/MoveType.json';
 import { sleep } from '../util/sleep';
 
 /**

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { useAuthStore } from '@/stores/auth';
 import { cloneDeep } from 'lodash';
 import { io } from '@/plugins/sails.js';
+import { MoveType } from '../../utils/MoveType.json';
 import { sleep } from '../util/sleep';
 
 /**
@@ -512,29 +513,42 @@ export const useGameStore = defineStore('game', {
     // In-Game Moves //
     ///////////////////
     async requestDrawCard() {
-      await this.makeSocketRequest('draw');
+      const moveType = MoveType.DRAW;
+      await this.makeSocketRequest(moveType, { moveType });
     },
     async requestPlayPoints(cardId) {
-      await this.makeSocketRequest('points', { moveType: 'points', cardId });
+      const moveType = MoveType.POINTS;
+      await this.makeSocketRequest(moveType, { moveType, cardId });
     },
     async requestPlayFaceCard(cardId) {
-      await this.makeSocketRequest('faceCard', { cardId });
+      const moveType = MoveType.FACECARD;
+      await this.makeSocketRequest(moveType, { moveType, cardId });
     },
     /**
      *
      * @param cardData @example {cardId: number, targetId: number}
      */
     async requestScuttle(cardData) {
+      const moveType = MoveType.SCUTTLE;
       const { cardId, targetId } = cardData;
-      await this.makeSocketRequest('scuttle', { cardId, targetId, opId: this.opponent.id });
+      await this.makeSocketRequest(moveType, { moveType, cardId, targetId, opId: this.opponent.id });
     },
+
     async requestPlayOneOff(cardId) {
-      await this.makeSocketRequest('untargetedOneOff', { cardId, opId: this.opponent.id });
+      const moveType = MoveType.UNTARGETED_ONE_OFF;
+      await this.makeSocketRequest(moveType, {
+        moveType,
+        cardId,
+        opId: this.opponent.id
+      });
       this.waitingForOpponentToCounter = true;
       return Promise.resolve();
     },
+
     async requestPlayTargetedOneOff({ cardId, targetId, pointId, targetType }) {
-      await this.makeSocketRequest('targetedOneOff', {
+      const moveType = MoveType.TARGETED_ONE_OFF;
+      await this.makeSocketRequest(moveType, {
+        moveType,
         cardId,
         targetId,
         pointId,
@@ -543,91 +557,132 @@ export const useGameStore = defineStore('game', {
       });
       this.waitingForOpponentToCounter = true;
     },
+
     async requestPlayJack({ cardId, targetId }) {
-      await this.makeSocketRequest('jack', {
+
+      const moveType = MoveType.JACK;
+      await this.makeSocketRequest(moveType, {
+        moveType,
         cardId,
         targetId,
         opId: this.opponent.id,
       });
     },
+
     /**
      *
      * @param {required} cardId1
      * @param {optional} cardId2
      */
     async requestDiscard({ cardId1, cardId2 }) {
-      const reqData = cardId2 ? { cardId1, cardId2 } : { cardId1 };
-      await this.makeSocketRequest('resolveFour', reqData);
+      const reqData = cardId2 ? { moveType, cardId1, cardId2 } : { moveType, cardId1 };
+
+      const moveType = MoveType.RESOLVE_FOUR;
+      await this.makeSocketRequest(moveType, reqData);
     },
+
     async requestResolve() {
       this.myTurnToCounter = false;
-      await this.makeSocketRequest('resolve', { opId: this.opponent.id });
+      const moveType = MoveType.RESOLVE;
+      await this.makeSocketRequest(moveType, { moveType, opId: this.opponent.id });
     },
+
     async requestResolveThree(cardId) {
       this.myTurnToCounter = false;
-      await this.makeSocketRequest('resolveThree', { cardId, opId: this.opponent.id });
+      const moveType = MoveType.RESOLVE_THREE;
+
+      await this.makeSocketRequest(moveType, {
+        moveType,
+        cardId,
+        opId: this.opponent.id,
+      });
       this.waitingForOpponentToCounter = false;
     },
+
     async requestResolveFive(cardId) {
       this.myTurnToCounter = false;
       this.waitingForOpponentToCounter = false;
-      await this.makeSocketRequest('resolveFive', { cardId });
+      const moveType = MoveType.RESOLVE_FIVE;
+
+      await this.makeSocketRequest(moveType, { moveType, cardId });
     },
+
+    async requestCounter(twoId) {
+      this.myTurnToCounter = false;
+      const moveType = MoveType.COUNTER;
+
+      await this.makeSocketRequest(moveType, {
+        moveType,
+        cardId: twoId,
+        opId: this.opponent.id
+      });
+      this.waitingForOpponentToCounter = true;
+    },
+
+    ////////////
+    // Sevens //
+    ////////////
+    async requestPlayPointsSeven({ cardId, index }) {
+      await this.makeSocketRequest('seven/points', {
+        moveType: MoveType.SEVEN_POINTS,
+        cardId,
+        index, // 0 if topCard, 1 if secondCard
+      });
+    },
+
+    async requestScuttleSeven({ cardId, index, targetId }) {
+      await this.makeSocketRequest('seven/scuttle', {
+        moveType: MoveType.SEVEN_SCUTTLE,
+        cardId,
+        index,
+        targetId,
+        opId: this.opponent.id,
+      });
+    },
+
+    async requestPlayJackSeven({ cardId, index, targetId }) {
+      await this.makeSocketRequest('seven/jack', {
+        moveType: MoveType.SEVEN_JACK,
+        cardId,
+        index, // 0 if topCard, 1 if secondCard
+        targetId,
+        opId: this.opponent.id,
+      });
+    },
+
     async requestResolveSevenDoubleJacks({ cardId, index }) {
       this.myTurnToCounter = false;
+
       await this.makeSocketRequest('seven/jack', {
+        moveType: MoveType.SEVEN_JACK,
         cardId,
         index, // 0 if topCard, 1 if secondCard
         targetId: -1, // -1 for the double jacks with no points to steal case
         opId: this.opponent.id,
       });
     },
-    async requestCounter(twoId) {
-      this.myTurnToCounter = false;
-      await this.makeSocketRequest('counter', { cardId: twoId, opId: this.opponent.id });
-      this.waitingForOpponentToCounter = true;
-    },
-    ////////////
-    // Sevens //
-    ////////////
-    async requestPlayPointsSeven({ cardId, index }) {
-      await this.makeSocketRequest('seven/points', {
-        cardId,
-        index, // 0 if topCard, 1 if secondCard
-      });
-    },
-    async requestScuttleSeven({ cardId, index, targetId }) {
-      await this.makeSocketRequest('seven/scuttle', {
-        cardId,
-        index,
-        targetId,
-        opId: this.opponent.id,
-      });
-    },
-    async requestPlayJackSeven({ cardId, index, targetId }) {
-      await this.makeSocketRequest('seven/jack', {
-        cardId,
-        index, // 0 if topCard, 1 if secondCard
-        targetId,
-        opId: this.opponent.id,
-      });
-    },
+
     async requestPlayFaceCardSeven({ index, cardId }) {
       await this.makeSocketRequest('seven/faceCard', {
+        moveType: MoveType.SEVEN_FACECARD,
         cardId,
         index,
       });
     },
+
     async requestPlayOneOffSeven({ cardId, index }) {
       await this.makeSocketRequest('seven/untargetedOneOff', {
+        moveType: MoveType.SEVEN_UNTARGETED_ONE_OFF,
         cardId,
         index, // 0 if topCard, 1 if secondCard
         opId: this.opponent.id,
       });
       this.waitingForOpponentToCounter = true;
     },
+
     async requestPlayTargetedOneOffSeven({ cardId, index, targetId, pointId, targetType }) {
       await this.makeSocketRequest('seven/targetedOneOff', {
+        moveType: MoveType.SEVEN_TARGETED_ONE_OFF,
         cardId,
         targetId,
         pointId,
@@ -637,22 +692,28 @@ export const useGameStore = defineStore('game', {
       });
       this.waitingForOpponentToCounter = true;
     },
+
     async requestPass() {
-      await this.makeSocketRequest('pass');
+      const moveType = MoveType.PASS;
+      await this.makeSocketRequest(moveType, { moveType });
     },
+
     async requestConcede() {
       await this.makeSocketRequest('concede');
     },
+
     async requestStalemate() {
       await this.makeSocketRequest('stalemate').then(() => {
         this.consideringOpponentStalemateRequest = false;
       });
     },
+
     async rejectStalemate() {
       await this.makeSocketRequest('reject-stalemate').then(() => {
         this.consideringOpponentStalemateRequest = false;
       });
     },
+
     async requestUnsubscribeFromGame() {
       return new Promise((resolve, reject) => {
         io.socket.get('/api/game/over', (res, jwres) => {
@@ -663,9 +724,11 @@ export const useGameStore = defineStore('game', {
         });
       });
     },
+
     async requestRematch({ gameId, rematch = true }) {
       await this.makeSocketRequest('rematch', { gameId, rematch });
     },
+
     async requestJoinRematch({ oldGameId }) {
       return new Promise((resolve, reject) => {
         io.socket.get('/api/game/join-rematch', { oldGameId }, (res, jwres) => {
@@ -676,5 +739,6 @@ export const useGameStore = defineStore('game', {
         });
       });
     },
+
   }, // End actions
 }); // End game store

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -575,9 +575,9 @@ export const useGameStore = defineStore('game', {
      * @param {optional} cardId2
      */
     async requestDiscard({ cardId1, cardId2 }) {
+      const moveType = MoveType.RESOLVE_FOUR;
       const reqData = cardId2 ? { moveType, cardId1, cardId2 } : { moveType, cardId1 };
 
-      const moveType = MoveType.RESOLVE_FOUR;
       await this.makeSocketRequest('resolveFour', reqData);
     },
 

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -329,8 +329,10 @@ Cypress.Commands.add('playPointsSpectator', (card, pNum) => {
           `Error playing points while spectating: could not find ${card.rank} of ${card.suit} in specified player's hand`,
         );
       }
+
+      const moveType = MoveType.POINTS;
       const cardId = foundCard.id;
-      cy.makeSocketRequest('game', 'points', { cardId });
+      cy.makeSocketRequest('game', moveType, { moveType, cardId });
     });
 });
 
@@ -355,9 +357,11 @@ Cypress.Commands.add('playOneOffSpectator', (card, pNum) => {
           `Error playing one-off while spectating: could not find ${card.rank} of ${card.suit} in specified player's hand`,
         );
       }
+
+      const moveType = MoveType.UNTARGETED_ONE_OFF;
       const cardId = foundCard.id;
       const opId = game.players[(pNum + 1) % 2].id;
-      cy.makeSocketRequest('game', 'untargetedOneOff', { cardId, opId });
+      cy.makeSocketRequest('game', moveType, { moveType, cardId, opId });
     });
 });
 

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -361,7 +361,7 @@ Cypress.Commands.add('playOneOffSpectator', (card, pNum) => {
       const moveType = MoveType.UNTARGETED_ONE_OFF;
       const cardId = foundCard.id;
       const opId = game.players[(pNum + 1) % 2].id;
-      cy.makeSocketRequest('game', 'untargeted-one-off', { moveType, cardId, opId });
+      cy.makeSocketRequest('game', 'untargetedOneOff', { moveType, cardId, opId });
     });
 });
 
@@ -385,7 +385,7 @@ Cypress.Commands.add('playFaceCardOpponent', (card) => {
 
       const cardId = foundCard.id;
       const moveType = MoveType.FACECARD;
-      cy.makeSocketRequest('game', 'face-card', { moveType, cardId });
+      cy.makeSocketRequest('game', 'faceCard', { moveType, cardId });
     });
 });
 
@@ -488,7 +488,7 @@ Cypress.Commands.add('playOneOffOpponent', (card) => {
       }
 
       const moveType = MoveType.UNTARGETED_ONE_OFF;
-      cy.makeSocketRequest('game', 'untargeted-one-off', {
+      cy.makeSocketRequest('game', 'untargetedOneOff', {
         moveType,
         opId: playerId,
         cardId: foundCard.id,
@@ -559,7 +559,7 @@ Cypress.Commands.add('playTargetedOneOffOpponent', (card, target, targetType) =>
       }
 
       const moveType = MoveType.TARGETED_ONE_OFF;
-      cy.makeSocketRequest('game', 'targeted-one-off', {
+      cy.makeSocketRequest('game', 'targetedOneOff', {
         moveType,
         opId: playerId, // opponent's opponent is the player
         targetId: foundTarget.id,
@@ -613,7 +613,7 @@ Cypress.Commands.add('resolveFiveOpponent', (card) => {
 
       const moveType = MoveType.RESOLVE_FIVE;
       const cardId = foundCard?.id ?? null;
-      cy.makeSocketRequest('game', 'resolve', { moveType, cardId });
+      cy.makeSocketRequest('game', 'resolveFive', { moveType, cardId });
     });
 });
 
@@ -635,7 +635,7 @@ Cypress.Commands.add('resolveThreeOpponent', (card) => {
 
       const moveType = MoveType.RESOLVE_THREE;
       const cardId = foundCard.id;
-      cy.makeSocketRequest('game', 'resolve-three', { moveType, cardId, opId });
+      cy.makeSocketRequest('game', 'resolveThree', { moveType, cardId, opId });
     });
 });
 
@@ -670,7 +670,7 @@ Cypress.Commands.add('discardOpponent', (card1, card2) => {
 
       const moveType = MoveType.RESOLVE_FOUR;
       //dont use makeSocketRequest due to edge case checking error on opponent side
-      transformGameUrl('game', 'resolve-four').then((url) => {
+      transformGameUrl('game', 'resolveFour').then((url) => {
         io.socket.request({
           method: 'post',
           url,

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -1,5 +1,6 @@
 import { getCardIds, hasValidSuitAndRank, cardsMatch, printCard } from './helpers';
 import { myUser, opponentOne, playerOne, playerTwo } from '../fixtures/userFixtures';
+import MoveType from '../../../utils/MoveType.json';
 
 /**
  * Require & configure socket connection to server
@@ -305,7 +306,8 @@ Cypress.Commands.add('playPointsOpponent', (card) => {
         );
       }
       const cardId = foundCard.id;
-      cy.makeSocketRequest('game', 'points', { moveType: 'points', cardId });
+      const moveType = MoveType.POINTS;
+      cy.makeSocketRequest('game', moveType, { moveType, cardId });
     });
 });
 

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -286,7 +286,7 @@ Cypress.Commands.add('recoverSessionOpponent', (userFixture) => {
 
 Cypress.Commands.add('drawCardOpponent', () => {
   const moveType = MoveType.DRAW;
-  cy.makeSocketRequest('game', moveType, { moveType });
+  cy.makeSocketRequest('game', 'draw', { moveType });
 });
 
 /**
@@ -308,7 +308,7 @@ Cypress.Commands.add('playPointsOpponent', (card) => {
       }
       const cardId = foundCard.id;
       const moveType = MoveType.POINTS;
-      cy.makeSocketRequest('game', moveType, { moveType, cardId });
+      cy.makeSocketRequest('game', 'points', { moveType, cardId });
     });
 });
 
@@ -332,7 +332,7 @@ Cypress.Commands.add('playPointsSpectator', (card, pNum) => {
 
       const moveType = MoveType.POINTS;
       const cardId = foundCard.id;
-      cy.makeSocketRequest('game', moveType, { moveType, cardId });
+      cy.makeSocketRequest('game', 'points', { moveType, cardId });
     });
 });
 
@@ -361,7 +361,7 @@ Cypress.Commands.add('playOneOffSpectator', (card, pNum) => {
       const moveType = MoveType.UNTARGETED_ONE_OFF;
       const cardId = foundCard.id;
       const opId = game.players[(pNum + 1) % 2].id;
-      cy.makeSocketRequest('game', moveType, { moveType, cardId, opId });
+      cy.makeSocketRequest('game', 'untargeted-one-off', { moveType, cardId, opId });
     });
 });
 
@@ -385,7 +385,7 @@ Cypress.Commands.add('playFaceCardOpponent', (card) => {
 
       const cardId = foundCard.id;
       const moveType = MoveType.FACECARD;
-      cy.makeSocketRequest('game', moveType, { moveType, cardId });
+      cy.makeSocketRequest('game', 'face-card', { moveType, cardId });
     });
 });
 
@@ -420,7 +420,7 @@ Cypress.Commands.add('playJackOpponent', (card, target) => {
       const cardId = foundCard.id;
       const targetId = foundTarget.id;
 
-      cy.makeSocketRequest('game', moveType, {
+      cy.makeSocketRequest('game', 'jack', {
         moveType,
         opId: player.id,
         cardId,
@@ -456,7 +456,7 @@ Cypress.Commands.add('scuttleOpponent', (card, target) => {
         );
       }
       const moveType = MoveType.SCUTTLE;
-      cy.makeSocketRequest('game', moveType, {
+      cy.makeSocketRequest('game', 'scuttle', {
         moveType,
         opId: player.id,
         cardId: foundCard.id,
@@ -488,7 +488,7 @@ Cypress.Commands.add('playOneOffOpponent', (card) => {
       }
 
       const moveType = MoveType.UNTARGETED_ONE_OFF;
-      cy.makeSocketRequest('game', moveType, {
+      cy.makeSocketRequest('game', 'untargeted-one-off', {
         moveType,
         opId: playerId,
         cardId: foundCard.id,
@@ -559,7 +559,7 @@ Cypress.Commands.add('playTargetedOneOffOpponent', (card, target, targetType) =>
       }
 
       const moveType = MoveType.TARGETED_ONE_OFF;
-      cy.makeSocketRequest('game', moveType, {
+      cy.makeSocketRequest('game', 'targeted-one-off', {
         moveType,
         opId: playerId, // opponent's opponent is the player
         targetId: foundTarget.id,
@@ -592,7 +592,7 @@ Cypress.Commands.add('counterOpponent', (card) => {
 
       const moveType = MoveType.COUNTER;
       const cardId = foundCard.id;
-      cy.makeSocketRequest('game', moveType, { moveType, cardId, opId });
+      cy.makeSocketRequest('game', 'counter', { moveType, cardId, opId });
     });
 });
 
@@ -613,7 +613,7 @@ Cypress.Commands.add('resolveFiveOpponent', (card) => {
 
       const moveType = MoveType.RESOLVE_FIVE;
       const cardId = foundCard?.id ?? null;
-      cy.makeSocketRequest('game', moveType, { moveType, cardId });
+      cy.makeSocketRequest('game', 'resolve', { moveType, cardId });
     });
 });
 
@@ -635,7 +635,7 @@ Cypress.Commands.add('resolveThreeOpponent', (card) => {
 
       const moveType = MoveType.RESOLVE_THREE;
       const cardId = foundCard.id;
-      cy.makeSocketRequest('game', moveType, { moveType, cardId, opId });
+      cy.makeSocketRequest('game', 'resolve-three', { moveType, cardId, opId });
     });
 });
 
@@ -646,7 +646,7 @@ Cypress.Commands.add('resolveOpponent', () => {
     .then((game) => {
       const moveType = MoveType.RESOLVE;
       const opId = game.players[game.myPNum].id;
-      cy.makeSocketRequest('game', moveType, { moveType, opId });
+      cy.makeSocketRequest('game', 'resolve', { moveType, opId });
     });
 });
 
@@ -670,7 +670,7 @@ Cypress.Commands.add('discardOpponent', (card1, card2) => {
 
       const moveType = MoveType.RESOLVE_FOUR;
       //dont use makeSocketRequest due to edge case checking error on opponent side
-      transformGameUrl('game', moveType).then((url) => {
+      transformGameUrl('game', 'resolve-four').then((url) => {
         io.socket.request({
           method: 'post',
           url,
@@ -1036,7 +1036,7 @@ Cypress.Commands.add('playTargetedOneOffFromSevenOpponent', (card, target, targe
 Cypress.Commands.add('passOpponent', () => {
   cy.log('Opponent Passes');
   const moveType = MoveType.PASS;
-  cy.makeSocketRequest('game', moveType, { moveType });
+  cy.makeSocketRequest('game', 'pass', { moveType });
 });
 
 Cypress.Commands.add('concedeOpponent', () => {

--- a/utils/MoveType.json
+++ b/utils/MoveType.json
@@ -6,7 +6,7 @@
   "FACECARD": "faceCard",
   "JACK": "jack",
   "UNTARGETED_ONE_OFF": "untargetedOneOff",
-  "TARGETED_ONE_OFF": "targetOneOff",
+  "TARGETED_ONE_OFF": "targetedOneOff",
   "COUNTER": "counter",
   "RESOLVE": "resolve",
   "FIZZLE": "fizzle",


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
* fixes issue where some requests to make moves were missing `moveType`. 
* Use the `MoveType` enum

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
