### PR TITLE
VSkeletonLoader max width was fixed in the HomeView Component. Added …

### DIFF
--- a/src/routes/home/HomeView.vue
+++ b/src/routes/home/HomeView.vue
@@ -32,14 +32,14 @@
                   <v-skeleton-loader
                     class="pa-0"
                     type="text"
-                    max-width="160"
+                    :max-width="160"
                     color="surface-2"
                     height="30"
                   />
                   <v-skeleton-loader
                     class="pa-0"
                     type="text"
-                    max-width="130"
+                    :max-width="130"
                     color="surface-2"
                     height="30"
                   />


### PR DESCRIPTION
…':' to prvent value from being string

<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number #1037

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #1037 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ yes] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ N/A] Have tests been added to cover any new features or fixes?
  - [N/A ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
