### PR TITLE
test(home.spec): skip it('Shows the Announcement Dialog when user nav…

### DIFF
--- a/tests/e2e/specs/out-of-game/home.spec.js
+++ b/tests/e2e/specs/out-of-game/home.spec.js
@@ -667,7 +667,8 @@ describe('Home - Create Game', () => {
 });
 
 describe('Announcement Dialogs', () => {
-  it('Shows the Announcement Dialog when user navigates to Home Page for the first time', () => {
+  // TODO #1159 - move this into component test and add cases for different announcements
+  it.skip('Shows the Announcement Dialog when user navigates to Home Page for the first time', () => {
     cy.wipeDatabase();
     cy.visit('/');
     cy.signupPlayer(myUser);


### PR DESCRIPTION
…igates to Home Page for the first time')

<!-- Thanks for contributing to Cuttle! 🎉 -->

Skips failing test which checks for the current announcement -- because no announcement is active atm. This should be addressed by refactoring the AnnouncementDialog and creating component tests to check the dialog with different announcements. See #1159 

## Issue number
N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
