### PR TITLE
Refactor/extended backend error handling

### DIFF
--- a/api/controllers/TestController.js
+++ b/api/controllers/TestController.js
@@ -1,7 +1,7 @@
 /**
  * TestController
  *
- * @description :: Server-side actions for handling incoming requests.
+ * @description :: Server-side actions for handling testing-only requests e.g wiping db
  * @help        :: See https://sailsjs.com/docs/concepts/actions
  */
 

--- a/api/controllers/game/move.js
+++ b/api/controllers/game/move.js
@@ -6,10 +6,12 @@ const BadRequestError = require('../../errors/badRequestError');
 module.exports = async function (req, res) {
   let game;
   try {
+    // Fetch and format relevant game data
     const { saveGamestate, createSocketEvent, unpackGamestate } = sails.helpers.gameStates;
     const { execute, validate } = sails.helpers.gameStates.moves[req.body.moveType];
     game = await sails.helpers.lockGame(req.params.gameId);
     const gameState = unpackGamestate(game.gameStates.at(-1));
+
     if (!game.gameStates.length || !gameState) {
       throw new BadRequestError({ message: 'Game has not yet started' });
     }

--- a/api/controllers/game/move.js
+++ b/api/controllers/game/move.js
@@ -44,11 +44,14 @@ module.exports = async function (req, res) {
       }
     }
 
+    const message = err?.message ?? err ?? 'Error making move';
     switch (err?.code) {
       case 'FORBIDDEN':
-        return res.forbidden({ message: err.message });
+        return res.forbidden({ message });
+      case 'BAD_REQUEST':
+        return res.badRequest({ message });
       default:
-        return res.badRequest({ message: err.message });
+        return res.serverError({ message });
     }
   }
 };

--- a/api/controllers/game/move.js
+++ b/api/controllers/game/move.js
@@ -37,12 +37,10 @@ module.exports = async function (req, res) {
     return res.ok();
   } catch (err) {
     // ensure the game is unlocked
-    if (game?.lock) {
-      try {
-        await sails.helpers.unlockGame(game.lock);
-      } catch (err) {
-        // fall through for generic error handling
-      }
+    try {
+      await sails.helpers.unlockGame(game.lock);
+    } catch (err) {
+      // fall through for generic error handling
     }
 
     const message = err?.message ?? err ?? 'Error making move';

--- a/api/controllers/game/move.js
+++ b/api/controllers/game/move.js
@@ -1,6 +1,7 @@
 // Request to make a move
 const CustomErrorType = require('../../errors/customErrorType');
 const ForbiddenError = require('../../errors/forbiddenError');
+const BadRequestError = require('../../errors/badRequestError');
 
 module.exports = async function (req, res) {
   let game;
@@ -10,7 +11,7 @@ module.exports = async function (req, res) {
     game = await sails.helpers.lockGame(req.params.gameId);
     const gameState = unpackGamestate(game.gameStates.at(-1));
     if (!game.gameStates.length || !gameState) {
-      throw new Error({ message: 'Game has not yet started' });
+      throw new BadRequestError({ message: 'Game has not yet started' });
     }
 
     // Verify whether user is in requested game and as which player

--- a/api/controllers/game/move.js
+++ b/api/controllers/game/move.js
@@ -1,4 +1,5 @@
 // Request to make a move
+const CustomErrorType = require('../../errors/customErrorType');
 const ForbiddenError = require('../../errors/forbiddenError');
 
 module.exports = async function (req, res) {
@@ -46,9 +47,9 @@ module.exports = async function (req, res) {
 
     const message = err?.message ?? err ?? 'Error making move';
     switch (err?.code) {
-      case 'FORBIDDEN':
+      case CustomErrorType.FORBIDDEN:
         return res.forbidden({ message });
-      case 'BAD_REQUEST':
+      case CustomErrorType.BAD_REQUEST:
         return res.badRequest({ message });
       default:
         return res.serverError({ message });

--- a/api/controllers/game/move.js
+++ b/api/controllers/game/move.js
@@ -50,6 +50,9 @@ module.exports = async function (req, res) {
 
     return res.ok();
   } catch (err) {
+    ///////////////////
+    // Handle Errors //
+    ///////////////////
     // Ensure the game is unlocked
     try {
       await sails.helpers.unlockGame(game.lock);

--- a/api/controllers/game/ready.js
+++ b/api/controllers/game/ready.js
@@ -60,12 +60,10 @@ module.exports = async function (req, res) {
     return res.ok();
   } catch (err) {
     // ensure the game is unlocked
-    if (game?.lock) {
-      try {
-        await sails.helpers.unlockGame(game.lock);
-      } catch (err) {
-        // fall through for generic error handling
-      }
+    try {
+      await sails.helpers.unlockGame(game.lock);
+    } catch (err) {
+      // fall through for generic error handling
     }
 
     const message = err?.raw?.message ?? err?.message ?? err;

--- a/api/controllers/game/ready.js
+++ b/api/controllers/game/ready.js
@@ -1,4 +1,6 @@
+const CustomErrorType = require('../../errors/customErrorType');
 const ForbiddenError = require('../../errors/forbiddenError');
+
 
 module.exports = async function (req, res) {
   // Query for game
@@ -68,7 +70,7 @@ module.exports = async function (req, res) {
 
     const message = err?.raw?.message ?? err?.message ?? err;
     switch (err?.code) {
-      case 'FORBIDDEN':
+      case CustomErrorType.FORBIDDEN:
         return res.forbidden({ message });
       default:
         return res.badRequest({ message });

--- a/api/controllers/game/ready.js
+++ b/api/controllers/game/ready.js
@@ -59,11 +59,14 @@ module.exports = async function (req, res) {
 
     return res.ok();
   } catch (err) {
-    // ensure the game is unlocked
+    ///////////////////
+    // Handle Errors //
+    ///////////////////
+    // Ensure the game is unlocked
     try {
       await sails.helpers.unlockGame(game.lock);
     } catch (err) {
-      // fall through for generic error handling
+      // Swallow if unlockGame errors, then respond based on error type
     }
 
     const message = err?.raw?.message ?? err?.message ?? err;

--- a/api/controllers/game/ready.js
+++ b/api/controllers/game/ready.js
@@ -71,7 +71,7 @@ module.exports = async function (req, res) {
       case CustomErrorType.FORBIDDEN:
         return res.forbidden({ message });
       default:
-        return res.badRequest({ message });
+        return res.serverError({ message });
     }
   }
 };

--- a/api/controllers/game/rematch-gamestate.js
+++ b/api/controllers/game/rematch-gamestate.js
@@ -8,6 +8,8 @@
  * with name "firstPlayerUsername VS secondPlayerUsername {p0wins}-{p1Wins}-{stalemates}"
  */
 const GameStatus = require('../../../utils/GameStatus.json');
+const CustomErrorType = require('../../errors/customErrorType');
+const ForbiddenError = require('../../errors/forbiddenError');
 
 let game;
 module.exports = async function (req, res) {
@@ -21,7 +23,7 @@ module.exports = async function (req, res) {
     // Early return if requesting user was not in the game
     const playerIds = [ game.p0?.id, game.p1?.id ].filter((val) => !!val);
     if (!playerIds.includes(userId)) {
-      return res.forbidden({ message: `You aren't a player in this game` });
+      throw new ForbiddenError('You are not a player in this game!');
     }
 
     // Determine whether to start new game
@@ -97,13 +99,19 @@ module.exports = async function (req, res) {
     await sails.helpers.unlockGame(game.lock);
     return res.ok({ newGameId: newGame.id });
   } catch (err) {
-    // ensure the game is unlocked
+    // Ensure the game is unlocked
     try {
       await sails.helpers.unlockGame(game.lock);
     } catch (err) {
-      // fall through for generic error handling
+      // Swallow if unlockGame errors, then respond based on error type
     }
+
     const message = err.raw?.message ?? err;
-    return res.badRequest({ message });
+    switch (err?.code) {
+      case CustomErrorType.FORBIDDEN:
+        return res.forbidden({ message });
+      default:
+        return res.serverError({ message });
+    }
   }
 };

--- a/api/controllers/game/rematch-gamestate.js
+++ b/api/controllers/game/rematch-gamestate.js
@@ -99,6 +99,9 @@ module.exports = async function (req, res) {
     await sails.helpers.unlockGame(game.lock);
     return res.ok({ newGameId: newGame.id });
   } catch (err) {
+    ///////////////////
+    // Handle Errors //
+    ///////////////////
     // Ensure the game is unlocked
     try {
       await sails.helpers.unlockGame(game.lock);

--- a/api/controllers/game/rematch.js
+++ b/api/controllers/game/rematch.js
@@ -7,12 +7,14 @@
  * with name "firstPlayerUsername VS secondPlayerUsername {p0wins}-{p1Wins}-{stalemates}"
  */
 const gameAPI = sails.hooks['customgamehook'];
+
+let game;
 module.exports = async function (req, res) {
   try {
     const { usr: userId } = req.session;
     const { gameId: oldGameId, rematch } = req.body;
 
-    let game = await sails.helpers.lockGame(req.session.game);
+    game = await sails.helpers.lockGame(req.session.game);
 
     // Early return if requesting user was not in the game
     if (!userId || ![ game.p0?.id, game.p1?.id ].includes(userId)) {
@@ -99,6 +101,12 @@ module.exports = async function (req, res) {
     await sails.helpers.unlockGame(game.lock);
     return res.ok({ newGameId: newGame.id });
   } catch (err) {
+    // ensure the game is unlocked
+    try {
+      await sails.helpers.unlockGame(game.lock);
+    } catch (err) {
+      // fall through for generic error handling
+    }
     const message = err.raw?.message ?? err;
     return res.badRequest({ message });
   }

--- a/api/errors/badRequestError.js
+++ b/api/errors/badRequestError.js
@@ -1,0 +1,8 @@
+class BadRequestError extends Error {
+  constructor(message) {
+    super(message);
+    this.code = 'BAD_REQUEST';
+  }
+}
+
+module.exports = BadRequestError;

--- a/api/errors/badRequestError.js
+++ b/api/errors/badRequestError.js
@@ -1,7 +1,9 @@
+const CustomErrorType = require('./customErrorType');
+
 class BadRequestError extends Error {
   constructor(message) {
     super(message);
-    this.code = 'BAD_REQUEST';
+    this.code = CustomErrorType.BAD_REQUEST;
   }
 }
 

--- a/api/errors/customErrorType.js
+++ b/api/errors/customErrorType.js
@@ -1,0 +1,13 @@
+/**
+ * CustomErrorTypes.js
+ * Enum of the allowed custom error types
+ * Each corresponds to a sub-class of error
+ * defined in api/errors e.g. BadRequestError
+ * 
+ * Those error sub-classes just add a `code`
+ * with the value specified by these enum vals
+ */
+module.exports = {
+  FORBIDDEN: 'FORBIDDEN',
+  BAD_REQUEST: 'BAD_REQUEST',
+};

--- a/api/errors/forbiddenError.js
+++ b/api/errors/forbiddenError.js
@@ -1,7 +1,9 @@
+const CustomErrorType = require('./customErrorType');
+
 class ForbiddenError extends Error {
   constructor(message) {
     super(message);
-    this.code = 'FORBIDDEN';
+    this.code = CustomErrorType.FORBIDDEN;
   }
 }
 

--- a/api/helpers/game-states/moves/counter/validate.js
+++ b/api/helpers/game-states/moves/counter/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to counter pending one-off',
@@ -38,23 +39,23 @@ module.exports = {
 
       // Must be COUNTERING phase
       if (currentState.phase !== GamePhase.COUNTERING) {
-        throw new Error(`Can only counter during the countering phase`);
+        throw new BadRequestError(`Can only counter during the countering phase`);
       }
 
       if (!currentState.oneOff) {
-        throw new Error('You cannot counter unless there is a one-off pending');
+        throw new BadRequestError('You cannot counter unless there is a one-off pending');
       }
 
       const player = playedBy ? currentState.p1 : currentState.p0;
       const playedCard = player.hand.find(({ id }) => requestedMove.cardId === id);
       if (!playedCard) {
-        throw new Error('game.snackbar.global.playFromHand');
+        throw new BadRequestError('game.snackbar.global.playFromHand');
       }
 
       // Must be your chance to counter
       const yourTurnToCounter = sails.helpers.gameStates.yourTurnToCounter(currentState, playedBy);
       if (!yourTurnToCounter) {
-        throw new Error('Waiting for opponent to counter');
+        throw new BadRequestError('Waiting for opponent to counter');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/draw/validate.js
+++ b/api/helpers/game-states/moves/draw/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to draw a card',
@@ -38,23 +39,23 @@ module.exports = {
 
       // Must be MAIN phase of the turn
       if (currentState.phase !== GamePhase.MAIN) {
-        throw new Error('game.snackbar.global.notInMainPhase');
+        throw new BadRequestError('game.snackbar.global.notInMainPhase');
       }
 
       // Must be your turn
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       // Must be under hand limit of 8
       const player = playedBy ? currentState.p1 : currentState.p0;
       if (player.hand.length >= 8) {
-        throw new Error('game.snackbar.draw.handLimit');
+        throw new BadRequestError('game.snackbar.draw.handLimit');
       }
 
       // Deck must have cards
       if (!currentState.deck.length) {
-        throw new Error('game.snackbar.draw.deckIsEmpty');
+        throw new BadRequestError('game.snackbar.draw.deckIsEmpty');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/face-card/validate.js
+++ b/api/helpers/game-states/moves/face-card/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to play face card',
@@ -40,23 +41,23 @@ module.exports = {
       const playedCard = player.hand.find(({ id }) => id === requestedMove.cardId);
 
       if (currentState.phase !== GamePhase.MAIN) {
-        throw new Error('game.snackbar.global.notInMainPhase');
+        throw new BadRequestError('game.snackbar.global.notInMainPhase');
       }
 
       if (!playedCard) {
-        throw new Error('game.snackbar.global.playFromHand');
+        throw new BadRequestError('game.snackbar.global.playFromHand');
       }
 
       if (playedCard.isFrozen) {
-        throw new Error('game.snackbar.global.cardFrozen');
+        throw new BadRequestError('game.snackbar.global.cardFrozen');
       }
 
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       if (![ 8, 12, 13 ].includes(playedCard.rank)) {
-        throw new Error('game.snackbar.faceCard.withoutTarget');
+        throw new BadRequestError('game.snackbar.faceCard.withoutTarget');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/jack/validate.js
+++ b/api/helpers/game-states/moves/jack/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to play Jack',
@@ -44,38 +45,38 @@ module.exports = {
 
       // GameState phase should be MAIN
       if (currentState.phase !== GamePhase.MAIN) {
-        throw new Error('game.snackbar.global.notInMainPhase');
+        throw new BadRequestError('game.snackbar.global.notInMainPhase');
       }
 
       // Must be player's turn
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       // playedCard must be in player's hand
       if (!playedCard) {
-        throw new Error('game.snackbar.global.playFromHand');
+        throw new BadRequestError('game.snackbar.global.playFromHand');
       }
 
       // playedCard must be a jack
       if (playedCard.rank !== 11) {
-        throw new Error('game.snackbar.jack.stealOnlyPointCards');
+        throw new BadRequestError('game.snackbar.jack.stealOnlyPointCards');
       }
 
       // targetCard must be in opponent's points
       if (!targetCard) {
-        throw new Error('game.snackbar.jack.stealOnlyPointCards');
+        throw new BadRequestError('game.snackbar.jack.stealOnlyPointCards');
       }
 
       // playedCard must not be frozen
       if (playedCard.isFrozen) {
-        throw new Error('game.snackbar.global.cardFrozen');
+        throw new BadRequestError('game.snackbar.global.cardFrozen');
       }
 
       // Can't jack if opponent has queen
       const queenCount = opponent.faceCards.filter(({ rank }) => rank === 12).length;
       if (queenCount > 0) {
-        throw new Error('game.snackbar.jack.noJackWithQueen');
+        throw new BadRequestError('game.snackbar.jack.noJackWithQueen');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/one-off/validate.js
+++ b/api/helpers/game-states/moves/one-off/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to play one-off',
@@ -43,23 +44,23 @@ module.exports = {
       const playedCard = player.hand.find(({ id }) => id === requestedMove.cardId);
 
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       if (currentState.phase !== GamePhase.MAIN) {
-        throw new Error('game.snackbar.global.notInMainPhase');
+        throw new BadRequestError('game.snackbar.global.notInMainPhase');
       }
 
       if (currentState.oneOff) {
-        throw new Error('game.snackbar.oneOffs.oneOffInPlay');
+        throw new BadRequestError('game.snackbar.oneOffs.oneOffInPlay');
       }
 
       if (!playedCard) {
-        throw new Error('game.snackbar.global.playFromHand');
+        throw new BadRequestError('game.snackbar.global.playFromHand');
       }
 
       if (playedCard.isFrozen) {
-        throw new Error('game.snackbar.global.cardFrozen');
+        throw new BadRequestError('game.snackbar.global.cardFrozen');
       }
 
       switch (playedCard.rank) {
@@ -78,11 +79,11 @@ module.exports = {
           );
           // Must have target
           if (!targetCard) {
-            throw new Error(`Can't find the ${requestedMove.targetId} on opponent's board`);
+            throw new BadRequestError(`Can't find the ${requestedMove.targetId} on opponent's board`);
           }
 
           if (playedCard.rank === 2 && ![ 'faceCard', 'jack' ].includes(requestedMove.targetType)) {
-            throw new Error('Twos can only target royals or glasses');
+            throw new BadRequestError('Twos can only target royals or glasses');
           }
 
           const queenCount = opponent.faceCards.filter((faceCard) => faceCard.rank === 12).length;
@@ -96,21 +97,21 @@ module.exports = {
             // One queen => can only target the queen
             case 1: {
               if (targetCard.rank !== 12) {
-                throw new Error('game.snackbar.global.blockedByQueen');
+                throw new BadRequestError('game.snackbar.global.blockedByQueen');
               }
               return exits.success();
             }
 
             // 2+ queens => Can't target at all
             default:
-              throw new Error('game.snackbar.global.blockedByMultipleQueens');
+              throw new BadRequestError('game.snackbar.global.blockedByMultipleQueens');
           }
         }
 
         // Three requires card(s) in scrap
         case 3:
           if (!currentState.scrap.length) {
-            throw new Error('game.snackbar.oneOffs.three.scrapIsEmpty');
+            throw new BadRequestError('game.snackbar.oneOffs.three.scrapIsEmpty');
           }
           return exits.success();
 
@@ -124,20 +125,20 @@ module.exports = {
         // Five and sevens require cards in deck
         case 5:
           if (!currentState.deck.length) {
-            throw new Error('game.snackbar.oneOffs.emptyDeck');
+            throw new BadRequestError('game.snackbar.oneOffs.emptyDeck');
           }
           return exits.success();
 
         // Seven requires cards in deck
         case 7:
           if (!currentState.deck.length) {
-            throw new Error('game.snackbar.oneOffs.sevenWithEmptyDeck');
+            throw new BadRequestError('game.snackbar.oneOffs.sevenWithEmptyDeck');
           }
           return exits.success();
 
         // No other cards can be used for a one-off
         default:
-          throw new Error('You cannot play that card as a one-off');
+          throw new BadRequestError('You cannot play that card as a one-off');
       }
     } catch (err) {
       return exits.error(err);

--- a/api/helpers/game-states/moves/pass/validate.js
+++ b/api/helpers/game-states/moves/pass/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to Pass',
@@ -37,12 +38,12 @@ module.exports = {
     try {
       // Must be your turn
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       // Must be MAIN phase of the turn
       if (currentState.phase !== GamePhase.MAIN) {
-        throw new Error('game.snackbar.global.notInMainPhase');
+        throw new BadRequestError('game.snackbar.global.notInMainPhase');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/points/validate.js
+++ b/api/helpers/game-states/moves/points/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to play points',
@@ -40,23 +41,23 @@ module.exports = {
       const playedCard = player.hand.find(({ id }) => id === requestedMove.cardId);
 
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       if (currentState.phase !== GamePhase.MAIN) {
-        throw new Error('game.snackbar.global.notInMainPhase');
+        throw new BadRequestError('game.snackbar.global.notInMainPhase');
       }
 
       if (!playedCard) {
-        throw new Error('game.snackbar.global.playFromHand');
+        throw new BadRequestError('game.snackbar.global.playFromHand');
       }
       
       if (playedCard.rank > 10) {
-        throw new Error('game.snackbar.points.numberOnlyForPoints');
+        throw new BadRequestError('game.snackbar.points.numberOnlyForPoints');
       }
 
       if (playedCard.isFrozen) {
-        throw new Error('game.snackbar.global.cardFrozen');
+        throw new BadRequestError('game.snackbar.global.cardFrozen');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/resolve-five/validate.js
+++ b/api/helpers/game-states/moves/resolve-five/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to resolve five',
@@ -38,23 +39,23 @@ module.exports = {
       const player = playedBy ? currentState.p1 : currentState.p0;
 
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       if (currentState.phase !== GamePhase.RESOLVING_FIVE) {
-        throw new Error('game.snackbar.oneOffs.five.wrongPhase');
+        throw new BadRequestError('game.snackbar.oneOffs.five.wrongPhase');
       }
 
       if (player.hand.length > 0 && !requestedMove.cardId) {
-        throw new Error('game.snackbar.oneOffs.five.selectCardToDiscard');
+        throw new BadRequestError('game.snackbar.oneOffs.five.selectCardToDiscard');
       }
 
       if (requestedMove.cardId && !player.hand.find(({ id }) => id === requestedMove.cardId)) {
-        throw new Error('You must discard a card from your hand');
+        throw new BadRequestError('You must discard a card from your hand');
       }
 
       if (currentState.deck.length === 0) {
-        throw new Error('game.snackbar.oneOffs.five.fiveDeckIsEmpty');
+        throw new BadRequestError('game.snackbar.oneOffs.five.fiveDeckIsEmpty');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/resolve-four/validate.js
+++ b/api/helpers/game-states/moves/resolve-four/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to resolve a four',
@@ -37,11 +38,11 @@ module.exports = {
   fn: ({ requestedMove, currentState, playedBy }, exits) => {
     try {
       if (currentState.turn % 2 === playedBy) {
-        throw new Error('game.snackbar.oneOffs.four.notYourTurn');
+        throw new BadRequestError('game.snackbar.oneOffs.four.notYourTurn');
       }
 
       if (currentState.phase !== GamePhase.RESOLVING_FOUR) {
-        throw new Error('game.snackbar.oneOffs.four.notResolvingFourPhase');
+        throw new BadRequestError('game.snackbar.oneOffs.four.notResolvingFourPhase');
       }
 
       const player = playedBy ? currentState.p1 : currentState.p0;
@@ -51,11 +52,11 @@ module.exports = {
       const selectedCard2 = player.hand.find(card => card.id === cardId2);
 
       if ((requestedMove.cardId1 && !selectedCard1) || (requestedMove.cardId2 && !selectedCard2)) {
-        throw new Error('game.snackbar.oneOffs.four.mustSelectCards');
+        throw new BadRequestError('game.snackbar.oneOffs.four.mustSelectCards');
       }
 
       if (!selectedCard2 && player.hand.length > 1) {
-        throw new Error('game.snackbar.oneOffs.four.mustSelectCards');
+        throw new BadRequestError('game.snackbar.oneOffs.four.mustSelectCards');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/resolve-three/validate.js
+++ b/api/helpers/game-states/moves/resolve-three/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to resolve a three',
@@ -38,15 +39,15 @@ module.exports = {
       const cardExists = currentState.scrap.find(card => card.id === requestedMove.cardId);
 
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       if (currentState.phase !== GamePhase.RESOLVING_THREE) {
-        throw new Error('game.snackbar.oneOffs.three.notResolvingThreePhase');
+        throw new BadRequestError('game.snackbar.oneOffs.three.notResolvingThreePhase');
       }
 
       if (!cardExists) {
-        throw new Error('game.snackbar.oneOffs.three.mustPickFromScrap');
+        throw new BadRequestError('game.snackbar.oneOffs.three.mustPickFromScrap');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/resolve/validate.js
+++ b/api/helpers/game-states/moves/resolve/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to resolve pending one-off and counters',
@@ -38,17 +39,17 @@ module.exports = {
 
       // Must be COUNTERING phase
       if (currentState.phase !== GamePhase.COUNTERING) {
-        throw new Error(`Can only resolve during the countering phase`);
+        throw new BadRequestError(`Can only resolve during the countering phase`);
       }
 
       if (!currentState.oneOff) {
-        throw new Error('You cannot resolve unless there is a one-off pending');
+        throw new BadRequestError('You cannot resolve unless there is a one-off pending');
       }
 
       // Must be your chance to resolve
       const yourTurnToResolve = sails.helpers.gameStates.yourTurnToCounter(currentState, playedBy);
       if (!yourTurnToResolve) {
-        throw new Error('Waiting for opponent to counter');
+        throw new BadRequestError('Waiting for opponent to counter');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/scuttle/validate.js
+++ b/api/helpers/game-states/moves/scuttle/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to scuttle',
@@ -43,34 +44,34 @@ module.exports = {
       const targetCard = opponent.points.find(({ id }) => id === requestedMove.targetId);
 
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       if (currentState.phase !== GamePhase.MAIN) {
-        throw new Error('game.snackbar.global.notInMainPhase');
+        throw new BadRequestError('game.snackbar.global.notInMainPhase');
       }
 
       if (!playedCard) {
-        throw new Error('game.snackbar.global.playFromHand');
+        throw new BadRequestError('game.snackbar.global.playFromHand');
       }
 
       if (playedCard.isFrozen) {
-        throw new Error('game.snackbar.global.cardFrozen');
+        throw new BadRequestError('game.snackbar.global.cardFrozen');
       }
 
       if (playedCard.rank > 10) {
-        throw new Error('game.snackbar.points.numberOnlyForPoints');
+        throw new BadRequestError('game.snackbar.points.numberOnlyForPoints');
       }
 
       if (!targetCard) {
-        throw new Error('game.snackbar.scuttle.mustTargetPointCard');
+        throw new BadRequestError('game.snackbar.scuttle.mustTargetPointCard');
       }
 
       const lowerRank = playedCard.rank < targetCard.rank;
       const sameRankLowerSuit = playedCard.rank === targetCard.rank && playedCard.suit < targetCard.suit;
 
       if (lowerRank || sameRankLowerSuit) {
-        throw new Error('game.snackbar.scuttle.rankTooLow');
+        throw new BadRequestError('game.snackbar.scuttle.rankTooLow');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/seven-discard/validate.js
+++ b/api/helpers/game-states/moves/seven-discard/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to seven-discard',
@@ -46,29 +47,29 @@ module.exports = {
 
       // Check if it's the player's turn
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       // Check if the game phase is RESOLVING_SEVEN
       if (currentState.phase !== GamePhase.RESOLVING_SEVEN) {
-        throw new Error('game.snackbar.seven.wrongPhase');
+        throw new BadRequestError('game.snackbar.seven.wrongPhase');
       }
 
       // Check if the playedCard is one of the top two cards
       if (!playedCard) {
-        throw new Error('game.snackbar.seven.pickAndPlay');
+        throw new BadRequestError('game.snackbar.seven.pickAndPlay');
       }
 
       // Top 2 cards must both be jacks
       if (topTwoCards.some((card) => card.rank !== 11)) {
-        throw new Error('game.snackbar.jack.mustBeDoubleJacks');
+        throw new BadRequestError('game.snackbar.jack.mustBeDoubleJacks');
       }
 
       // Jacks must be unplayable due to queen or lack of points
       const queenCount = opponent.faceCards.filter(({ rank }) => rank === 12).length;
       const pointCount = opponent.points.length;
       if (queenCount === 0 && pointCount > 0) {
-        throw new Error('game.snackbar.jack.jacksMustBeUnplayable');
+        throw new BadRequestError('game.snackbar.jack.jacksMustBeUnplayable');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/seven-face-card/validate.js
+++ b/api/helpers/game-states/moves/seven-face-card/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate sevenFaceCard',
@@ -39,19 +40,19 @@ module.exports = {
       const playedCard = topTwoCards.find(({ id }) => id === requestedMove.cardId);
 
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       if (currentState.phase !== GamePhase.RESOLVING_SEVEN) {
-        throw new Error('game.snackbar.seven.wrongPhase');
+        throw new BadRequestError('game.snackbar.seven.wrongPhase');
       }
 
       if (!playedCard) {
-        throw new Error('game.snackbar.seven.pickAndPlay');
+        throw new BadRequestError('game.snackbar.seven.pickAndPlay');
       }
 
       if (![ 8, 12, 13 ].includes(playedCard.rank)) {
-        throw new Error('game.snackbar.faceCard.withoutTarget');
+        throw new BadRequestError('game.snackbar.faceCard.withoutTarget');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/seven-jack/validate.js
+++ b/api/helpers/game-states/moves/seven-jack/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to seven-jack',
@@ -48,33 +49,33 @@ module.exports = {
 
       // Check if it's the player's turn
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       // Check if the game phase is RESOLVING_SEVEN
       if (currentState.phase !== GamePhase.RESOLVING_SEVEN) {
-        throw new Error('game.snackbar.seven.wrongPhase');
+        throw new BadRequestError('game.snackbar.seven.wrongPhase');
       }
 
       // Check if the playedCard is one of the top two cards
       if (!playedCard) {
-        throw new Error('game.snackbar.seven.pickAndPlay');
+        throw new BadRequestError('game.snackbar.seven.pickAndPlay');
       }
 
       // playedCard must be a jack
       if (playedCard.rank !== 11) {
-        throw new Error('game.snackbar.jack.stealOnlyPointCards');
+        throw new BadRequestError('game.snackbar.jack.stealOnlyPointCards');
       }
 
       // targetCard must be in opponent's points
       if (!targetCard) {
-        throw new Error('game.snackbar.jack.stealOnlyPointCards');
+        throw new BadRequestError('game.snackbar.jack.stealOnlyPointCards');
       }
 
       // Can't jack if opponent has queen
       const queenCount = opponent.faceCards.filter(({ rank }) => rank === 12).length;
       if (queenCount > 0) {
-        throw new Error('game.snackbar.jack.noJackWithQueen');
+        throw new BadRequestError('game.snackbar.jack.noJackWithQueen');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/seven-one-off/validate.js
+++ b/api/helpers/game-states/moves/seven-one-off/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate sevenOneOff',
@@ -41,15 +42,15 @@ module.exports = {
       const opponent = playedBy ? currentState.p0 : currentState.p1;
 
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       if (currentState.phase !== GamePhase.RESOLVING_SEVEN) {
-        throw new Error('game.snackbar.seven.wrongPhase');
+        throw new BadRequestError('game.snackbar.seven.wrongPhase');
       }
 
       if (!playedCard) {
-        throw new Error('game.snackbar.seven.pickAndPlay');
+        throw new BadRequestError('game.snackbar.seven.pickAndPlay');
       }
 
       switch (playedCard.rank) {
@@ -68,11 +69,11 @@ module.exports = {
           );
           // Must have target
           if (!targetCard) {
-            throw new Error(`Can't find the ${requestedMove.targetId} on opponent's board`);
+            throw new BadRequestError(`Can't find the ${requestedMove.targetId} on opponent's board`);
           }
 
           if (playedCard.rank === 2 && ![ 'faceCard', 'jack' ].includes(requestedMove.targetType)) {
-            throw new Error('Twos can only target royals or glasses');
+            throw new BadRequestError('Twos can only target royals or glasses');
           }
 
           const queenCount = opponent.faceCards.filter((faceCard) => faceCard.rank === 12).length;
@@ -86,48 +87,48 @@ module.exports = {
             // One queen => can only target the queen
             case 1: {
               if (targetCard.rank !== 12) {
-                throw new Error('game.snackbar.global.blockedByQueen');
+                throw new BadRequestError('game.snackbar.global.blockedByQueen');
               }
               return exits.success();
             }
 
             // 2+ queens => Can't target at all
             default:
-              throw new Error('game.snackbar.global.blockedByMultipleQueens');
+              throw new BadRequestError('game.snackbar.global.blockedByMultipleQueens');
           }
         }
 
         // Three requires card(s) in scrap
         case 3:
           if (!currentState.scrap.length) {
-            throw new Error('game.snackbar.oneOffs.three.scrapIsEmpty');
+            throw new BadRequestError('game.snackbar.oneOffs.three.scrapIsEmpty');
           }
           return exits.success();
 
         // Four requires opponent to have cards in hand
         case 4:
           if (!opponent.hand.length) {
-            throw new Error('game.snackbar.oneOffs.four.opponentHasNoCards');
+            throw new BadRequestError('game.snackbar.oneOffs.four.opponentHasNoCards');
           }
           return exits.success();
 
         // Five and sevens require cards in deck
         case 5:
           if (!currentState.deck.length) {
-            throw new Error('game.snackbar.oneOffs.emptyDeck');
+            throw new BadRequestError('game.snackbar.oneOffs.emptyDeck');
           }
           return exits.success();
 
         // Seven requires cards in deck
         case 7:
           if (!currentState.deck.length) {
-            throw new Error('game.snackbar.oneOffs.sevenWithEmptyDeck');
+            throw new BadRequestError('game.snackbar.oneOffs.sevenWithEmptyDeck');
           }
           return exits.success();
 
         // No other cards can be used for a one-off
         default:
-          throw new Error('You cannot play that card as a one-off');
+          throw new BadRequestError('You cannot play that card as a one-off');
       }
     } catch (err) {
       return exits.error(err);

--- a/api/helpers/game-states/moves/seven-points/validate.js
+++ b/api/helpers/game-states/moves/seven-points/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate sevenPoints',
@@ -39,19 +40,19 @@ module.exports = {
       const playedCard = topTwoCards.find(({ id }) => id === requestedMove.cardId);
 
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       if (currentState.phase !== GamePhase.RESOLVING_SEVEN) {
-        throw new Error('game.snackbar.seven.wrongPhase');
+        throw new BadRequestError('game.snackbar.seven.wrongPhase');
       }
 
       if (!playedCard) {
-        throw new Error('game.snackbar.seven.pickAndPlay');
+        throw new BadRequestError('game.snackbar.seven.pickAndPlay');
       }
 
       if (playedCard.rank > 10) {
-        throw new Error('game.snackbar.points.numberOnlyForPoints');
+        throw new BadRequestError('game.snackbar.points.numberOnlyForPoints');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/seven-scuttle/validate.js
+++ b/api/helpers/game-states/moves/seven-scuttle/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to seven-scuttle',
@@ -48,37 +49,37 @@ module.exports = {
 
       // Check if it's the player's turn
       if (currentState.turn % 2 !== playedBy) {
-        throw new Error('game.snackbar.global.notYourTurn');
+        throw new BadRequestError('game.snackbar.global.notYourTurn');
       }
 
       // Check if the game phase is RESOLVING_SEVEN
       if (currentState.phase !== GamePhase.RESOLVING_SEVEN) {
-        throw new Error('game.snackbar.seven.wrongPhase');
+        throw new BadRequestError('game.snackbar.seven.wrongPhase');
       }
 
       // Check if the playedCard is one of the top two cards
       if (!playedCard) {
-        throw new Error('game.snackbar.seven.pickAndPlay');
+        throw new BadRequestError('game.snackbar.seven.pickAndPlay');
       }
 
       // Check if the playedCard is a number card (rank < 11)
       if (playedCard.rank >= 11) {
-        throw new Error('game.snackbar.points.numberOnlyForPoints');
+        throw new BadRequestError('game.snackbar.points.numberOnlyForPoints');
       }
 
       // Check if the targetCard is in the opponent's points
       if (!targetCard) {
-        throw new Error('game.snackbar.scuttle.mustTargetPointCard');
+        throw new BadRequestError('game.snackbar.scuttle.mustTargetPointCard');
       }
 
       if (playedCard.rank < targetCard.rank) {
-        throw new Error('game.snackbar.scuttle.rankTooLow');
+        throw new BadRequestError('game.snackbar.scuttle.rankTooLow');
       }
 
       const lowerRank = playedCard.rank < targetCard.rank;
       const sameRankLowerSuit = playedCard.rank === targetCard.rank && playedCard.suit < targetCard.suit;
       if (lowerRank || sameRankLowerSuit) {
-        throw new Error('game.snackbar.scuttle.rankTooLow');
+        throw new BadRequestError('game.snackbar.scuttle.rankTooLow');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/stalemate-accept/validate.js
+++ b/api/helpers/game-states/moves/stalemate-accept/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to accept pending stalemate offer',
@@ -37,12 +38,12 @@ module.exports = {
     try {
       // Must already be considering a stalemate
       if (currentState.phase !== GamePhase.CONSIDERING_STALEMATE) {
-        throw new Error('game.snackbar.stalemate.noStalemateOffered');
+        throw new BadRequestError('game.snackbar.stalemate.noStalemateOffered');
       }
 
       // Cannot accept your own stalemate request
       if (currentState.playedBy === playedBy) {
-        throw new Error('game.snackbar.stalemate.opponentConsideringStalemate');
+        throw new BadRequestError('game.snackbar.stalemate.opponentConsideringStalemate');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/stalemate-reject/validate.js
+++ b/api/helpers/game-states/moves/stalemate-reject/validate.js
@@ -1,4 +1,5 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request to reject pending stalemate offer',
@@ -37,12 +38,12 @@ module.exports = {
     try {
       // Must already be considering a stalemate
       if (currentState.phase !== GamePhase.CONSIDERING_STALEMATE) {
-        throw new Error('game.snackbar.stalemate.noStalemateOffered');
+        throw new BadRequestError('game.snackbar.stalemate.noStalemateOffered');
       }
 
       // Cannot reject your own stalemate request
       if (currentState.playedBy === playedBy) {
-        throw new Error('game.snackbar.stalemate.opponentConsideringStalemate');
+        throw new BadRequestError('game.snackbar.stalemate.opponentConsideringStalemate');
       }
 
       return exits.success();

--- a/api/helpers/game-states/moves/stalemate-request/validate.js
+++ b/api/helpers/game-states/moves/stalemate-request/validate.js
@@ -1,5 +1,6 @@
 const GamePhase = require('../../../../../utils/GamePhase.json');
 const MoveType = require('../../../../../utils/MoveType.json');
+const BadRequestError = require('../../../../errors/badRequestError');
 
 module.exports = {
   friendlyName: 'Validate request for Stalemate',
@@ -39,7 +40,7 @@ module.exports = {
 
       // Must not already be considering a stalemate
       if (currentState.phase === GamePhase.STALEMATE_REQUEST) {
-        throw new Error('game.snackbar.stalemate.alreadyConsideringStalemate');
+        throw new BadRequestError('game.snackbar.stalemate.alreadyConsideringStalemate');
       }
 
       // Can't request stalemate more than once per turn
@@ -48,12 +49,12 @@ module.exports = {
           (state) => state.moveType === MoveType.STALEMATE_REQUEST && state.turn === currentState.turn,
         )
       ) {
-        throw new Error('game.snackbar.stalemate.previousStalemateRejected');
+        throw new BadRequestError('game.snackbar.stalemate.previousStalemateRejected');
       }
 
       // Must be in main phase
       if (currentState.phase !== GamePhase.MAIN) {
-        throw new Error('game.snackbar.stalemate.wrongPhase');
+        throw new BadRequestError('game.snackbar.stalemate.wrongPhase');
       }
 
 

--- a/api/helpers/unlock-game.js
+++ b/api/helpers/unlock-game.js
@@ -14,6 +14,10 @@ module.exports = {
   },
 
   fn: async ({ lock }, exits) => {
+    if (!lock) {
+      return exits.success();
+    }
+
     await Game.updateOne({ lock }).set({ lock: null, lockedAt: null });
     return exits.success();
   },


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

Creates new Error subclass `BadRequestError` and applies it throughout move validation in the GameState API. Requests to make a move will now 500 by default and will 400 and 403 for specific errors

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #1195 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
