### PR TITLE
Fix/resolve increment turn on fizzle

### DIFF
--- a/api/helpers/game-states/moves/resolve/execute.js
+++ b/api/helpers/game-states/moves/resolve/execute.js
@@ -50,6 +50,7 @@ module.exports = {
     if (fizzles) {
       result.moveType = MoveType.FIZZLE;
       result.scrap.push(result.oneOff);
+      result.turn++;
       return exits.success(result);
     }
 

--- a/tests/e2e/specs/in-game/one-offs/0_countering.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/0_countering.spec.js
@@ -332,22 +332,21 @@ describe('Countering One-Offs P0 Perspective', () => {
     cy.setupGameAsP0();
   });
 
-  it('Can counter a three', () => {
-    cy.skipOnGameStateApi();
+  it('Increments turn when one-off fizzles', () => {
     cy.loadGameFixture(0, {
       // Player is P0
-      p0Hand: [Card.FIVE_OF_CLUBS, Card.FOUR_OF_SPADES],
+      p0Hand: [Card.THREE_OF_CLUBS, Card.FOUR_OF_SPADES],
       p0Points: [Card.TEN_OF_SPADES, Card.ACE_OF_SPADES],
       p0FaceCards: [Card.KING_OF_SPADES],
       // Opponent is P1
       p1Hand: [Card.ACE_OF_HEARTS, Card.TWO_OF_SPADES, Card.SIX_OF_CLUBS],
       p1Points: [Card.TEN_OF_HEARTS, Card.ACE_OF_DIAMONDS],
-      p1FaceCards: [Card.KING_OF_HEARTS],
+      p1FaceCards: [],
       scrap: [Card.QUEEN_OF_CLUBS],
     });
 
     // Player plays three of clubs as one-off
-    cy.get('[data-player-hand-card=5-0]').click();
+    cy.get('[data-player-hand-card=3-0]').click();
     cy.get('[data-move-choice=oneOff]').click();
 
     // Opponent counters and player resolves
@@ -355,30 +354,22 @@ describe('Countering One-Offs P0 Perspective', () => {
     cy.get('#cannot-counter-dialog').should('be.visible').get('[data-cy=cannot-counter-resolve]').click();
 
     // No longer player turn
-    cy.get('[data-player-hand-card=4-3]').click(); // king of clubs
+    cy.get('[data-player-hand-card=4-3]').click(); // Four of Spades
     playOutOfTurn('points');
 
-    // Opponent plays a Six
-    cy.playOneOffOpponent(Card.SIX_OF_CLUBS);
-    cy.get('#cannot-counter-dialog').should('be.visible').get('[data-cy=cannot-counter-resolve]').click();
+    // Opponent plays a six
+    cy.playPointsOpponent(Card.SIX_OF_CLUBS);
 
-    assertGameState(0, {
+    cy.loadGameFixture(0, {
       // Player is P0
       p0Hand: [Card.FOUR_OF_SPADES],
       p0Points: [Card.TEN_OF_SPADES, Card.ACE_OF_SPADES],
-      p0FaceCards: [],
+      p0FaceCards: [Card.KING_OF_SPADES],
       // Opponent is P1
       p1Hand: [Card.ACE_OF_HEARTS],
-      p1Points: [Card.TEN_OF_HEARTS, Card.ACE_OF_DIAMONDS],
+      p1Points: [Card.TEN_OF_HEARTS, Card.ACE_OF_DIAMONDS, Card.SIX_OF_CLUBS],
       p1FaceCards: [],
-      scrap: [
-        Card.QUEEN_OF_CLUBS,
-        Card.FIVE_OF_CLUBS,
-        Card.KING_OF_SPADES,
-        Card.SIX_OF_CLUBS,
-        Card.KING_OF_HEARTS,
-        Card.TWO_OF_SPADES,
-      ],
+      scrap: [Card.QUEEN_OF_CLUBS, Card.THREE_OF_CLUBS, Card.TWO_OF_SPADES],
     });
   });
 

--- a/tests/e2e/specs/in-game/one-offs/0_countering.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/0_countering.spec.js
@@ -332,7 +332,7 @@ describe('Countering One-Offs P0 Perspective', () => {
     cy.setupGameAsP0();
   });
 
-  it.only('Increments turn when one-off fizzles', () => {
+  it('Increments turn when one-off fizzles', () => {
     cy.loadGameFixture(0, {
       // Player is P0
       p0Hand: [Card.THREE_OF_CLUBS, Card.FOUR_OF_SPADES],

--- a/tests/e2e/specs/in-game/one-offs/0_countering.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/0_countering.spec.js
@@ -332,7 +332,7 @@ describe('Countering One-Offs P0 Perspective', () => {
     cy.setupGameAsP0();
   });
 
-  it('Increments turn when one-off fizzles', () => {
+  it.only('Increments turn when one-off fizzles', () => {
     cy.loadGameFixture(0, {
       // Player is P0
       p0Hand: [Card.THREE_OF_CLUBS, Card.FOUR_OF_SPADES],
@@ -360,7 +360,7 @@ describe('Countering One-Offs P0 Perspective', () => {
     // Opponent plays a six
     cy.playPointsOpponent(Card.SIX_OF_CLUBS);
 
-    cy.loadGameFixture(0, {
+    assertGameState(0, {
       // Player is P0
       p0Hand: [Card.FOUR_OF_SPADES],
       p0Points: [Card.TEN_OF_SPADES, Card.ACE_OF_SPADES],


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes bug in GameState API where the turn doesn't increment when the one-off fizzles
Renames and reworks test case `it('can counter a three')` to `it('Increments turn when one-off fizzles')`

These failures were brought to light by #1059 


## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
