### PR TITLE
Dev ex 1131 configure eslint to error on .only()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     sourceType: 'module',
   },
   extends: [ 'eslint:recommended', 'plugin:vue/vue3-recommended', 'plugin:vuetify/base' ],
-  plugins: [ 'cypress', 'vitest', 'prettier' ],
+  plugins: [ 'cypress', 'vitest', 'prettier', 'mocha' ],
   ignorePatterns: [ '/node_modules/*', '/assets/*' ],
   rules: {
     'eol-last': [ 'error', 'always' ],
@@ -161,7 +161,10 @@ module.exports = {
         socket3: true,
         Promise: true,
       },
-      rules: sharedTestRules,
+      rules: {
+        ...sharedTestRules,
+        'mocha/no-exclusive-tests': 'error'
+      },
     },
   ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
-  extends: [ 'eslint:recommended', 'plugin:vue/vue3-recommended', 'plugin:vuetify/base' ],
+  extends: [ 'eslint:recommended', 'plugin:vue/vue3-recommended', 'plugin:vuetify/base', 'plugin:mocha/recommended' ],
   plugins: [ 'cypress', 'vitest', 'prettier', 'mocha' ],
   ignorePatterns: [ '/node_modules/*', '/assets/*' ],
   rules: {
@@ -163,6 +163,7 @@ module.exports = {
       },
       rules: {
         ...sharedTestRules,
+        'mocha/no-mocha-arrows': 'off',
         'mocha/no-exclusive-tests': 'error'
       },
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
-  extends: [ 'eslint:recommended', 'plugin:vue/vue3-recommended', 'plugin:vuetify/base', 'plugin:mocha/recommended' ],
+  extends: [ 'eslint:recommended', 'plugin:vue/vue3-recommended', 'plugin:vuetify/base' ],
   plugins: [ 'cypress', 'vitest', 'prettier', 'mocha' ],
   ignorePatterns: [ '/node_modules/*', '/assets/*' ],
   rules: {
@@ -163,7 +163,6 @@ module.exports = {
       },
       rules: {
         ...sharedTestRules,
-        'mocha/no-mocha-arrows': 'off',
         'mocha/no-exclusive-tests': 'error'
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "eslint": "8.54.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-cypress": "3.5.0",
-        "eslint-plugin-mocha": "^10.5.0",
+        "eslint-plugin-mocha": "^10.1.0",
         "eslint-plugin-prettier": "5.2.1",
         "eslint-plugin-storybook": "0.9.0",
         "eslint-plugin-vitest": "^0.3.10",
@@ -11001,35 +11001,19 @@
       }
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.5.0.tgz",
-      "integrity": "sha512-F2ALmQVPT1GoP27O1JTZGrV9Pqg8k79OeIuvw63UxMtQKREZtmkK1NFgkZQ2TW7L2JSSFKHFPTtHu5z8R9QNRw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz",
+      "integrity": "sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^3.0.0",
-        "globals": "^13.24.0",
-        "rambda": "^7.4.0"
+        "rambda": "^7.1.0"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-mocha/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "eslint": "8.54.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-cypress": "3.5.0",
+        "eslint-plugin-mocha": "^10.5.0",
         "eslint-plugin-prettier": "5.2.1",
         "eslint-plugin-storybook": "0.9.0",
         "eslint-plugin-vitest": "^0.3.10",
@@ -10999,6 +11000,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint-plugin-mocha": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.5.0.tgz",
+      "integrity": "sha512-F2ALmQVPT1GoP27O1JTZGrV9Pqg8k79OeIuvw63UxMtQKREZtmkK1NFgkZQ2TW7L2JSSFKHFPTtHu5z8R9QNRw==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^3.0.0",
+        "globals": "^13.24.0",
+        "rambda": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
@@ -11262,6 +11295,33 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -16956,6 +17016,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "dev": true
+    },
+    "node_modules/rambda": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.5.0.tgz",
+      "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==",
       "dev": true
     },
     "node_modules/ramda": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint": "8.54.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-cypress": "3.5.0",
-    "eslint-plugin-mocha": "^10.5.0",
+    "eslint-plugin-mocha": "^10.1.0",
     "eslint-plugin-prettier": "5.2.1",
     "eslint-plugin-storybook": "0.9.0",
     "eslint-plugin-vitest": "^0.3.10",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "8.54.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-cypress": "3.5.0",
+    "eslint-plugin-mocha": "^10.5.0",
     "eslint-plugin-prettier": "5.2.1",
     "eslint-plugin-storybook": "0.9.0",
     "eslint-plugin-vitest": "^0.3.10",


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #[1131](https://github.com/cuttle-cards/cuttle/issues/1131)

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

Adds [package Eslint-Plugin-Mocha](https://www.npmjs.com/package/eslint-plugin-mocha) as a dependency. ~~Using recommended settings to apply linting to Cypress test.~~

**removed recommended settings due to too many failed linting requirements until further discussion**

Test Rule Changes:

~~Turned off test for no arrow functions been passed to cypress test.~~

Changed warn to error on .only() test. 

![image](https://github.com/user-attachments/assets/7d71c2b7-2c8e-4402-80fa-6e72eb3253c6)
