### PR TITLE
Feat/disable stalemate request during other phases

### DIFF
--- a/api/controllers/game/stalemate.js
+++ b/api/controllers/game/stalemate.js
@@ -17,13 +17,14 @@ module.exports = async function (req, res) {
     const playerStalemateKey = `${keyPrefix}${pNum}`;
     const playerStalemateVal = game.turn;
 
-    // Error if in the middle of another move/phase
-    if (game.oneOff || game.resolving || game.twos.length) {
-      throw new Error('game.snackbar.stalemate.wrongPhase');
-    }
     // Error if this player already requested stalemate this turn
     if (game[playerStalemateKey] === game.turn) {
       throw new Error('game.snackbar.stalemate.previousStalemateRejected');
+    }
+
+    // Error if in the middle of another move/phase
+    if (game.oneOff || game.resolving || game.twos.length) {
+      throw new Error('game.snackbar.stalemate.wrongPhase');
     }
 
     gameUpdates[playerStalemateKey] = playerStalemateVal;

--- a/api/helpers/game-states/moves/stalemate-request/validate.js
+++ b/api/helpers/game-states/moves/stalemate-request/validate.js
@@ -39,7 +39,7 @@ module.exports = {
 
       // Must not already be considering a stalemate
       if (currentState.phase === GamePhase.STALEMATE_REQUEST) {
-        throw new Error('game.snackbar.global.alreadyConsideringStalemate');
+        throw new Error('game.snackbar.stalemate.alreadyConsideringStalemate');
       }
 
       // Must be in main phase

--- a/api/helpers/game-states/moves/stalemate-request/validate.js
+++ b/api/helpers/game-states/moves/stalemate-request/validate.js
@@ -36,6 +36,17 @@ module.exports = {
   sync: true,
   fn: ({ currentState, priorStates }, exits) => {
     try {
+
+      // Must not already be considering a stalemate
+      if (currentState.phase === GamePhase.STALEMATE_REQUEST) {
+        throw new Error('game.snackbar.global.alreadyConsideringStalemate');
+      }
+
+      // Must be in main phase
+      if (currentState.phase !== GamePhase.main) {
+        throw new Error('game.snackbar.stalemate.wrongPhase');
+      }
+
       // Can't request stalemate more than once per turn
       if (
         priorStates.some(
@@ -43,11 +54,6 @@ module.exports = {
         )
       ) {
         throw new Error('game.snackbar.stalemate.previousStalemateRejected');
-      }
-
-      // Must not already be considering a stalemate
-      if (currentState.phase === GamePhase.STALEMATE_REQUEST) {
-        throw new Error('game.snackbar.global.alreadyConsideringStalemate');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/stalemate-request/validate.js
+++ b/api/helpers/game-states/moves/stalemate-request/validate.js
@@ -42,11 +42,6 @@ module.exports = {
         throw new Error('game.snackbar.stalemate.alreadyConsideringStalemate');
       }
 
-      // Must be in main phase
-      if (currentState.phase !== GamePhase.MAIN) {
-        throw new Error('game.snackbar.stalemate.wrongPhase');
-      }
-
       // Can't request stalemate more than once per turn
       if (
         priorStates.some(
@@ -55,6 +50,12 @@ module.exports = {
       ) {
         throw new Error('game.snackbar.stalemate.previousStalemateRejected');
       }
+
+      // Must be in main phase
+      if (currentState.phase !== GamePhase.MAIN) {
+        throw new Error('game.snackbar.stalemate.wrongPhase');
+      }
+
 
       return exits.success();
     } catch (err) {

--- a/api/helpers/game-states/moves/stalemate-request/validate.js
+++ b/api/helpers/game-states/moves/stalemate-request/validate.js
@@ -43,7 +43,7 @@ module.exports = {
       }
 
       // Must be in main phase
-      if (currentState.phase !== GamePhase.main) {
+      if (currentState.phase !== GamePhase.MAIN) {
         throw new Error('game.snackbar.stalemate.wrongPhase');
       }
 

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -277,7 +277,8 @@
         "alreadyConsideringStalemate": "Ein Patt wurde bereits angeboten",
         "noStalemateOffered": "Dein Gegner hat kein Patt angeboten",
         "opponentConsideringStalemate": "Dein Gegner erwägt dein Patt-Angebot",
-        "previousStalemateRejected": "Die Patt-Anfrage wurde in dieser Runde bereits abgelehnt"
+        "previousStalemateRejected": "Die Patt-Anfrage wurde in dieser Runde bereits abgelehnt",
+        "wrongPhase": "Sie können während anderer Züge kein Remis verlangen"
       },
       "oneOffs": {
         "oneOffInPlay": "Es ist bereits ein One-Off im Spiel; du kannst keine Karte spielen, außer einer Zwei zum Kontern.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -277,7 +277,8 @@
         "alreadyConsideringStalemate": "A stalemate has already been offered",
         "noStalemateOffered": "Your opponent has not offered a stalemate",
         "opponentConsideringStalemate": "Your opponent is considering your stalemate offer",
-        "previousStalemateRejected": "Stalemate request was already rejected this turn"
+        "previousStalemateRejected": "Stalemate request was already rejected this turn",
+        "wrongPhase": "You can't request a stalemate during other moves"
       },
       "oneOffs": {
         "oneOffInPlay": "There is already a one-off in play; you cannot play any card, except a two to counter.",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -277,7 +277,8 @@
         "alreadyConsideringStalemate": "Ya se ha ofrecido un empate",
         "noStalemateOffered": "Tu oponente no ha ofrecido un empate",
         "opponentConsideringStalemate": "Tu oponente está considerando tu oferta de empate",
-        "previousStalemateRejected": "La solicitud de empate ya fue rechazada en este turno"
+        "previousStalemateRejected": "La solicitud de empate ya fue rechazada en este turno",
+        "wrongPhase": "No puedes solicitar tablas durante otros movimientos"
       },
       "oneOffs": {
         "oneOffInPlay": "Ya hay en juego una carta de habilidad única; no puedes jugar ninguna carta, excepto un Dos para contrarrestar.",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -277,7 +277,8 @@
         "alreadyConsideringStalemate": "Une proposition de match nul a déjà été faite",
         "noStalemateOffered": "Votre adversaire n'a pas proposé de match nul",
         "opponentConsideringStalemate": "Votre adversaire envisage votre offre de match nul",
-        "previousStalemateRejected": "La demande de match nul a déjà été rejetée ce tour"
+        "previousStalemateRejected": "La demande de match nul a déjà été rejetée ce tour",
+        "wrongPhase": "Vous ne pouvez pas demander la nulle pendant d'autres mouvements"
       },
       "oneOffs": {
         "oneOffInPlay": "Une capacité est en cours d'exécution, vous ne pouvez jouer qu'un deux pour contrer.",

--- a/src/translations/ukr.json
+++ b/src/translations/ukr.json
@@ -277,7 +277,8 @@
         "alreadyConsideringStalemate": "Нічия вже була запропонована",
         "noStalemateOffered": "Ваш опонент не запропонував нічию",
         "opponentConsideringStalemate": "Ваш опонент розглядає вашу пропозицію нічиєї",
-        "previousStalemateRejected": "Запит на нічию вже було відхилено цього ходу"
+        "previousStalemateRejected": "Запит на нічию вже було відхилено цього ходу",
+        "wrongPhase": "Ви не можете запросити нічию під час інших ходів"
       },
       "oneOffs": {
         "oneOffInPlay": "Вже є одна картка ONE-OFF на полі; ви не можете зіграти будь-яку іншу картку, крім двійки для контратаки.",

--- a/tests/e2e/specs/in-game/game-over/winConditions.spec.js
+++ b/tests/e2e/specs/in-game/game-over/winConditions.spec.js
@@ -380,48 +380,6 @@ describe('Stalemates', () => {
       assertStalemate();
     });
 
-    it('Rejects a stalemate while resolving a seven', () => {
-      cy.setupGameAsP0();
-      cy.loadGameFixture(0, {
-        p0Hand: [ Card.SEVEN_OF_CLUBS ],
-        p0Points: [],
-        p0FaceCards: [],
-        p1Hand: [],
-        p1Points: [],
-        p1FaceCards: [],
-        topCard: Card.FOUR_OF_CLUBS,
-        secondCard: Card.SIX_OF_DIAMONDS,
-      });
-  
-      cy.playOneOffAndResolveAsPlayer(Card.SEVEN_OF_CLUBS);
-  
-      cy.get('[data-top-card=4-0]').should('exist')
-        .and('be.visible');
-
-      cy.stalemateOpponent();
-
-      cy.get('#opponent-requested-stalemate-dialog')
-        .should('be.visible')
-        .find('[data-cy=reject-stalemate]')
-        .click();
-
-      cy.get('#opponent-requested-stalemate-dialog')
-        .should('not.exist');
-
-      cy.get('[data-second-card=6-1]').click();
-      cy.get('[data-move-choice=points]').click();
-
-      assertGameState(0, {
-        p0Hand: [],
-        p0Points: [ Card.SIX_OF_DIAMONDS ],
-        p0FaceCards: [],
-        p1Hand: [],
-        p1Points: [],
-        p1FaceCards: [],
-        scrap: [ Card.SEVEN_OF_CLUBS ]
-      });
-    });
-
     describe('Illegal stalemate requests', () => {
       // TODO: #965 test that you can't request stalemate while your opponent's stalemate req is pending
 
@@ -485,7 +443,80 @@ describe('Stalemates', () => {
             }
           });
       });
-    });
+
+      it('Rejects a stalemate while resolving a seven', () => {
+        cy.setupGameAsP0();
+        cy.loadGameFixture(0, {
+          p0Hand: [ Card.SEVEN_OF_CLUBS ],
+          p0Points: [],
+          p0FaceCards: [],
+          p1Hand: [],
+          p1Points: [],
+          p1FaceCards: [],
+          topCard: Card.FOUR_OF_CLUBS,
+          secondCard: Card.SIX_OF_DIAMONDS,
+        });
+    
+        cy.playOneOffAndResolveAsPlayer(Card.SEVEN_OF_CLUBS);
+    
+        cy.get('[data-top-card=4-0]').should('exist')
+          .and('be.visible');
+  
+        // Force store to request stalemate; should 400
+        cy.window()
+          .its('cuttle.gameStore')
+          .then(async (store) => {
+            try {
+              await store.requestStalemate();
+              // Fail test if backend allows request
+              expect(true).to.eq(false, 'Expected 400 error when requesting to initiate stalemate during 7 resolution, but got 200 response');
+            } catch (err) {
+              expect(err).to.eq('game.snackbar.stalemate.wrongPhase');
+            }
+          });
+  
+        cy.get('[data-second-card=6-1]').click();
+        cy.get('[data-move-choice=points]').click();
+  
+        assertGameState(0, {
+          p0Hand: [],
+          p0Points: [ Card.SIX_OF_DIAMONDS ],
+          p0FaceCards: [],
+          p1Hand: [],
+          p1Points: [],
+          p1FaceCards: [],
+          scrap: [ Card.SEVEN_OF_CLUBS ]
+        });
+      });
+  
+      it('Rejects a stalemate during countering', () => {
+        cy.setupGameAsP1();
+        cy.loadGameFixture(1, {
+          p0Hand: [ Card.ACE_OF_CLUBS ],
+          p0Points: [],
+          p0FaceCards: [],
+          p1Hand: [],
+          p1Points: [],
+          p1FaceCards: [],
+        });
+  
+        cy.playOneOffOpponent(Card.ACE_OF_CLUBS);
+        cy.get('#cannot-counter-dialog').should('be.visible');
+  
+        // Force store to request stalemate; should 400
+        cy.window()
+          .its('cuttle.gameStore')
+          .then(async (store) => {
+            try {
+              await store.requestStalemate();
+              // Fail test if backend allows request
+              expect(true).to.eq(false, 'Expected 400 error when requesting to initiate stalemate during countering phase, but got 200 response');
+            } catch (err) {
+              expect(err).to.eq('game.snackbar.stalemate.wrongPhase');
+            }
+          });
+      });
+    }); // End describe illegal stalemates
   }); // End describe requesting stalemates
 }); // End describe stalemates
 

--- a/tests/e2e/specs/in-game/game-over/winConditions.spec.js
+++ b/tests/e2e/specs/in-game/game-over/winConditions.spec.js
@@ -444,7 +444,7 @@ describe('Stalemates', () => {
           });
       });
 
-      it('Rejects a stalemate while resolving a seven', () => {
+      it('Prevents users from requesting a stalemate while resolving a seven', () => {
         cy.setupGameAsP0();
         cy.loadGameFixture(0, {
           p0Hand: [ Card.SEVEN_OF_CLUBS ],
@@ -489,7 +489,7 @@ describe('Stalemates', () => {
         });
       });
   
-      it('Rejects a stalemate during countering', () => {
+      it('Prevents users from requesting a stalemate during countering', () => {
         cy.setupGameAsP1();
         cy.loadGameFixture(1, {
           p0Hand: [ Card.ACE_OF_CLUBS ],


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

This fixes a bug where rejecting a stalemate during phases of the game like countering or seven resolution and then refreshing the page would break players' ability to make the correct move. Root cause is that the client doesn't know or use the `phase` attribute, only `moveType` and so it doesn't know which moves are legal if the moveType was stalemateRejected. 

Long term it'd be best to utilize `phase` directly on the clientside to control which move is expected, but presently the best option is to disable stalemates during phases other than `GamePhase.MAIN`.

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
