### PR TITLE
fix: disable rollbar in the hopes that this prevents the home page crashes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import i18n from '@/plugins/i18n';
-import rollbar from '@/plugins/rollbar';
+// import rollbar from '@/plugins/rollbar';
 import vuetify from '@/plugins/vuetify';
 import router from '@/router';
 import { createHead } from '@unhead/vue';

--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,7 @@ const head = createHead();
 // Add rollbar to vue
 if (import.meta.env.VITE_ROLLBAR_ACCESS_TOKEN) {
   // TODO #1129 - re-enable rollbar when it doesn't crash the tab
-  app.use(rollbar);
+  // app.use(rollbar);
 }
 
 // Add router to vue

--- a/src/plugins/rollbar.js
+++ b/src/plugins/rollbar.js
@@ -51,6 +51,6 @@ export default {
 
       rollbar.error(error, { vueComponent, info });
     };
-    // app.provide('rollbar', rollbar);
+    app.provide('rollbar', rollbar);
   },
 };

--- a/src/plugins/rollbar.js
+++ b/src/plugins/rollbar.js
@@ -51,6 +51,6 @@ export default {
 
       rollbar.error(error, { vueComponent, info });
     };
-    app.provide('rollbar', rollbar);
+    // app.provide('rollbar', rollbar);
   },
 };


### PR DESCRIPTION
Users are reporting that navigating to the home page sometimes crashes the app with an out of memory error (Oh Snap! in chrome). Due to #1161 and issues with rollbar performance in the past, I'm disabling the error logger to see if that's the culprit.

<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
