### PR TITLE
fix(moves/points/execute): set playedBy in returned result

### DIFF
--- a/api/helpers/gamestate/moves/points/execute.js
+++ b/api/helpers/gamestate/moves/points/execute.js
@@ -37,6 +37,7 @@ module.exports = {
     result = {
       ...result,
       ...requestedMove,
+      playedBy,
       playedCard: player.points.at(-1),
     };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

The `points/execute` move was missing the `playedBy` attribute from the returned GameState

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
