### PR TITLE
Feat #945 Add refresh to game menu

### DIFF
--- a/src/routes/game/components/GameMenu.vue
+++ b/src/routes/game/components/GameMenu.vue
@@ -31,8 +31,11 @@
           <v-list-item data-cy="stalemate-initiate" @click="shownDialog = 'stalemate'">
             {{ t('game.menus.gameMenu.stalemate') }}
           </v-list-item>
-          <TheLanguageSelector />
         </template>
+        <TheLanguageSelector />
+        <v-list-item data-cy="refesh" prepend-icon="mdi-refresh" @click="refresh">
+          {{ t('game.menus.gameMenu.refresh') }}
+        </v-list-item>
       </v-list>
     </v-menu>
 
@@ -74,6 +77,7 @@
 import { useI18n } from 'vue-i18n';
 import { mapStores } from 'pinia';
 import { useGameStore } from '@/stores/game';
+import { useAuthStore } from '@/stores/auth';
 import BaseDialog from '@/components/BaseDialog.vue';
 import RulesDialog from '@/routes/game/components/dialogs/components/RulesDialog.vue';
 import TheLanguageSelector from '@/components/TheLanguageSelector.vue';
@@ -103,6 +107,7 @@ export default {
   },
   computed: {
     ...mapStores(useGameStore),
+    ...mapStores(useAuthStore),
     showEndGameDialog:{
       get() {
         return this.showConcedeDialog || this.showStalemateDialog;
@@ -181,6 +186,9 @@ export default {
         this.$router.push('/');
       }
     },
+    async refresh() {
+      await this.authStore.requestStatus();
+    }
   },
 };
 </script>

--- a/src/routes/game/components/GameMenu.vue
+++ b/src/routes/game/components/GameMenu.vue
@@ -33,7 +33,7 @@
           </v-list-item>
         </template>
         <TheLanguageSelector />
-        <v-list-item data-cy="refesh" prepend-icon="mdi-refresh" @click="refresh">
+        <v-list-item data-cy="refresh" prepend-icon="mdi-refresh" @click="refresh">
           {{ t('game.menus.gameMenu.refresh') }}
         </v-list-item>
       </v-list>

--- a/src/routes/game/components/GameMenu.vue
+++ b/src/routes/game/components/GameMenu.vue
@@ -187,7 +187,7 @@ export default {
       }
     },
     async refresh() {
-      await this.authStore.requestStatus();
+      await this.authStore.reconnectSocket();
     }
   },
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -217,6 +217,7 @@
     },
     "menus": {
       "gameMenu": {
+        "refresh": "Refresh",
         "rules": "Rules",
         "concede": "Concede",
         "stalemate": "Request Stalemate",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -217,7 +217,7 @@
     },
     "menus": {
       "gameMenu": {
-        "refresh": "refrescar",
+        "refresh": "Refrescar",
         "rules": "Reglas",
         "concede": "Conceder",
         "stalemate": "Solicitud de empate",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -217,6 +217,7 @@
     },
     "menus": {
       "gameMenu": {
+        "refresh": "refrescar",
         "rules": "Reglas",
         "concede": "Conceder",
         "stalemate": "Solicitud de empate",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -217,7 +217,7 @@
     },
     "menus": {
       "gameMenu": {
-        "refresh": "actualiser",
+        "refresh": "Actualiser",
         "rules": "Règles",
         "concede": "Déclarer forfait",
         "stalemate": "Proposer match nul",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -217,6 +217,7 @@
     },
     "menus": {
       "gameMenu": {
+        "refresh": "actualiser",
         "rules": "Règles",
         "concede": "Déclarer forfait",
         "stalemate": "Proposer match nul",

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -3,6 +3,45 @@ import { myUser, opponentOne } from '../../fixtures/userFixtures';
 import { Card } from '../../fixtures/cards';
 
 describe('Reconnecting to a game', () => {
+  it('Refreshs Game from Game Menu', () => {
+    cy.setupGameAsP1();
+    cy.loadGameFixture(1, {
+      p0Hand: [Card.ACE_OF_CLUBS, Card.SEVEN_OF_DIAMONDS],
+      p0Points: [Card.SEVEN_OF_HEARTS],
+      p0FaceCards: [],
+      p1Hand: [Card.TEN_OF_DIAMONDS],
+      p1Points: [],
+      p1FaceCards: [],
+    });
+
+    cy.window()
+      .its('cuttle.authStore')
+      .then((store) => store.disconnectSocket());
+
+    cy.playPointsOpponent(Card.SEVEN_OF_DIAMONDS);
+
+    assertGameState(1, {
+      p0Hand: [Card.ACE_OF_CLUBS, Card.SEVEN_OF_DIAMONDS],
+      p0Points: [Card.SEVEN_OF_HEARTS],
+      p0FaceCards: [],
+      p1Hand: [Card.TEN_OF_DIAMONDS],
+      p1Points: [],
+      p1FaceCards: [],
+    });
+
+    cy.get('#game-menu-activator').click();
+    cy.get('[data-cy=refresh]').click();
+
+    assertGameState(1, {
+      p0Hand: [Card.ACE_OF_CLUBS],
+      p0Points: [Card.SEVEN_OF_HEARTS, Card.SEVEN_OF_DIAMONDS],
+      p0FaceCards: [],
+      p1Hand: [Card.TEN_OF_DIAMONDS],
+      p1Points: [],
+      p1FaceCards: [],
+    });
+  });
+
   it('Persists session after refreshing the page', () => {
     cy.skipOnGameStateApi();
     cy.setupGameAsP0();

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -4,6 +4,7 @@ import { Card } from '../../fixtures/cards';
 
 describe('Reconnecting to a game', () => {
   it('Refreshs Game from Game Menu', () => {
+    cy.skipOnGameStateApi();
     cy.setupGameAsP1();
     cy.loadGameFixture(1, {
       p0Hand: [Card.ACE_OF_CLUBS, Card.SEVEN_OF_DIAMONDS],


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #945 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
-Added refresh option in game menu and added translations
-Added corresponding test