### PR TITLE
Feat/one off error reconciliation

### DIFF
--- a/api/controllers/game/resolve-five.js
+++ b/api/controllers/game/resolve-five.js
@@ -7,16 +7,16 @@ module.exports = async function (req, res) {
     const [game, player, cardToDiscard] = await Promise.all([promiseGame, promisePlayer, promiseCard]);
 
     if (!game.topCard) {
-      throw { message: 'game.snackbar.five.fiveDeckIsEmpty' };
+      throw { message: 'game.snackbar.oneOffs.five.fiveDeckIsEmpty' };
     }
     if (player.hand?.length && !cardToDiscard) {
-      throw { message: 'game.snackbar.five.selectCardToDiscard' };
+      throw { message: 'game.snackbar.oneOffs.five.selectCardToDiscard' };
     }
     if (game.turn % 2 !== player.pNum) {
       throw { message: 'game.snackbar.global.notYourTurn' };
     }
     if (!game.oneOff || game.oneOff?.rank !== 5) {
-      throw { message: 'game.snackbar.five.incorrectCard' };
+      throw { message: 'game.snackbar.oneOffs.five.incorrectCard' };
     }
 
     const gameUpdates = {

--- a/api/controllers/game/seven/face-card.js
+++ b/api/controllers/game/seven/face-card.js
@@ -47,7 +47,7 @@ module.exports = function (req, res) {
           });
         }
         return Promise.reject({
-          message: 'game.snackbar.seven.pickAndPlay',
+          message: 'game.snackbar.oneOffs.seven.pickAndPlay',
         });
       }
       return Promise.reject({ message: 'game.snackbar.global.notYourTurn' });

--- a/api/controllers/game/seven/jack.js
+++ b/api/controllers/game/seven/jack.js
@@ -95,7 +95,7 @@ module.exports = function (req, res) {
           return Promise.reject({ message: 'game.snackbar.jack.stealOnlyPointCards' });
         }
         return Promise.reject({
-          message: 'game.snackbar.seven.pickAndPlay',
+          message: 'game.snackbar.oneOffs.seven.pickAndPlay',
         });
       }
       return Promise.reject({ message: 'game.snackbar.global.notYourTurn' });

--- a/api/controllers/game/seven/points.js
+++ b/api/controllers/game/seven/points.js
@@ -37,7 +37,7 @@ module.exports = function (req, res) {
           return Promise.reject({ message: 'game.snackbar.points.numberOnlyForPoints' });
         }
         return Promise.reject({
-          message: 'game.snackbar.seven.pickAndPlay',
+          message: 'game.snackbar.oneOffs.seven.pickAndPlay',
         });
       }
       return Promise.reject({ message: "It's not your turn" });

--- a/api/controllers/game/seven/scuttle.js
+++ b/api/controllers/game/seven/scuttle.js
@@ -58,7 +58,7 @@ module.exports = function (req, res) {
           return Promise.reject({ message: 'game.snackbar.scuttle.mustUsePointCard' });
         }
         return Promise.reject({
-          message: 'game.snackbar.seven.pickAndPlay',
+          message: 'game.snackbar.oneOffs.seven.pickAndPlay',
         });
       }
       return Promise.reject({ message: 'game.snackbar.global.notYourTurn' });

--- a/api/controllers/game/seven/targeted-one-off.js
+++ b/api/controllers/game/seven/targeted-one-off.js
@@ -78,7 +78,7 @@ module.exports = function (req, res) {
           }
         } else {
           return Promise.reject({
-            message: 'game.snackbar.seven.pickAndPlay',
+            message: 'game.snackbar.oneOffs.seven.pickAndPlay',
           });
         }
       } else {

--- a/api/controllers/game/seven/untargeted-one-off.js
+++ b/api/controllers/game/seven/untargeted-one-off.js
@@ -40,7 +40,7 @@ module.exports = function (req, res) {
                   if (!game.topCard)
                     {
                       return Promise.reject({
-                        message: 'game.snackbar.oneOffs.sevenWithEmptyDeck',
+                        message: 'game.snackbar.oneOffs.emptyDeck',
                       });
                     }
                   if (game.topCard.id === card.id && !game.secondCard)

--- a/api/controllers/game/seven/untargeted-one-off.js
+++ b/api/controllers/game/seven/untargeted-one-off.js
@@ -23,7 +23,7 @@ module.exports = function (req, res) {
                   if (game.scrap.length === 0)
                     {
                       return Promise.reject({
-                        message: 'game.snackbar.oneOffs.scrapIsEmpty',
+                        message: 'game.snackbar.oneOffs.three.scrapIsEmpty',
                       });
                     }
                   break;
@@ -31,7 +31,7 @@ module.exports = function (req, res) {
                   if (opponent.hand.length === 0)
                     {
                       return Promise.reject({
-                        message: 'game.snackbar.oneOffs.opponentHasNoCards',
+                        message: 'game.snackbar.oneOffs.four.opponentHasNoCards',
                       });
                     }
                   break;
@@ -46,7 +46,7 @@ module.exports = function (req, res) {
                   if (game.topCard.id === card.id && !game.secondCard)
                     {
                       return Promise.reject({
-                        message: 'game.snackbar.oneOffs.sevenWithOneCardInDeck',
+                        message: 'game.snackbar.oneOffs.seven.oneCardInDeck',
                       });
                     }
                   break;
@@ -82,7 +82,7 @@ module.exports = function (req, res) {
           }
         } else {
           return Promise.reject({
-            message: 'game.snackbar.seven.pickAndPlay',
+            message: 'game.snackbar.oneOffs.seven.pickAndPlay',
           });
         }
       } else {

--- a/api/controllers/game/untargeted-one-off.js
+++ b/api/controllers/game/untargeted-one-off.js
@@ -28,7 +28,7 @@ module.exports = function (req, res) {
                     if (game.scrap.length < 1)
                       {
                         return Promise.reject({
-                          message: 'You can only play a 3 as a one-off, if there are cards in the scrap pile',
+                          message: 'game.snackbar.oneOffs.scrapIsEmpty',
                         });
                       }
                     break;

--- a/api/controllers/game/untargeted-one-off.js
+++ b/api/controllers/game/untargeted-one-off.js
@@ -45,7 +45,7 @@ module.exports = function (req, res) {
                     if (!game.topCard)
                       {
                         return Promise.reject({
-                          message: "You can't play that card as a one-off, unless there are cards in the deck",
+                          message: 'game.snackbar.oneOffs.emptyDeck',
                         });
                       }
                     break;

--- a/api/controllers/game/untargeted-one-off.js
+++ b/api/controllers/game/untargeted-one-off.js
@@ -28,7 +28,7 @@ module.exports = function (req, res) {
                     if (game.scrap.length < 1)
                       {
                         return Promise.reject({
-                          message: 'game.snackbar.oneOffs.scrapIsEmpty',
+                          message: 'game.snackbar.oneOffs.three.scrapIsEmpty',
                         });
                       }
                     break;

--- a/api/helpers/gamestate/moves/one-off/validate.js
+++ b/api/helpers/gamestate/moves/one-off/validate.js
@@ -141,10 +141,10 @@ module.exports = {
           }
           return exits.success();
 
-        // Five requires cards in deck
+        // Five and sevens require cards in deck
         case 5:
           if (!currentState.deck.length) {
-            throw new Error('game.snackbar.five.fiveDeckIsEmpty');
+            throw new Error('game.snackbar.five.emptyDeck');
           }
           return exits.success();
 

--- a/api/helpers/gamestate/moves/one-off/validate.js
+++ b/api/helpers/gamestate/moves/one-off/validate.js
@@ -66,9 +66,7 @@ module.exports = {
       }
 
       if (currentState.oneOff) {
-        throw new Error(
-          'There is already a one-off in play; You cannot play any card, except a two to counter.',
-        );
+        throw new Error('game.snackbar.oneOffs.oneOffInPlay');
       }
 
       if (!cardPlayed) {

--- a/api/helpers/gamestate/moves/one-off/validate.js
+++ b/api/helpers/gamestate/moves/one-off/validate.js
@@ -130,14 +130,14 @@ module.exports = {
         // Three requires card(s) in scrap
         case 3:
           if (!currentState.scrap.length) {
-            throw new Error('game.snackbar.oneOffs.scrapIsEmpty');
+            throw new Error('game.snackbar.oneOffs.three.scrapIsEmpty');
           }
           return exits.success();
 
         // Four requires opponent to have cards in hand
         case 4:
           if (!opponent.hand.length) {
-            throw new Error('game.snackbar.oneOffs.opponentHasNoCards');
+            throw new Error('game.snackbar.oneOffs.four.opponentHasNoCards');
           }
           return exits.success();
 

--- a/api/policies/hasCardId.js
+++ b/api/policies/hasCardId.js
@@ -13,11 +13,11 @@ module.exports = function (req, res, next) {
     if (typeof req.body.cardId === 'number') {
       return next();
     }
-    return res.forbidden({
+    return res.badRequest({
       message: 'Error: You must provide a valid card for your move (ID was non-integer)',
     });
   }
-  return res.forbidden({
+  return res.badRequest({
     message: 'Error You must provide a valid card to make that move (No ID given)',
   });
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -282,7 +282,6 @@
         "scrapIsEmpty": "You can only play a 3 as a one-off if there are cards in the scrap pile",
         "opponentHasNoCards": "You cannot play a 4 as a one-off while your opponent has no cards in hand",
         "emptyDeck": "You can't play that one-off unless there are cards in the deck",
-        "sevenWithEmptyDeck": "You can only play a 7 as a ONE-OFF if there are cards in the deck",
         "sevenWithOneCardInDeck": "You cannot play a 7 as a ONE-OFF if it is the last card in the deck",
         "cantPlayWithoutATarget": "You cannot play that card as a ONE-OFF without a target",
         "onlyTwoOrNine": "You can only play a 2, or a 9 as targeted one-offs.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -280,7 +280,7 @@
       },
       "oneOffs": {
         "scrapIsEmpty": "You can only play a 3 as a one-off if there are cards in the scrap pile",
-        "opponentHasNoCards": "You cannot play a 4 as a ONE-OFF while your opponent has no cards in hand",
+        "opponentHasNoCards": "You cannot play a 4 as a one-off while your opponent has no cards in hand",
         "sevenWithEmptyDeck": "You can only play a 7 as a ONE-OFF if there are cards in the deck",
         "sevenWithOneCardInDeck": "You cannot play a 7 as a ONE-OFF if it is the last card in the deck",
         "cantPlayWithoutATarget": "You cannot play that card as a ONE-OFF without a target",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -279,7 +279,7 @@
         "mustTargetPointCard": "You can only scuttle a card your opponent has played for points"
       },
       "oneOffs": {
-        "scrapIsEmpty": "You can only play a 3 ONE-OFF if there are cards in the scrap pile",
+        "scrapIsEmpty": "You can only play a 3 as a one-off if there are cards in the scrap pile",
         "opponentHasNoCards": "You cannot play a 4 as a ONE-OFF while your opponent has no cards in hand",
         "sevenWithEmptyDeck": "You can only play a 7 as a ONE-OFF if there are cards in the deck",
         "sevenWithOneCardInDeck": "You cannot play a 7 as a ONE-OFF if it is the last card in the deck",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -250,14 +250,6 @@
         "blockedByQueen": "Your opponent's queen prevents you from targeting their other cards",
         "blockedByMultipleQueens": "You cannot play a Targeted One-Off (Two, Nine) when your opponent has more than one Queen"
       },
-      "seven": {
-        "pickAndPlay": "You can only play cards from the top of the deck while resolving a seven."
-      },
-      "five": {
-        "selectCardToDiscard": "You must select one card to discard",
-        "incorrectCard": "Incorrect card played",
-        "fiveDeckIsEmpty": "Cannot resolve 5 one-off with an empty deck"
-      },
       "draw": {
         "deckIsEmpty": "The deck is empty; you cannot draw.",
         "handLimit": "You are at the hand limit; you cannot draw."
@@ -279,13 +271,25 @@
         "mustTargetPointCard": "You can only scuttle a card your opponent has played for points"
       },
       "oneOffs": {
-        "scrapIsEmpty": "You can only play a 3 as a one-off if there are cards in the scrap pile",
-        "opponentHasNoCards": "You cannot play a 4 as a one-off while your opponent has no cards in hand",
-        "emptyDeck": "You can't play that one-off unless there are cards in the deck",
-        "sevenWithOneCardInDeck": "You cannot play a 7 as a ONE-OFF if it is the last card in the deck",
+        "oneOffInPlay": "There is already a one-off in play; you cannot play any card, except a two to counter.",
         "cantPlayWithoutATarget": "You cannot play that card as a ONE-OFF without a target",
         "onlyTwoOrNine": "You can only play a 2, or a 9 as targeted one-offs.",
-        "oneOffInPlay": "There is already a one-off in play; you cannot play any card, except a two to counter."
+        "emptyDeck": "You can't play that one-off unless there are cards in the deck",
+        "three": {
+          "scrapIsEmpty": "You can only play a 3 as a one-off if there are cards in the scrap pile"
+        },
+        "four": {
+          "opponentHasNoCards": "You cannot play a 4 as a one-off while your opponent has no cards in hand"
+        },
+        "five": {
+          "selectCardToDiscard": "You must select one card to discard",
+          "incorrectCard": "Incorrect card played",
+          "fiveDeckIsEmpty": "Cannot resolve 5 one-off with an empty deck"
+        },
+        "seven": {
+          "oneCardInDeck": "You cannot play a 7 as a ONE-OFF if it is the last card in the deck",
+          "pickAndPlay": "You can only play cards from the top of the deck while resolving a seven."
+        }
       }
     }
   },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -281,6 +281,7 @@
       "oneOffs": {
         "scrapIsEmpty": "You can only play a 3 as a one-off if there are cards in the scrap pile",
         "opponentHasNoCards": "You cannot play a 4 as a one-off while your opponent has no cards in hand",
+        "emptyDeck": "You can't play that one-off unless there are cards in the deck",
         "sevenWithEmptyDeck": "You can only play a 7 as a ONE-OFF if there are cards in the deck",
         "sevenWithOneCardInDeck": "You cannot play a 7 as a ONE-OFF if it is the last card in the deck",
         "cantPlayWithoutATarget": "You cannot play that card as a ONE-OFF without a target",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -281,7 +281,7 @@
       "oneOffs": {
         "scrapIsEmpty": "Solo puedes jugar un 3 como carta de habilidad única si hay cartas en el mazo de descarte",
         "opponentHasNoCards": "No puedes jugar un 4 como carta de habilidad única mientras tu oponente no tenga cartas en su mano",
-        "sevenWithEmptyDeck": "Solo puedes jugar un 7 como carta de habilidad única si hay cartas en el mazo",
+        "emptyDeck": "No puedes jugar ese uno por uno a menos que haya cartas en el mazo",
         "sevenWithOneCardInDeck": "No puedes jugar un 7 como carta de habilidad única si es la última carta del mazo",
         "cantPlayWithoutATarget": "No puedes jugar un 1 como carta de habilidad única sin un objetivo",
         "onlyTwoOrNine": "Solo puedes jugar un 2 o un 9 como cartas de habilidad única con objetivo",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -250,14 +250,6 @@
         "blockedByQueen": "La Reina de tu oponente evita que puedas seleccionar como objetivo sus otras cartas",
         "blockedByMultipleQueens": "No puedes jugar una carta de habilidad única con objetivo (Dos, Nueve) cuando tu oponente tiene más de una reina"
       },
-      "seven": {
-        "pickAndPlay": "Solo puedes jugar las cartas superiores del mazo mientras se resuelve un Siete"
-      },
-      "five": {
-        "selectCardToDiscard": "Debes seleccionar una carta para descartar",
-        "incorrectCard": "Carta incorrecta jugada",
-        "fiveDeckIsEmpty": "No se puede resolver la habilidad única de un 5 con un mazo vacío"
-      },
       "draw": {
         "deckIsEmpty": "El mazo está vacío; no puedes robar.",
         "handLimit": "Tu mano ha alcanzado el límite; no puedes robar."
@@ -279,13 +271,25 @@
         "mustTargetPointCard": "Solo puedes hundir una carta que tu oponente haya jugado como puntos"
       },
       "oneOffs": {
-        "scrapIsEmpty": "Solo puedes jugar un 3 como carta de habilidad única si hay cartas en el mazo de descarte",
-        "opponentHasNoCards": "No puedes jugar un 4 como carta de habilidad única mientras tu oponente no tenga cartas en su mano",
-        "emptyDeck": "No puedes jugar ese uno por uno a menos que haya cartas en el mazo",
-        "sevenWithOneCardInDeck": "No puedes jugar un 7 como carta de habilidad única si es la última carta del mazo",
+        "oneOffInPlay": "Ya hay en juego una carta de habilidad única; no puedes jugar ninguna carta, excepto un Dos para contrarrestar.",
         "cantPlayWithoutATarget": "No puedes jugar un 1 como carta de habilidad única sin un objetivo",
         "onlyTwoOrNine": "Solo puedes jugar un 2 o un 9 como cartas de habilidad única con objetivo",
-        "oneOffInPlay": "Ya hay en juego una carta de habilidad única; no puedes jugar ninguna carta, excepto un Dos para contrarrestar."
+        "emptyDeck": "No puedes jugar ese uno por uno a menos que haya cartas en el mazo",
+        "three": {
+          "scrapIsEmpty": "Solo puedes jugar un 3 como carta de habilidad única si hay cartas en el mazo de descarte"
+        },
+        "four": {
+          "opponentHasNoCards": "No puedes jugar un 4 como carta de habilidad única mientras tu oponente no tenga cartas en su mano"
+        },
+        "five": {
+          "selectCardToDiscard": "Debes seleccionar una carta para descartar",
+          "incorrectCard": "Carta incorrecta jugada",
+          "fiveDeckIsEmpty": "No se puede resolver la habilidad única de un 5 con un mazo vacío"
+        },
+        "seven": {
+          "oneCardInDeck": "No puedes jugar un 7 como carta de habilidad única si es la última carta del mazo",
+          "pickAndPlay": "Solo puedes jugar las cartas superiores del mazo mientras se resuelve un Siete"
+        }
       }
     }
   },

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -250,14 +250,6 @@
         "blockedByQueen": "La Dame de votre adversaire empêche ses autres cartes d'être ciblées.",
         "blockedByMultipleQueens": "Impossible de jouer une capacité cible (2 ou 9) quand votre adversaire a plus d'une dame."
       },
-      "seven": {
-        "pickAndPlay": "Après avoir joué un Sept, vous ne pouvez jouer qu'une carte du paquet."
-      },
-      "five": {
-        "selectCardToDiscard": "Vous devez sélectionner une carte à défausser",
-        "incorrectCard": "Mauvaise carte jouée",
-        "fiveDeckIsEmpty": "Impossible de résoudre 5 points ponctuels avec un deck vide"
-      },
       "draw": {
         "deckIsEmpty": "Le paquet est vide, voune pouvez pas piocher.",
         "handLimit": "Votre limite de carte en main est atteinte !"
@@ -279,13 +271,25 @@
         "mustTargetPointCard": "Les scuttles ne peuvent cibler que les cartes à points."
       },
       "oneOffs": {
-        "scrapIsEmpty": "La capacité du Trois n'est possible que si la corbeille n'est pas vide.",
-        "opponentHasNoCards": "La capacité du Quatre n'est possible que si votre adversaire a des cartes en main.",
-        "emptyDeck": "Vous ne pouvez pas jouer cette carte unique à moins qu'il y ait des cartes dans le deck",
-        "sevenWithOneCardInDeck": "Impossible de jouer la capacité du Sept si c'était la dernière carte du paquet.",
+        "oneOffInPlay": "Une capacité est en cours d'exécution, vous ne pouvez jouer qu'un deux pour contrer.",
         "cantPlayWithoutATarget": "La capacité de cette nécessite de cibler une carte.",
         "onlyTwoOrNine": "La capacité du Deux et du Neuf nécessite de cibler une carte.",
-        "oneOffInPlay": "Une capacité est en cours d'exécution, vous ne pouvez jouer qu'un deux pour contrer."
+        "emptyDeck": "Vous ne pouvez pas jouer cette carte unique à moins qu'il y ait des cartes dans le deck",
+        "three": {
+          "scrapIsEmpty": "La capacité du Trois n'est possible que si la corbeille n'est pas vide."
+        },
+        "four": {
+          "opponentHasNoCards": "La capacité du Quatre n'est possible que si votre adversaire a des cartes en main."
+        },
+        "five": {
+          "selectCardToDiscard": "Vous devez sélectionner une carte à défausser",
+          "incorrectCard": "Mauvaise carte jouée",
+          "fiveDeckIsEmpty": "Impossible de résoudre 5 points ponctuels avec un deck vide"
+        },
+        "seven": {
+          "oneCardInDeck": "Impossible de jouer la capacité du Sept si c'était la dernière carte du paquet.",
+          "pickAndPlay": "Après avoir joué un Sept, vous ne pouvez jouer qu'une carte du paquet."
+        }
       }
     }
   },

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -281,7 +281,7 @@
       "oneOffs": {
         "scrapIsEmpty": "La capacité du Trois n'est possible que si la corbeille n'est pas vide.",
         "opponentHasNoCards": "La capacité du Quatre n'est possible que si votre adversaire a des cartes en main.",
-        "sevenWithEmptyDeck": "La capacité du Sept n'est possible que si le paquet n'est pas vide.",
+        "emptyDeck": "Vous ne pouvez pas jouer cette carte unique à moins qu'il y ait des cartes dans le deck",
         "sevenWithOneCardInDeck": "Impossible de jouer la capacité du Sept si c'était la dernière carte du paquet.",
         "cantPlayWithoutATarget": "La capacité de cette nécessite de cibler une carte.",
         "onlyTwoOrNine": "La capacité du Deux et du Neuf nécessite de cibler une carte.",

--- a/tests/e2e/fixtures/snackbarError.js
+++ b/tests/e2e/fixtures/snackbarError.js
@@ -9,6 +9,7 @@ const SnackBarError = {
   ONE_OFF: {
     THREE_EMPTY_SCRAP: 'You can only play a 3 as a one-off if there are cards in the scrap pile',
     FOUR_EMPTY_HAND: 'You cannot play a 4 as a one-off while your opponent has no cards in hand',
+    EMPTY_DECK: "You can't play that one-off unless there are cards in the deck",
   }
 };
 

--- a/tests/e2e/fixtures/snackbarError.js
+++ b/tests/e2e/fixtures/snackbarError.js
@@ -5,7 +5,11 @@ const SnackBarError = {
   FROZEN_CARD: 'That card is frozen! You must wait a turn to play it',
   NOT_IN_GAME: "You can't do that because you're not a player in this game",
   GAME_IS_FULL: `Cannot join that game because it's already full`,
-  CANT_FIND_GAME: "Can't find game"
+  CANT_FIND_GAME: "Can't find game",
+  ONE_OFF: {
+    THREE_EMPTY_SCRAP: 'You can only play a 3 as a one-off if there are cards in the scrap pile',
+    FOUR_EMPTY_HAND: 'You cannot play a 4 as a one-off while your opponent has no cards in hand',
+  }
 };
 
 export { SnackBarError };

--- a/tests/e2e/specs/in-game/one-offs/3_threes.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/3_threes.spec.js
@@ -8,7 +8,6 @@ describe('Playing THREEs', () => {
   });
 
   it('Plays 3s with no cards in scrap', () => {
-    cy.skipOnGameStateApi();
     // Set Up
     cy.loadGameFixture(0, {
       p0Hand: [Card.ACE_OF_SPADES, Card.THREE_OF_CLUBS],
@@ -22,7 +21,7 @@ describe('Playing THREEs', () => {
     // Player plays three
     cy.get('[data-player-hand-card=3-0]').click(); // three of clubs
     cy.get('[data-move-choice=oneOff]').click();
-    assertSnackbarError('You can only play a 3 as a one-off, if there are cards in the scrap pile');
+    assertSnackbarError('You can only play a 3 as a one-off if there are cards in the scrap pile');
   });
 
   it('Plays 3s successfully', () => {

--- a/tests/e2e/specs/in-game/one-offs/3_threes.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/3_threes.spec.js
@@ -1,5 +1,6 @@
 import { assertGameState, assertSnackbarError, playOutOfTurn } from '../../../support/helpers';
 import { Card } from '../../../fixtures/cards';
+import { SnackBarError } from '../../../fixtures/snackbarError';
 const { _ } = Cypress;
 
 describe('Playing THREEs', () => {
@@ -21,7 +22,7 @@ describe('Playing THREEs', () => {
     // Player plays three
     cy.get('[data-player-hand-card=3-0]').click(); // three of clubs
     cy.get('[data-move-choice=oneOff]').click();
-    assertSnackbarError('You can only play a 3 as a one-off if there are cards in the scrap pile');
+    assertSnackbarError(SnackBarError.ONE_OFF.THREE_EMPTY_SCRAP);
   });
 
   it('Plays 3s successfully', () => {

--- a/tests/e2e/specs/in-game/one-offs/4_fours.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/4_fours.spec.js
@@ -1,5 +1,6 @@
 import { assertGameState, assertSnackbarError } from '../../../support/helpers';
 import { Card } from '../../../fixtures/cards';
+import { SnackBarError } from '../../../fixtures/snackbarError';
 
 describe('FOURS', () => {
   describe('Playing FOURS', () => {
@@ -114,7 +115,7 @@ describe('FOURS', () => {
       cy.get('[data-player-hand-card=4-0]').click(); // four of clubs
       cy.get('[data-move-choice=oneOff]').click();
 
-      assertSnackbarError('You cannot play a 4 as a one-off while your opponent has no cards in hand');
+      assertSnackbarError(SnackBarError.ONE_OFF.FOUR_EMPTY_HAND);
 
       assertGameState(0, {
         p0Hand: [Card.FOUR_OF_CLUBS],

--- a/tests/e2e/specs/in-game/one-offs/4_fours.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/4_fours.spec.js
@@ -99,7 +99,6 @@ describe('FOURS', () => {
     });
 
     it('Prevents playing a 4 when opponent has no cards in hand', () => {
-      cy.skipOnGameStateApi();
       // Set Up
       cy.loadGameFixture(0, {
         p0Hand: [Card.FOUR_OF_CLUBS],

--- a/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
@@ -425,7 +425,7 @@ describe('FIVES', () => {
               );
 
             } catch (err) {
-              expect(err).to.eq('game.snackbar.five.selectCardToDiscard');
+              expect(err).to.eq('game.snackbar.oneOffs.five.selectCardToDiscard');
             }
           });
       });

--- a/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
@@ -415,19 +415,18 @@ describe('FIVES', () => {
         cy.playOneOffAndResolveAsPlayer(Card.FIVE_OF_SPADES);
         cy.window()
           .its('cuttle.gameStore')
-          .then((gameStore) => {
+          .then(async (gameStore) => {
             // Request to resolve five without discarding
-            gameStore
-              .requestResolveFive(undefined)
-              .then((res) => {
-                expect(true).to.eq(
-                  false,
-                  `Expected request to resolve five without discarding to error, but instead came back 200: ${res}`,
-                );
-              })
-              .catch((err) => {
-                expect(err).to.eq('game.snackbar.five.emptyDeck');
-              });
+            try {
+              const res = await gameStore.requestResolveFive(undefined);
+              expect(true).to.eq(
+                false,
+                `Expected request to resolve five without discarding to error, but instead came back 200: ${res}`,
+              );
+
+            } catch (err) {
+              expect(err).to.eq('game.snackbar.five.selectCardToDiscard');
+            }
           });
       });
     });

--- a/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
@@ -350,8 +350,11 @@ describe('FIVES', () => {
           deck: [],
         });
       });
+    });
 
-      it('Attempts to play 5 with an empty deck', () => {
+    describe('Illegal FIVES', () => {
+
+      it('Cannot to play 5 with an empty deck', () => {
         cy.skipOnGameStateApi();
         cy.loadGameFixture(0, {
           // Player is P0
@@ -394,9 +397,7 @@ describe('FIVES', () => {
             }
           });
       });
-    });
 
-    describe('Illegal FIVES', () => {
       it('Cannot resolve five without discarding when you have cards in hand', () => {
         cy.skipOnGameStateApi();
         cy.loadGameFixture(0, {

--- a/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
@@ -367,11 +367,32 @@ describe('FIVES', () => {
           deck: [],
         });
         cy.get('#deck').click();
+        cy.get('#deck').should('contain', '(1)');
+
         cy.drawCardOpponent();
 
         cy.get('#deck').should('contain', 'PASS');
         cy.get('[data-player-hand-card=5-3]').click();
         cy.get('[data-move-choice=oneOff]').should('have.class', 'v-card--disabled');
+
+        // Forcibly make request to play 5 and confirm response is error
+        cy.window()
+          .its('cuttle.gameStore')
+          .then(async (gameStore) => {
+            const fiveId = gameStore.player.hand.find((card) => card.rank === 5 && card.suit === 3).id;
+
+            try {
+              const res = await gameStore.requestPlayOneOff(fiveId);
+              // If the promise resolves, this assertion will fail the test (as expected in your case)
+              expect(true).to.eq(
+                false,
+                `Expected request to resolve five without discarding to error, but instead came back 200: ${res}`,
+              );
+            } catch (err) {
+              // If the promise rejects, this will handle the error
+              expect(err).to.eq('game.snackbar.oneOffs.emptyDeck');
+            }
+          });
       });
     });
 
@@ -404,7 +425,7 @@ describe('FIVES', () => {
                 );
               })
               .catch((err) => {
-                expect(err).to.eq('game.snackbar.five.selectCardToDiscard');
+                expect(err).to.eq('game.snackbar.five.emptyDeck');
               });
           });
       });

--- a/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
@@ -1,5 +1,6 @@
 import { assertGameState, assertSnackbarError } from '../../../../support/helpers';
 import { Card } from '../../../../fixtures/cards';
+import { SnackBarError } from '../../../../fixtures/snackbarError';
 
 describe('Playing SEVENS', () => {
   beforeEach(() => {
@@ -539,7 +540,7 @@ describe('Playing SEVENS', () => {
       // Should not allow playing 4 as one-off
       cy.get('#waiting-for-opponent-counter-scrim').should('not.exist');
       cy.get('#waiting-for-opponent-discard-scrim').should('not.exist');
-      assertSnackbarError('You cannot play a 4 as a ONE-OFF while your opponent has no cards in hand');
+      assertSnackbarError(SnackBarError.ONE_OFF.FOUR_EMPTY_HAND);
     });
   }); // End player seven one-off describe
 


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number
Applies i18n to error messages from the legacy api's `untargetedOneOff` and `targetedOneOff` endpoints, and reconciles them with their /seven counterpoints. Applies the translated errors to the GameStateAPI's `oneOff/validate` and `oneOff/execute` helpers.


Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #1040 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
