### PR TITLE
Fix/empty deck snackbar conditional

### DIFF
--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -750,7 +750,7 @@ export default {
       });
     },
     topCard(newTopCard, oldTopCard) {
-      if (oldTopCard && !newTopCard) {
+      if (this.gameStore.id && oldTopCard && !newTopCard) {
         this.showCustomSnackbarMessage('game.snackbar.draw.exhaustedDeck');
       }
     }

--- a/tests/e2e/specs/in-game/game-over/rematch.spec.js
+++ b/tests/e2e/specs/in-game/game-over/rematch.spec.js
@@ -269,6 +269,10 @@ describe('Creating And Updating Casual Games With Rematch', () => {
     // Game 2: Player concedes
     startRematchPlayerFirst();
     cy.get('[data-player-hand-card]').should('have.length', 6);
+
+    // Snackbar about empty deck should not appear
+    cy.get('[data-cy=game-snackbar] .v-snackbar__wrapper').should('not.exist');
+
     concedePlayer();
     assertLoss({ wins: 1, losses: 1, stalemates: 0 });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes bug where snackbar to alert players of an empty deck would appear at the beginning of a game during a rematch:
<img width="872" alt="image" src="https://github.com/user-attachments/assets/0f7ea1b0-6508-438f-bad3-27a6f01135a8">



## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
