### PR TITLE
test(winConditions.spec): add it('Shows when player wins game with 21…

### DIFF
--- a/tests/e2e/specs/in-game/game-over/winConditions.spec.js
+++ b/tests/e2e/specs/in-game/game-over/winConditions.spec.js
@@ -19,7 +19,6 @@ describe('Winning the game', () => {
   });
 
   it('Shows when player wins game with 21 points', () => {
-    cy.skipOnGameStateApi();
     cy.loadGameFixture(0, {
       p0Hand: [Card.SEVEN_OF_CLUBS],
       p0Points: [Card.SEVEN_OF_DIAMONDS, Card.SEVEN_OF_HEARTS],


### PR DESCRIPTION
… points') to gamestate test scope

<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
No issue; just realized we can run this test in the gamestate api so I'm adding to to CI scope

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
