### PR TITLE
fix: set playedCard and targetCard to null when appropriate

### DIFF
--- a/api/helpers/gamestate/moves/draw/execute.js
+++ b/api/helpers/gamestate/moves/draw/execute.js
@@ -38,6 +38,8 @@ module.exports = {
       ...requestedMove,
       phase: GamePhase.MAIN,
       playedBy,
+      playedCard: null,
+      targetCard: null,
     };
 
     return exits.success(result);

--- a/api/helpers/gamestate/moves/face-card/execute.js
+++ b/api/helpers/gamestate/moves/face-card/execute.js
@@ -45,6 +45,7 @@ module.exports = {
       phase: GamePhase.MAIN,
       playedBy,
       playedCard,
+      targetCard: null,
     };
 
     return exits.success(result);

--- a/api/helpers/gamestate/moves/pass/execute.js
+++ b/api/helpers/gamestate/moves/pass/execute.js
@@ -35,6 +35,8 @@ module.exports = {
       ...requestedMove,
       phase: GamePhase.MAIN,
       playedBy,
+      playedCard: null,
+      targetCard: null,
     };
     return exits.success(result);
   },

--- a/api/helpers/gamestate/moves/points/execute.js
+++ b/api/helpers/gamestate/moves/points/execute.js
@@ -42,6 +42,7 @@ module.exports = {
       phase: GamePhase.MAIN,
       playedBy,
       playedCard: player.points.at(-1),
+      targetCard: null,
     };
 
     return exits.success(result);

--- a/api/helpers/gamestate/moves/seven-points/execute.js
+++ b/api/helpers/gamestate/moves/seven-points/execute.js
@@ -42,10 +42,11 @@ module.exports = {
       ...result,
       ...requestedMove,
       phase: GamePhase.MAIN,
+      oneOff: null,
       playedBy,
       playedCard,
+      targetCard: null,
       resolved: oneOff,
-      oneOff: null,
     };
 
     return exits.success(result);


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes bug where `playedCard` and `targetCard` would carry over between moves

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #1061 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
