### PR TITLE
Fix/resolve five log

### DIFF
--- a/api/helpers/game-states/get-log.js
+++ b/api/helpers/game-states/get-log.js
@@ -35,8 +35,9 @@ module.exports = {
 
       const getResolveFiveMessage = () => {
         const previousRow = game.gameStates[i - 1] ?? null;
-        const amountOfCardsDrawn =
-          row[`p${row.playedBy}Hand`]?.length - previousRow[`p${row.playedBy}Hand`?.length];
+        let amountOfCardsDrawn =
+          row[`p${row.playedBy}Hand`]?.length - previousRow[`p${row.playedBy}Hand`]?.length;
+        amountOfCardsDrawn += row.discardedCards.length; // account for discarded cards in num drawn
 
         return amountOfCardsDrawn === 1 ? `draws 1 card` : `draws ${amountOfCardsDrawn} cards`;
       };

--- a/api/helpers/game-states/get-log.js
+++ b/api/helpers/game-states/get-log.js
@@ -39,7 +39,7 @@ module.exports = {
           row[`p${row.playedBy}Hand`]?.length - previousRow[`p${row.playedBy}Hand`]?.length;
         amountOfCardsDrawn += row.discardedCards.length; // account for discarded cards in num drawn
 
-        return amountOfCardsDrawn === 1 ? `draws 1 card` : `draws ${amountOfCardsDrawn} cards`;
+        return amountOfCardsDrawn === 1 ? `drew 1 card` : `drew ${amountOfCardsDrawn} cards`;
       };
 
       switch (moveType) {
@@ -129,7 +129,7 @@ module.exports = {
               discardedCards[0],
             )} and ${getResolveFiveMessage()}`;
           }
-          return `${player} ${getResolveFiveMessage()}`;
+          return `${player} skipped discarding (empty hand) and ${getResolveFiveMessage()}`;
 
         case MoveType.SEVEN_POINTS:
           return `${player} played the ${playedCardName} from the top of the deck for points.`;

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -303,7 +303,12 @@
             </h3>
             <v-divider />
             <div id="history-logs" ref="logsContainer" class="d-flex flex-column">
-              <p v-for="(log, index) in logs" :key="index" class="my-2">
+              <p
+                v-for="(log, index) in logs"
+                :key="index"
+                class="my-2"
+                data-cy="history-log"
+              >
                 {{ log }}
               </p>
             </div>

--- a/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
@@ -8,7 +8,7 @@ describe('FIVES', () => {
     });
 
     describe('Legal FIVES', () => {
-      it.only('Plays a 5 to discard 1 card, and draw 3', () => {
+      it('Plays a 5 to discard 1 card, and draw 3', () => {
         // Setup
         cy.loadGameFixture(0, {
           // Player is P0
@@ -32,7 +32,7 @@ describe('FIVES', () => {
         cy.get('#deck').should('contain', '(39)');
         cy.get('[data-player-hand-card]').should('have.length', 4);
 
-        cy.get('[data-cy=history-log]').should('contain', 'myUsername discarded the A♣️ and draws 3 cards');
+        cy.get('[data-cy=history-log]').should('contain', 'myUsername discarded the A♣️ and drew 3 cards');
         // Attempt to plays five out of turn
         cy.get('[data-player-hand-card=5-2]').click(); // five of hearts
         playOutOfTurn('oneOff');
@@ -84,6 +84,8 @@ describe('FIVES', () => {
           secondCard: null,
           deck: [],
         });
+
+        cy.get('[data-cy=history-log]').should('contain', 'myUsername skipped discarding (empty hand) and drew 3 cards');
         // Deck should now be empty
         cy.get('#deck').should('contain', '(0)')
           .should('contain', 'PASS');

--- a/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
@@ -32,7 +32,7 @@ describe('FIVES', () => {
         cy.get('#deck').should('contain', '(39)');
         cy.get('[data-player-hand-card]').should('have.length', 4);
 
-        cy.get('#history').should('contain', 'myUsername discarded the A♣️ and draws 3 cards');
+        cy.get('[data-cy=history-log]').should('contain', 'myUsername discarded the A♣️ and draws 3 cards');
         // Attempt to plays five out of turn
         cy.get('[data-player-hand-card=5-2]').click(); // five of hearts
         playOutOfTurn('oneOff');

--- a/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
@@ -8,7 +8,7 @@ describe('FIVES', () => {
     });
 
     describe('Legal FIVES', () => {
-      it('Plays a 5 to discard 1 card, and draw 3', () => {
+      it.only('Plays a 5 to discard 1 card, and draw 3', () => {
         // Setup
         cy.loadGameFixture(0, {
           // Player is P0
@@ -31,6 +31,8 @@ describe('FIVES', () => {
 
         cy.get('#deck').should('contain', '(39)');
         cy.get('[data-player-hand-card]').should('have.length', 4);
+
+        cy.get('#history').should('contain', 'myUsername discarded the A♣️ and draws 3 cards');
         // Attempt to plays five out of turn
         cy.get('[data-player-hand-card=5-2]').click(); // five of hearts
         playOutOfTurn('oneOff');


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes bug in logs for resolve five where they would show 'NaN' cards:

![image](https://github.com/user-attachments/assets/acafcf1a-1c0c-4bde-83ef-33e16d6df984)

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #1200 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
