### PR TITLE
chore: rename cardPlayed to playedCard across validate() helpers

### DIFF
--- a/api/helpers/gamestate/moves/counter/validate.js
+++ b/api/helpers/gamestate/moves/counter/validate.js
@@ -41,8 +41,8 @@ module.exports = {
       }
 
       const player = playedBy ? currentState.p1 : currentState.p0;
-      const cardPlayed = player.hand.find(({ id }) => requestedMove.cardId === id);
-      if (!cardPlayed) {
+      const playedCard = player.hand.find(({ id }) => requestedMove.cardId === id);
+      if (!playedCard) {
         throw new Error('game.snackbar.global.playFromHand');
       }
 

--- a/api/helpers/gamestate/moves/face-card/validate.js
+++ b/api/helpers/gamestate/moves/face-card/validate.js
@@ -32,17 +32,17 @@ module.exports = {
     try {
       const player = playedBy ? currentState.p1 : currentState.p0;
 
-      const cardPlayed = player.hand.find(({ id }) => id === requestedMove.cardId);
+      const playedCard = player.hand.find(({ id }) => id === requestedMove.cardId);
 
       if (currentState.phase !== GamePhase.MAIN) {
         throw new Error(`Can only play face card in main phase, not ${currentState.phase}`);
       }
 
-      if (!cardPlayed) {
+      if (!playedCard) {
         throw new Error('game.snackbar.global.playFromHand');
       }
 
-      if (cardPlayed.isFrozen) {
+      if (playedCard.isFrozen) {
         throw new Error('game.snackbar.global.cardFrozen');
       }
 
@@ -50,7 +50,7 @@ module.exports = {
         throw new Error('game.snackbar.global.notYourTurn');
       }
 
-      if (![8, 12, 13].includes(cardPlayed.rank)) {
+      if (![8, 12, 13].includes(playedCard.rank)) {
         throw new Error('game.snackbar.faceCard.withoutTarget');
       }
 

--- a/api/helpers/gamestate/moves/one-off/validate.js
+++ b/api/helpers/gamestate/moves/one-off/validate.js
@@ -59,7 +59,7 @@ module.exports = {
       const player = playedBy ? currentState.p1 : currentState.p0;
       const opponent = playedBy ? currentState.p0 : currentState.p1;
 
-      const cardPlayed = player.hand.find(({ id }) => id === requestedMove.cardId);
+      const playedCard = player.hand.find(({ id }) => id === requestedMove.cardId);
 
       if (currentState.phase !== GamePhase.MAIN) {
         throw new Error(`Can only play one-off in main phase, not ${currentState.phase}`);
@@ -69,7 +69,7 @@ module.exports = {
         throw new Error('game.snackbar.oneOffs.oneOffInPlay');
       }
 
-      if (!cardPlayed) {
+      if (!playedCard) {
         throw new Error('game.snackbar.global.playFromHand');
       }
 
@@ -77,11 +77,11 @@ module.exports = {
         throw new Error('game.snackbar.global.notYourTurn');
       }
 
-      if (cardPlayed.isFrozen) {
+      if (playedCard.isFrozen) {
         throw new Error('game.snackbar.global.cardFrozen');
       }
 
-      switch (cardPlayed.rank) {
+      switch (playedCard.rank) {
         // Ace and Six are always allowed
         case 1:
         case 6:
@@ -97,7 +97,7 @@ module.exports = {
               throw new Error(`Can't find the ${requestedMove.targetId} on opponent's board`);
             }
 
-            if (cardPlayed.rank === 2 && !['faceCard', 'jack'].includes(requestedMove.targetType)) {
+            if (playedCard.rank === 2 && !['faceCard', 'jack'].includes(requestedMove.targetType)) {
               throw new Error('Twos can only target royals or glasses');
             }
 

--- a/api/helpers/gamestate/moves/points/validate.js
+++ b/api/helpers/gamestate/moves/points/validate.js
@@ -32,17 +32,17 @@ module.exports = {
     try {
       const playerKey = playedBy ? 'p1' : 'p0';
 
-      const cardPlayed = currentState[playerKey].hand.find(({ id }) => id === requestedMove.cardId);
+      const playedCard = currentState[playerKey].hand.find(({ id }) => id === requestedMove.cardId);
 
       if (currentState.phase !== GamePhase.MAIN) {
         throw new Error(`Can only play points in main phase, not ${currentState.phase}`);
       }
 
-      if (!cardPlayed) {
+      if (!playedCard) {
         throw new Error('game.snackbar.global.playFromHand');
       }
 
-      if (cardPlayed.isFrozen) {
+      if (playedCard.isFrozen) {
         throw new Error('game.snackbar.global.cardFrozen');
       }
 
@@ -50,7 +50,7 @@ module.exports = {
         throw new Error('game.snackbar.global.notYourTurn');
       }
 
-      if (cardPlayed.rank > 10) {
+      if (playedCard.rank > 10) {
         throw new Error('game.snackbar.points.numberOnlyForPoints');
       }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
The `/validate.js` helpers had been copying the inconsistent variable name `cardPlayed` while the `GameState` and `GameStateRow` values actually used by the `execute()` and `saveGameState()` helpers use the name `playedCard` (as it's more consistent with `targetCard`. This PR renames all instances of `cardPlayed` to `playedCard` to match


## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
No issue - small name change

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
