### PR TITLE
Fix/five announcement styles

### DIFF
--- a/src/routes/home/components/announcementDialog/AnnouncementDialog.vue
+++ b/src/routes/home/components/announcementDialog/AnnouncementDialog.vue
@@ -20,7 +20,7 @@
       </v-btn>
     </template>
     <template #body>
-      <div v-if="announcementData.displayCards.length" class="cards d-flex my-4">
+      <div v-if="announcementData.displayCards.length" class="cards d-flex justify-center my-4">
         <GameCard
           v-for="card in announcementData.displayCards"
           :key="card.suit + card.rank"

--- a/src/routes/home/components/announcementDialog/data/announcementData.js
+++ b/src/routes/home/components/announcementDialog/data/announcementData.js
@@ -3,7 +3,7 @@ import { Card } from '../../../../../../tests/e2e/fixtures/cards';
 export const announcementData = {
   id: 'recyclerFivesPermanent',
   activatorText: 'Recycler Fives are here to stay!',
-  title: 'Keeping Recycler Fives',
+  title: 'Recycler Fives',
   imgSrc: null,
   displayCards: [Card.FIVE_OF_CLUBS, Card.FIVE_OF_DIAMONDS, Card.FIVE_OF_HEARTS, Card.FIVE_OF_SPADES],
   announcementText: [

--- a/src/routes/home/components/announcementDialog/data/announcementData.js
+++ b/src/routes/home/components/announcementDialog/data/announcementData.js
@@ -5,7 +5,7 @@ export const announcementData = {
   activatorText: 'Recycler Fives are here to stay!',
   title: 'Keeping Recycler Fives',
   imgSrc: null,
-  displayCards: [Card.FIVE_OF_CLUBS, Card.FIVE_OF_CLUBS, Card.FIVE_OF_CLUBS, Card.FIVE_OF_CLUBS],
+  displayCards: [Card.FIVE_OF_CLUBS, Card.FIVE_OF_DIAMONDS, Card.FIVE_OF_HEARTS, Card.FIVE_OF_SPADES],
   announcementText: [
     {
       heading: 'Recycler Fives are here to stay',


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes alignment, title length, and card selection for five announcment:
<img width="504" alt="image" src="https://github.com/user-attachments/assets/789da340-41f1-4f7b-ba59-57ca68c17b15">

Now looks like this:
<img width="497" alt="image" src="https://github.com/user-attachments/assets/43d8b774-cb97-42a3-b1d8-ac15e4b6d01c">

## Issue number
N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
