### PR TITLE
Feature Dedupe and Remove 'butt' from `badWordsEn.json`

### DIFF
--- a/src/util/badWordsEn.js
+++ b/src/util/badWordsEn.js
@@ -1,69 +1,69 @@
 const badWordsEn = [
   // #
-  "4r5e", "5h1t", "5hit", "God", 
+  '4r5e', '5h1t', '5hit', 'God', 
   
   // A
-  "a55", "a_s_s", "anal", "anus", "ar5e", "arrse", "arse", "ass", 
+  'a55', 'a_s_s', 'anal', 'anus', 'ar5e', 'arrse', 'arse', 'ass', 
   
   // B
-  "b!tch", "b00bs", "b17ch", "b1tch", "ballbag", "balls", "bastard", "beastial", "bellend",
-  "bestial", "bi+ch", "biatch", "bitch", "bloody", "blow job", "blowjob", "boiolas", "bollock",
-  "bollok", "boner", "boob", "booobs", "boooobs", "booooobs", "booooooobs", "breasts", "buceta",
-  "bugger", "bum", "bunny fucker", "butthole", "buttmunch", "buttplug", 
+  'b!tch', 'b00bs', 'b17ch', 'b1tch', 'ballbag', 'balls', 'bastard', 'beastial', 'bellend',
+  'bestial', 'bi+ch', 'biatch', 'bitch', 'bloody', 'blow job', 'blowjob', 'boiolas', 'bollock',
+  'bollok', 'boner', 'boob', 'booobs', 'boooobs', 'booooobs', 'booooooobs', 'breasts', 'buceta',
+  'bugger', 'bum', 'bunny fucker', 'butthole', 'buttmunch', 'buttplug', 
   
   // C
-  "c0ck", "carpet muncher", "cawk", "chink", "cipa", "cl1t", "clit", "cnut", "cock", "cok", "coon",
-  "crap", "cum", "cunilingus", "cunillingus", "cunnilingus", "cunt", "cyalis", "cyberfuc",
+  'c0ck', 'carpet muncher', 'cawk', 'chink', 'cipa', 'cl1t', 'clit', 'cnut', 'cock', 'cok', 'coon',
+  'crap', 'cum', 'cunilingus', 'cunillingus', 'cunnilingus', 'cunt', 'cyalis', 'cyberfuc',
   
   // D
-  "d1ck", "damn", "dick", "dildo", "dink", "dirsa", "dlck", "dog-fucker", "doggin", "donkeyribber",
-  "doosh", "duche", "dyke",
+  'd1ck', 'damn', 'dick', 'dildo', 'dink', 'dirsa', 'dlck', 'dog-fucker', 'doggin', 'donkeyribber',
+  'doosh', 'duche', 'dyke',
   
   // E
-  "ejaculate", "ejaculating", "ejaculation", "ejakulate",
+  'ejaculate', 'ejaculating', 'ejaculation', 'ejakulate',
   
   // F
-  "f u c k", "f4nny", "f4rk", "f_u_c_k", "fag", "fanny", "fanyy", "fark", "fatass", "fcuk", "feck",
-  "felching", "fellate", "fellatio", "fingerfuck", "fistfuck", "flange", "fook", "fuck", "fudge packer",
-  "fudgepacker", "fuk", "fux",
+  'f u c k', 'f4nny', 'f4rk', 'f_u_c_k', 'fag', 'fanny', 'fanyy', 'fark', 'fatass', 'fcuk', 'feck',
+  'felching', 'fellate', 'fellatio', 'fingerfuck', 'fistfuck', 'flange', 'fook', 'fuck', 'fudge packer',
+  'fudgepacker', 'fuk', 'fux',
   
   // G
-  "gangbang", "gaylord", "gaysex", "goatse", "god-dam", "goddamn",
+  'gangbang', 'gaylord', 'gaysex', 'goatse', 'god-dam', 'goddamn',
   
   // H
-  "hardcoresex", "hell", "heshe", "hoar", "hoer", "homo", "hore", "horniest", "horny", "hotsex",
+  'hardcoresex', 'hell', 'heshe', 'hoar', 'hoer', 'homo', 'hore', 'horniest', 'horny', 'hotsex',
   
   // J
-  "jack-off", "jackoff", "jap", "jerk-off", "jism", "jiz",
+  'jack-off', 'jackoff', 'jap', 'jerk-off', 'jism', 'jiz',
   
   // K
-  "kawk", "knob", "kock", "kondum", "kum", "kunilingus",
+  'kawk', 'knob', 'kock', 'kondum', 'kum', 'kunilingus',
   
   // L
-  "l3i+ch", "l3itch", "labia", "lmfao", "lust",
+  'l3i+ch', 'l3itch', 'labia', 'lmfao', 'lust',
   
   // M
-  "m0f0", "m0fo", "m45terbate", "ma5terb8", "ma5terbate", "masochist", "master-bate", "masterb8",
-  "masterbat*", "masterbat3", "masterbate", "masterbation", "masturbate", "mo-fo", "mof0", "mofo",
-  "mothafuck", "mother fucker", "motherfuck", "muff", "mutha", "muther",
+  'm0f0', 'm0fo', 'm45terbate', 'ma5terb8', 'ma5terbate', 'masochist', 'master-bate', 'masterb8',
+  'masterbat*', 'masterbat3', 'masterbate', 'masterbation', 'masturbate', 'mo-fo', 'mof0', 'mofo',
+  'mothafuck', 'mother fucker', 'motherfuck', 'muff', 'mutha', 'muther',
   
   // N
-  "n1gga", "n1gger", "nazi", "nigg3r", "nigg4h", "nigga", "nigger", "nob", "numbnuts", "nutsack",
+  'n1gga', 'n1gger', 'nazi', 'nigg3r', 'nigg4h', 'nigga', 'nigger', 'nob', 'numbnuts', 'nutsack',
   
   // O
-  "orgasim", "orgasm",
+  'orgasim', 'orgasm',
   
   // P
-  "p0rn", "pawn", "pecker", "penis", "phonesex", "phuck", "phuk", "phuq", "pigfucker", "pimpis",
-  "piss", "poop", "porn", "prick", "pron", "pube", "pusse", "pussi", "pussy",
+  'p0rn', 'pawn', 'pecker', 'penis', 'phonesex', 'phuck', 'phuk', 'phuq', 'pigfucker', 'pimpis',
+  'piss', 'poop', 'porn', 'prick', 'pron', 'pube', 'pusse', 'pussi', 'pussy',
   
   // R
-  "rectum", "retard", "rimjaw", "rimming",
+  'rectum', 'retard', 'rimjaw', 'rimming',
   
   // S
-  "s hit", "s.o.b.", "sadist", "schlong", "screwing", "scroat", "scrote", "scrotum", "semen",
-  "sex", "sh!+", "sh!t", "sh1t", "shag", "shemale", "shi+", "shit", "skank", "slut", "smegma",
-  "smut", "snatch", "son-of-a-bitch"
+  's hit', 's.o.b.', 'sadist', 'schlong', 'screwing', 'scroat', 'scrote', 'scrotum', 'semen',
+  'sex', 'sh!+', 'sh!t', 'sh1t', 'shag', 'shemale', 'shi+', 'shit', 'skank', 'slut', 'smegma',
+  'smut', 'snatch', 'son-of-a-bitch'
 ];
 
 module.exports = badWordsEn;

--- a/src/util/badWordsEn.js
+++ b/src/util/badWordsEn.js
@@ -9,15 +9,15 @@ const badWordsEn = [
   'b!tch', 'b00bs', 'b17ch', 'b1tch', 'ballbag', 'balls', 'bastard', 'beastial', 'bellend',
   'bestial', 'bi+ch', 'biatch', 'bitch', 'bloody', 'blow job', 'blowjob', 'boiolas', 'bollock',
   'bollok', 'boner', 'boob', 'booobs', 'boooobs', 'booooobs', 'booooooobs', 'breasts', 'buceta',
-  'bugger', 'bum', 'bunny fucker', 'butthole', 'buttmunch', 'buttplug', 
+  'bugger', 'butthole', 'buttmunch', 'buttplug', 
   
   // C
   'c0ck', 'carpet muncher', 'cawk', 'chink', 'cipa', 'cl1t', 'clit', 'cnut', 'cock', 'cok', 'coon',
   'crap', 'cum', 'cunilingus', 'cunillingus', 'cunnilingus', 'cunt', 'cyalis', 'cyberfuc',
   
   // D
-  'd1ck', 'damn', 'dick', 'dildo', 'dink', 'dirsa', 'dlck', 'dog-fucker', 'doggin', 'donkeyribber',
-  'doosh', 'duche', 'dyke',
+  'd1ck', 'damn', 'dick', 'dildo', 'dink', 'dirsa', 'dlck', 'doggin', 'donkeyribber',
+  'doosh', 'douche', 'duche', 'dyke',
   
   // E
   'ejaculate', 'ejaculating', 'ejaculation', 'ejakulate',
@@ -55,7 +55,7 @@ const badWordsEn = [
   
   // P
   'p0rn', 'pawn', 'pecker', 'penis', 'phonesex', 'phuck', 'phuk', 'phuq', 'pigfucker', 'pimpis',
-  'piss', 'poop', 'porn', 'prick', 'pron', 'pube', 'pusse', 'pussi', 'pussy',
+  'piss', 'poop', 'porn', 'prick', 'pube', 'pusse', 'pussi', 'pussy',
   
   // R
   'rectum', 'retard', 'rimjaw', 'rimming',

--- a/src/util/badWordsEn.js
+++ b/src/util/badWordsEn.js
@@ -1,52 +1,69 @@
 const badWordsEn = [
-  '4r5e', '5h1t', '5hit', 'a55', 'anal', 'anus', 'ar5e', 'arrse', 'arse', 'ass',
-  'ass-fucker', 'asses', 'assfucker', 'assfukka', 'asshole', 'assholes', 'asswhole',
-  'a_s_s', 'b!tch', 'b00bs', 'b17ch', 'b1tch', 'ballbag', 'balls', 'ballsack', 'bastard',
-  'beastial', 'beastiality', 'bellend', 'bestial', 'bestiality', 'bi+ch', 'biatch', 'bitch',
-  'bitcher', 'bitchers', 'bitches', 'bitchin', 'bitching', 'bloody', 'blow job', 'blowjob',
-  'blowjobs', 'boiolas', 'bollock', 'bollok', 'boner', 'boob', 'boobs', 'booobs', 'boooobs',
-  'booooobs', 'booooooobs', 'breasts', 'buceta', 'bugger', 'bum', 'bunny fucker', 'butt',
-  'butthole', 'buttmunch', 'buttplug', 'c0ck', 'c0cksucker', 'carpet muncher', 'cawk', 'chink',
-  'cipa', 'cl1t', 'clit', 'clitoris', 'clits', 'cnut', 'cock', 'cock-sucker', 'cockface',
-  'cockhead', 'cockmunch', 'cockmuncher', 'cocks', 'cocksuck', 'cocksucked', 'cocksucker',
-  'cocksucking', 'cocksucks', 'cocksuka', 'cocksukka', 'cok', 'cokmuncher', 'coksucka', 'coon',
-  'cox', 'crap', 'cum', 'cummer', 'cumming', 'cums', 'cumshot', 'cunilingus', 'cunillingus',
-  'cunnilingus', 'cunt', 'cuntlick', 'cuntlicker', 'cuntlicking', 'cunts', 'cyalis', 'cyberfuc',
-  'cyberfuck', 'cyberfucked', 'cyberfucker', 'cyberfuckers', 'cyberfucking', 'd1ck', 'damn',
-  'dick', 'dickhead', 'dildo', 'dildos', 'dink', 'dinks', 'dirsa', 'dlck', 'dog-fucker', 'doggin',
-  'dogging', 'donkeyribber', 'doosh', 'duche', 'dyke', 'ejaculate', 'ejaculated', 'ejaculates',
-  'ejaculating', 'ejaculatings', 'ejaculation', 'ejakulate', 'f u c k', 'f u c k e r', 'f4nny',
-  'fag', 'fagging', 'faggitt', 'faggot', 'faggs', 'fagot', 'fagots', 'fags', 'fanny', 'fannyflaps',
-  'fannyfucker', 'fanyy', 'fark', 'f4rk', 'fatass', 'fcuk', 'fcuker', 'fcuking', 'feck', 'fecker',
-  'felching', 'fellate', 'fellatio', 'fingerfuck', 'fingerfucked', 'fingerfucker', 'fingerfuckers',
-  'fingerfucking', 'fingerfucks', 'fistfuck', 'fistfucked', 'fistfucker', 'fistfuckers', 'fistfucking',
-  'fistfuckings', 'fistfucks', 'flange', 'fook', 'fooker', 'fuck', 'fucka', 'fucked', 'fucker',
-  'fuckers', 'fuckhead', 'fuckheads', 'fuckin', 'fucking', 'fuckings', 'fuckingshitmotherfucker',
-  'fuckme', 'fucks', 'fuckwhit', 'fuckwit', 'fudge packer', 'fudgepacker', 'fuk', 'fuker', 'fukker',
-  'fukkin', 'fuks', 'fukwhit', 'fukwit', 'fux', 'fux0r', 'f_u_c_k', 'gangbang', 'gangbanged',
-  'gangbangs', 'gaylord', 'gaysex', 'goatse', 'God', 'god-dam', 'god-damned', 'goddamn', 'goddamned',
-  'hardcoresex', 'hell', 'heshe', 'hoar', 'hoare', 'hoer', 'homo', 'hore', 'horniest', 'horny',
-  'hotsex', 'jack-off', 'jackoff', 'jap', 'jerk-off', 'jism', 'jiz', 'jizm', 'jizz', 'kawk', 'knob',
-  'knobead', 'knobed', 'knobend', 'knobhead', 'knobjocky', 'knobjokey', 'kock', 'kondum', 'kondums',
-  'kum', 'kummer', 'kumming', 'kums', 'kunilingus', 'l3i+ch', 'l3itch', 'labia', 'lmfao', 'lust',
-  'lusting', 'm0f0', 'm0fo', 'm45terbate', 'ma5terb8', 'ma5terbate', 'masochist', 'master-bate',
-  'masterb8', 'masterbat*', 'masterbat3', 'masterbate', 'masterbation', 'masterbations',
-  'masturbate', 'mo-fo', 'mof0', 'mofo', 'mothafuck', 'mothafucka', 'mothafuckas', 'mothafuckaz',
-  'mothafucked', 'mothafucker', 'mothafuckers', 'mothafuckin', 'mothafucking', 'mothafuckings',
-  'mothafucks', 'mother fucker', 'motherfuck', 'motherfucked', 'motherfucker', 'motherfuckers',
-  'motherfuckin', 'motherfucking', 'motherfuckings', 'motherfuckka', 'motherfucks', 'muff', 'mutha',
-  'muthafecker', 'muthafuckker', 'muther', 'mutherfucker', 'n1gga', 'n1gger', 'nazi', 'nigg3r',
-  'nigg4h', 'nigga', 'niggah', 'niggas', 'niggaz', 'nigger', 'niggers', 'nob', 'nob jokey', 'nobhead',
-  'nobjocky', 'nobjokey', 'numbnuts', 'nutsack', 'orgasim', 'orgasims', 'orgasm', 'orgasms', 'p0rn',
-  'pawn', 'pecker', 'penis', 'penisfucker', 'phonesex', 'phuck', 'phuk', 'phuked', 'phuking',
-  'phukked', 'phukking', 'phuks', 'phuq', 'pigfucker', 'pimpis', 'piss', 'pissed', 'pisser',
-  'pissers', 'pisses', 'pissflaps', 'pissin', 'pissing', 'pissoff', 'poop', 'porn', 'porno',
-  'pornography', 'pornos', 'prick', 'pricks', 'pron', 'pube', 'pusse', 'pussi', 'pussies', 'pussy',
-  'pussys', 'rectum', 'retard', 'rimjaw', 'rimming', 's hit', 's.o.b.', 'sadist', 'schlong',
-  'screwing', 'scroat', 'scrote', 'scrotum', 'semen', 'sex', 'sh!+', 'sh!t', 'sh1t', 'shag', 'shagger',
-  'shaggin', 'shagging', 'shemale', 'shi+', 'shit', 'shitdick', 'shite', 'shited', 'shitey', 'shitfuck',
-  'shitfull', 'shithead', 'shiting', 'shitings', 'shits', 'shitted', 'shitter', 'shitters', 'shitting',
-  'shittings', 'shitty', 'skank', 'slut', 'sluts', 'smegma', 'smut', 'snatch', 'son-of-a-bitch'
+  // #
+  "4r5e", "5h1t", "5hit", "God", 
+  
+  // A
+  "a55", "a_s_s", "anal", "anus", "ar5e", "arrse", "arse", "ass", 
+  
+  // B
+  "b!tch", "b00bs", "b17ch", "b1tch", "ballbag", "balls", "bastard", "beastial", "bellend",
+  "bestial", "bi+ch", "biatch", "bitch", "bloody", "blow job", "blowjob", "boiolas", "bollock",
+  "bollok", "boner", "boob", "booobs", "boooobs", "booooobs", "booooooobs", "breasts", "buceta",
+  "bugger", "bum", "bunny fucker", "butthole", "buttmunch", "buttplug", 
+  
+  // C
+  "c0ck", "carpet muncher", "cawk", "chink", "cipa", "cl1t", "clit", "cnut", "cock", "cok", "coon",
+  "crap", "cum", "cunilingus", "cunillingus", "cunnilingus", "cunt", "cyalis", "cyberfuc",
+  
+  // D
+  "d1ck", "damn", "dick", "dildo", "dink", "dirsa", "dlck", "dog-fucker", "doggin", "donkeyribber",
+  "doosh", "duche", "dyke",
+  
+  // E
+  "ejaculate", "ejaculating", "ejaculation", "ejakulate",
+  
+  // F
+  "f u c k", "f4nny", "f4rk", "f_u_c_k", "fag", "fanny", "fanyy", "fark", "fatass", "fcuk", "feck",
+  "felching", "fellate", "fellatio", "fingerfuck", "fistfuck", "flange", "fook", "fuck", "fudge packer",
+  "fudgepacker", "fuk", "fux",
+  
+  // G
+  "gangbang", "gaylord", "gaysex", "goatse", "god-dam", "goddamn",
+  
+  // H
+  "hardcoresex", "hell", "heshe", "hoar", "hoer", "homo", "hore", "horniest", "horny", "hotsex",
+  
+  // J
+  "jack-off", "jackoff", "jap", "jerk-off", "jism", "jiz",
+  
+  // K
+  "kawk", "knob", "kock", "kondum", "kum", "kunilingus",
+  
+  // L
+  "l3i+ch", "l3itch", "labia", "lmfao", "lust",
+  
+  // M
+  "m0f0", "m0fo", "m45terbate", "ma5terb8", "ma5terbate", "masochist", "master-bate", "masterb8",
+  "masterbat*", "masterbat3", "masterbate", "masterbation", "masturbate", "mo-fo", "mof0", "mofo",
+  "mothafuck", "mother fucker", "motherfuck", "muff", "mutha", "muther",
+  
+  // N
+  "n1gga", "n1gger", "nazi", "nigg3r", "nigg4h", "nigga", "nigger", "nob", "numbnuts", "nutsack",
+  
+  // O
+  "orgasim", "orgasm",
+  
+  // P
+  "p0rn", "pawn", "pecker", "penis", "phonesex", "phuck", "phuk", "phuq", "pigfucker", "pimpis",
+  "piss", "poop", "porn", "prick", "pron", "pube", "pusse", "pussi", "pussy",
+  
+  // R
+  "rectum", "retard", "rimjaw", "rimming",
+  
+  // S
+  "s hit", "s.o.b.", "sadist", "schlong", "screwing", "scroat", "scrote", "scrotum", "semen",
+  "sex", "sh!+", "sh!t", "sh1t", "shag", "shemale", "shi+", "shit", "skank", "slut", "smegma",
+  "smut", "snatch", "son-of-a-bitch"
 ];
 
 module.exports = badWordsEn;


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue Number

- Resolves #1174

See [superset-remover](https://github.com/tcox-coding/superset-remover) for implementation details. All superset words have been removed, as well as the words `cox` and `butt`. The new list of words is down from 410 words to 217 words. Additionally, the document has been formatted alphabetically and commented.

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
Given this is just updating the profanity filter, I don't see much in the way of testing to validate the accuracy of this change.