### PR TITLE
Feat/seven discard

### DIFF
--- a/api/helpers/game-states/get-log.js
+++ b/api/helpers/game-states/get-log.js
@@ -147,6 +147,9 @@ module.exports = {
           }
           return `${player} stole ${opponent}'s ${targetCardName} with the ${playedCardName} from the top of the deck.`;
 
+        case MoveType.SEVEN_DISCARD:
+          return `${player} discarded the ${playedCardName} since neither of the top two cards could be played.`;
+
         case MoveType.SEVEN_UNTARGETED_ONE_OFF:
           return `${player} played the ${playedCardName} from the top of the deck as a one-off to ${
             gameText.moves.effects[playedCard.rank]

--- a/api/helpers/game-states/moves/seven-discard/execute.js
+++ b/api/helpers/game-states/moves/seven-discard/execute.js
@@ -1,20 +1,20 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
 
 module.exports = {
-  friendlyName: 'Play a Jack via a seven',
+  friendlyName: 'Discard a Jack via a seven',
 
-  description: 'Returns new GameState resulting from requested move',
+  description: 'Returns new GameState resulting discarding the played card (due to being unable to play card to resolve a previous seven, when both of the top two cards were jacks which could not be played)',
 
   inputs: {
     currentState: {
       type: 'ref',
-      description: 'The latest gameState before playing Jack from the seven',
+      description: 'The latest gameState before discarding Jack from the seven',
       required: true,
     },
     /**
      * @param { Object } requestedMove - The move being requested.
      * @param { String } requestedMove.cardId - Card Played (Jack)
-     * @param { String } [ requestedMove.targetId ] - Opponent's point card targeted by the jack
+     * @param { MoveType.SEVEN_DISCARD } requestedMove.moveType - Specifies that this a sevenDiscard
      */
     requestedMove: {
       type: 'ref',
@@ -32,28 +32,15 @@ module.exports = {
   fn: ({ currentState, requestedMove, playedBy }, exits) => {
     let result = _.cloneDeep(currentState);
 
-    const { cardId, targetId } = requestedMove;
-
-    const player = playedBy ? result.p1 : result.p0;
-    const opponent = playedBy ? result.p0 : result.p1;
-
+    const { cardId } = requestedMove;
     const cardIndex = result.deck.findIndex(({ id }) => id === cardId);
-    const targetIndex = opponent.points.findIndex(({ id }) => id === targetId);
 
-    // Remove card from the deck
+    // Remove discarded card from the deck
     const [ playedCard ] = result.deck.splice(cardIndex, 1);
 
-    // Remove target card from oppponent's points
-    const [ targetCard ] = opponent.points.splice(targetIndex, 1);
-
-    // Add jack (playedCard) to targetCard's attachment
-    targetCard.attachments.push(playedCard);
-
-    // Add targetCard to player's points
-    player.points.push(targetCard);
-    // Scrap oneOff
+    // Scrap oneOff and playedCard
     const { oneOff } = result;
-    result.scrap.push(oneOff);
+    result.scrap.push(oneOff, playedCard);
 
     result.turn++;
 
@@ -63,7 +50,6 @@ module.exports = {
       phase: GamePhase.MAIN,
       playedBy,
       playedCard,
-      targetCard,
       resolved: oneOff,
       oneOff: null,
     };

--- a/api/helpers/game-states/moves/seven-discard/validate.js
+++ b/api/helpers/game-states/moves/seven-discard/validate.js
@@ -1,0 +1,74 @@
+const GamePhase = require('../../../../../utils/GamePhase.json');
+
+module.exports = {
+  friendlyName: 'Validate request to seven-discard',
+
+  description: 'Verifies whether a request to discard a jack via a seven is legal (because no cards can be played), throwing an explanatory error if not.',
+
+  inputs: {
+    currentState: {
+      type: 'ref',
+      description: 'Object containing the current game state',
+      required: true,
+    },
+    /**
+     * @param { Object } requestedMove - Object describing the request to play jack from the top of the deck
+     * @param { String } requestedMove.cardId - The jack from the top of the deck
+     * @param { MoveType.SEVEN_DISCARD } requestedMove.moveType - Specifies that this a sevenDiscard
+     */
+    requestedMove: {
+      type: 'ref',
+      description: 'Object describing the request to discard jack via a seven',
+      required: true,
+    },
+    playedBy: {
+      type: 'number',
+      description: 'Player number of player requesting the move',
+      required: true,
+    },
+  },
+
+  sync: true,
+
+  fn: ({ requestedMove, currentState, playedBy }, exits) => {
+    try {
+      // Determine opponent (opponent is the other player)
+      const opponent = playedBy ? currentState.p0 : currentState.p1;
+
+      // Get the top two cards from the deck
+      const topTwoCards = currentState.deck.slice(0, 2);
+      const playedCard = topTwoCards.find(({ id }) => id === requestedMove.cardId);
+
+      // Check if it's the player's turn
+      if (currentState.turn % 2 !== playedBy) {
+        throw new Error('game.snackbar.global.notYourTurn');
+      }
+
+      // Check if the game phase is RESOLVING_SEVEN
+      if (currentState.phase !== GamePhase.RESOLVING_SEVEN) {
+        throw new Error('game.snackbar.seven.wrongPhase');
+      }
+
+      // Check if the playedCard is one of the top two cards
+      if (!playedCard) {
+        throw new Error('game.snackbar.seven.pickAndPlay');
+      }
+
+      // Top 2 cards must both be jacks
+      if (topTwoCards.some((card) => card.rank !== 11)) {
+        throw new Error('game.snackbar.jack.stealOnlyPointCards');
+      }
+
+      // Jacks must be unplayable due to queen or lack of points
+      const queenCount = opponent.faceCards.filter(({ rank }) => rank === 12).length;
+      const pointCount = opponent.points.length;
+      if (queenCount === 0 && pointCount > 0) {
+        throw new Error('game.snackbar.jack.jacksMustBeUnplayable');
+      }
+
+      return exits.success();
+    } catch (err) {
+      return exits.error(err);
+    }
+  },
+};

--- a/api/helpers/game-states/moves/seven-discard/validate.js
+++ b/api/helpers/game-states/moves/seven-discard/validate.js
@@ -56,7 +56,7 @@ module.exports = {
 
       // Top 2 cards must both be jacks
       if (topTwoCards.some((card) => card.rank !== 11)) {
-        throw new Error('game.snackbar.jack.stealOnlyPointCards');
+        throw new Error('game.snackbar.jack.mustBeDoubleJacks');
       }
 
       // Jacks must be unplayable due to queen or lack of points

--- a/api/policies/hasValidMoveBody.js
+++ b/api/policies/hasValidMoveBody.js
@@ -13,18 +13,20 @@ module.exports = function (req, res, next) {
   const { moveType, cardId, cardId1, cardId2, targetId, targetType } = req.body;
 
   switch (moveType) {
+    // These moves require no extra data
     case MoveType.PASS:
     case MoveType.DRAW:
     case MoveType.RESOLVE:
     case MoveType.RESOLVE_FIVE: 
-      // These moves require no extra data
       return next();
 
+    // These require a `cardId`
     case MoveType.POINTS:
     case MoveType.FACE_CARD:
     case MoveType.SEVEN_POINTS:
     case MoveType.COUNTER:
     case MoveType.RESOLVE_THREE:
+    case MoveType.SEVEN_DISCARD:
       {
         if (!cardId) {
           return res.badRequest({ message: 'Must specify a card' });
@@ -35,7 +37,8 @@ module.exports = function (req, res, next) {
         }
       }
       return next();
-    
+
+    // Requires `card1` and optionally accepts `card2`
     case MoveType.RESOLVE_FOUR:
       {
         if (!cardId1) {
@@ -52,6 +55,7 @@ module.exports = function (req, res, next) {
       }
       return next();
 
+    // These require `cardId` and `targetId`
     case MoveType.JACK:
     case MoveType.SCUTTLE:
     case MoveType.SEVEN_SCUTTLE:
@@ -68,6 +72,7 @@ module.exports = function (req, res, next) {
       }
       return next();
 
+    // Requires `cardId`; additionally requires `targetId` and `targetType` if cardId specifies a 2 or 9
     case MoveType.ONE_OFF:
       {
         if (!cardId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cuttle",
-  "version": "10.30.2",
+  "version": "10.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cuttle",
-      "version": "10.30.2",
+      "version": "10.31.0",
       "dependencies": {
         "chart.js": "4.4.4",
         "connect-redis": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cuttle",
   "description": "The deepest card game under the sea",
-  "version": "10.30.2",
+  "version": "10.31.0",
   "dependencies": {
     "chart.js": "4.4.4",
     "connect-redis": "6.1.3",

--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -120,6 +120,7 @@ export async function handleInGameEvents(evData) {
     case SocketEvent.SEVEN_POINTS:
     case SocketEvent.SEVEN_FACE_CARD:
     case SocketEvent.SEVEN_JACK:
+    case SocketEvent.SEVEN_DISCARD:
     case SocketEvent.SEVEN_SCUTTLE:
       gameStore.resetPNumIfNullThenUpdateGame(evData.game);
       gameStore.playingFromDeck = false;

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -654,12 +654,13 @@ export const useGameStore = defineStore('game', {
       this.myTurnToCounter = false;
 
       await this.makeSocketRequest('seven/jack', {
-        moveType: MoveType.SEVEN_JACK,
+        moveType: MoveType.SEVEN_DISCARD,
         cardId,
         index, // 0 if topCard, 1 if secondCard
-        targetId: -1, // -1 for the double jacks with no points to steal case
-        opId: this.opponent.id,
+        targetId: -1, // FIXME: Remove in #965
+        opId: this.opponent.id, // FIXME: Remove in #965
       });
+
     },
 
     async requestPlayFaceCardSeven({ index, cardId }) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -298,7 +298,9 @@
         "seven": {
           "oneCardInDeck": "You cannot play a 7 as a ONE-OFF if it is the last card in the deck",
           "pickAndPlay": "You can only play cards from the top of the deck while resolving a seven.",
-          "wrongPhase": "You can't play from the deck right now"
+          "wrongPhase": "You can't play from the deck right now",
+          "mustBeDoubleJacks": "You can't discard from a seven unless both cards are jacks",
+          "jacksMustBeUnplayable": "You can't discard because the jacks can be played"
         }
       }
     }

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -298,7 +298,9 @@
         "seven": {
           "oneCardInDeck": "No puedes jugar un 7 como carta de habilidad única si es la última carta del mazo",
           "pickAndPlay": "Solo puedes jugar las cartas superiores del mazo mientras se resuelve un Siete",
-          "wrongPhase": "No puedes jugar desde el mazo en este momento"
+          "wrongPhase": "No puedes jugar desde el mazo en este momento",
+          "mustBeDoubleJacks": "No puedes descartar desde un siete a menos que ambas cartas sean jotas",
+          "jacksMustBeUnplayable": "No puedes descartar porque las jotas se pueden jugar"
         }
       }
     }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -298,7 +298,9 @@
         "seven": {
           "oneCardInDeck": "Impossible de jouer la capacité du Sept si c'était la dernière carte de la pioche.",
           "pickAndPlay": "Après avoir joué un Sept, vous ne pouvez jouer qu'une carte de la pioche.",
-          "wrongPhase": "Vous ne pouvez pas jouer depuis le paquet pour le moment"
+          "wrongPhase": "Vous ne pouvez pas jouer depuis le paquet pour le moment",
+          "mustBeDoubleJacks": "Vous ne pouvez pas défausser depuis un sept sauf si les deux cartes sont des valets",
+          "jacksMustBeUnplayable": "Vous ne pouvez pas défausser parce que les valets peuvent être joués"
         }
       }
     }

--- a/tests/e2e/specs/in-game/one-offs/7_sevens/opponent_sevens.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/7_sevens/opponent_sevens.spec.js
@@ -106,7 +106,6 @@ describe('Opponent playing SEVENS', () => {
   });
 
   it('Plays jack from a seven - special case - opponent plays seven into double jacks with no points to steal', () => {
-    cy.skipOnGameStateApi();
     cy.setupGameAsP1();
     cy.loadGameFixture(1, {
       p0Hand: [ Card.SEVEN_OF_CLUBS ],
@@ -138,7 +137,7 @@ describe('Opponent playing SEVENS', () => {
       .click({ force: true })
       .should('not.have.class', 'selected');
 
-    cy.playJackFromSevenOpponent(Card.JACK_OF_CLUBS, -1);
+    cy.sevenDiscardOpponent(Card.JACK_OF_CLUBS);
 
     assertGameState(0, {
       p0Hand: [],

--- a/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
@@ -185,7 +185,6 @@ describe('Playing SEVENS', () => {
     });
 
     it('Plays jack from a seven - special case - double jacks with some points to steal but opponent has queen', () => {
-      cy.skipOnGameStateApi();
       cy.loadGameFixture(0, {
         p0Hand: [ Card.SEVEN_OF_CLUBS ],
         p0Points: [],
@@ -233,7 +232,6 @@ describe('Playing SEVENS', () => {
     });
 
     it('Plays jack from a seven - special case - double jacks with no points to steal', () => {
-      cy.skipOnGameStateApi();
       cy.loadGameFixture(0, {
         p0Hand: [ Card.SEVEN_OF_CLUBS ],
         p0Points: [],
@@ -281,7 +279,6 @@ describe('Playing SEVENS', () => {
     });
 
     it('Plays jack from a seven - special case - final card in deck is a jack with with no points on the board', () => {
-      cy.skipOnGameStateApi();
       cy.setupGameAsP1();
       cy.loadGameFixture(1, {
         p0Hand: [],

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -898,6 +898,51 @@ Cypress.Commands.add('playJackFromSevenOpponent', (card, target) => {
     });
 });
 
+Cypress.Commands.add('sevenDiscardOpponent', (card) => {
+  if (!hasValidSuitAndRank(card)) {
+    throw new Error('Cannot play opponent points: Invalid card input');
+  }
+
+  Cypress.log({
+    displayName: 'Opponent seven discard',
+    name: 'Opponent discards jack from seven',
+    message: printCard(card),
+  });
+
+  return cy
+    .window()
+    .its('cuttle.gameStore')
+    .then((game) => {
+      const player = game.players[game.myPNum];
+      let foundCard;
+      let index;
+
+      if (cardsMatch(card, game.topCard)) {
+        foundCard = game.topCard;
+        index = 0;
+      } else if (cardsMatch(card, game.secondCard)) {
+        foundCard = game.secondCard;
+        index = 1;
+      } else {
+        throw new Error(
+          `Error playing ${printCard(
+            card,
+          )} for jack from seven as opponent: Could not find it in top two cards`,
+        );
+      }
+
+      const cardId = foundCard.id;
+
+      cy.makeSocketRequest('game', 'seven/jack', {
+        moveType: MoveType.SEVEN_DISCARD,
+        cardId,
+        index,
+        targetId: -1,
+        opId: player.id,
+      });
+    });
+});
+
 /**
  * @param card {suit: number, rank: number}
  */

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -870,9 +870,7 @@ Cypress.Commands.add('playJackFromSevenOpponent', (card, target) => {
         );
       }
 
-      // -1 is the target naming convention for discarding a card
-      const discarding = target === -1;
-      const foundTarget = discarding ? -1 : player.points.find((pointCard) => cardsMatch(target, pointCard));
+      const foundTarget = player.points.find((pointCard) => cardsMatch(target, pointCard));
 
       if (!foundTarget) {
         throw new Error(
@@ -881,13 +879,8 @@ Cypress.Commands.add('playJackFromSevenOpponent', (card, target) => {
       }
 
       const cardId = foundCard.id;
-      let targetId;
+      const targetId = foundTarget.id;
 
-      if (target !== -1) {
-        targetId = foundTarget.id;
-      } else {
-        targetId = -1;
-      }
       cy.makeSocketRequest('game', 'seven/jack', {
         moveType: MoveType.SEVEN_JACK,
         cardId,

--- a/types/SocketEvent.js
+++ b/types/SocketEvent.js
@@ -21,6 +21,7 @@ export default {
   SCUTTLE: 'scuttle',
   SEVEN_FACE_CARD: 'sevenFaceCard',
   SEVEN_JACK: 'sevenJack',
+  SEVEN_DISCARD: 'sevenDiscard',
   SEVEN_ONE_OFF: 'sevenOneOff',
   SEVEN_POINTS: 'sevenPoints',
   SEVEN_SCUTTLE: 'sevenScuttle',

--- a/utils/MoveType.json
+++ b/utils/MoveType.json
@@ -16,6 +16,7 @@
   "SEVEN_SCUTTLE": "sevenScuttle",
   "SEVEN_FACE_CARD": "sevenFaceCard",
   "SEVEN_JACK": "sevenJack",
+  "SEVEN_DISCARD": "sevenDiscard",
   "SEVEN_ONE_OFF": "sevenOneOff",
   "PASS": "pass",
   "LOADFIXTURE": "loadFixture"


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

Implements seven discard: throwing away a jack from the top of the deck when both cards are unplayable jacks

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #1112 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
