### PR TITLE
fix(scuttle/execute): scrap all jacks when scuttling

### DIFF
--- a/api/helpers/game-states/moves/scuttle/execute.js
+++ b/api/helpers/game-states/moves/scuttle/execute.js
@@ -46,10 +46,11 @@ module.exports = {
     
     // remove target card from opponent points
     const targetPlayedIndex = opponent.points.findIndex(({ id }) => id === targetId);
-    const [ targetCard ]= opponent.points.splice(targetPlayedIndex, 1);
+    const [ targetCard ] = opponent.points.splice(targetPlayedIndex, 1);
     
     // move both cards into scrap
-    result.scrap.push(targetCard, playedCard );
+    result.scrap.push(playedCard, ...targetCard.attachments, targetCard);
+    targetCard.attachments = [];
 
     result.turn++;
 

--- a/tests/e2e/specs/in-game/basicMoves.spec.js
+++ b/tests/e2e/specs/in-game/basicMoves.spec.js
@@ -170,6 +170,55 @@ describe('Game Basic Moves - P0 Perspective', () => {
     cy.log('Scuttling is disabled with specific message when opponent has no points');
   });
 
+  it('Scuttles a card with two jacks on it', () => {
+    cy.loadGameFixture(0, {
+      p0Hand: [ Card.JACK_OF_CLUBS, Card.TEN_OF_SPADES ],
+      p0Points: [ Card.TEN_OF_HEARTS ],
+      p0FaceCards: [ ],
+      p1Hand: [ Card.JACK_OF_DIAMONDS ],
+      p1Points: [ Card.FOUR_OF_DIAMONDS ],
+      p1FaceCards: [],
+    });
+
+    cy.get('[data-player-hand-card=11-0]').click();
+    cy.get('[data-move-choice=jack]').click();
+    cy.get('[data-opponent-point-card=4-1]').click();
+
+    assertGameState(0, {
+      p0Hand: [ Card.TEN_OF_SPADES ],
+      p0Points: [ Card.TEN_OF_HEARTS, Card.FOUR_OF_DIAMONDS ],
+      p0FaceCards: [ ],
+      p1Hand: [ Card.JACK_OF_DIAMONDS ],
+      p1Points: [],
+      p1FaceCards: [],
+    });
+
+    cy.playJackOpponent(Card.JACK_OF_DIAMONDS, Card.FOUR_OF_DIAMONDS);
+
+    assertGameState(0, {
+      p0Hand: [  Card.TEN_OF_SPADES ],
+      p0Points: [ Card.TEN_OF_HEARTS ],
+      p0FaceCards: [ ],
+      p1Hand: [],
+      p1Points: [ Card.FOUR_OF_DIAMONDS ],
+      p1FaceCards: [],
+    });
+
+    cy.get('[data-player-hand-card=10-3]').click();
+    cy.get('[data-move-choice=scuttle]').click();
+    cy.get('[data-opponent-point-card=4-1]').click({ force: true });
+
+    assertGameState(0, {
+      p0Hand: [],
+      p0Points: [ Card.TEN_OF_HEARTS ],
+      p0FaceCards: [ ],
+      p1Hand: [],
+      p1Points: [],
+      p1FaceCards: [],
+      scrap: [ Card.FOUR_OF_DIAMONDS, Card.TEN_OF_SPADES, Card.JACK_OF_CLUBS, Card.JACK_OF_DIAMONDS ],
+    });
+  });
+
   it('Plays Kings', () => {
     // Setup
     cy.loadGameFixture(0, {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

Fixes bug where scuttling was not putting jacks into the scrap

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
