### PR TITLE
Revert "Added .gitattributes to enforce LF line endings"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf


### PR DESCRIPTION
Reverts cuttle-cards/cuttle#1084

Reverting because this somehow seems to have corrupted all png's and caused other git problems. This needs further investigation