### PR TITLE
Fix/navigate home from spectate

### DIFF
--- a/src/routes/game/components/GameUnavailableOverlay.vue
+++ b/src/routes/game/components/GameUnavailableOverlay.vue
@@ -15,7 +15,6 @@
       color="secondary"
       class="mt-4"
       data-cy="leave-unavailable-game-button"
-      :loading="leavingGame"
       @click="$router.push('/')"
     >
       Go Home

--- a/src/routes/game/components/dialogs/components/gameOver/GameOverDialog.vue
+++ b/src/routes/game/components/dialogs/components/gameOver/GameOverDialog.vue
@@ -268,7 +268,11 @@ export default {
         conceded: false,
         winner: null,
       });
-      await this.gameStore.requestRematch({ gameId:this.gameStore.id, rematch: false });
+
+      if (!this.gameStore.isSpectating) {
+        await this.gameStore.requestRematch({ gameId:this.gameStore.id, rematch: false });
+      }
+
       await this.gameStore.requestUnsubscribeFromGame();
     },
     async rematch() {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->


Fixes bug where navigating home after spectating a game crashes tab. I've been unable to replicate the tab crash locally, but I do see a type error due to a failed request that we shouldn't be making when spectating anyway.
## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #1129 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
