### PR TITLE
 Fix for issue #1199-color of the ranked and casual switch changed to newPrimary

### DIFF
--- a/src/routes/lobby/LobbyView.vue
+++ b/src/routes/lobby/LobbyView.vue
@@ -57,7 +57,7 @@
                   class="mx-md-4 pl-2 flex-shrink-0"
                   :label="gameStore.isRanked ? t('global.ranked') : t('global.casual')"
                   data-cy="edit-game-ranked-switch"
-                  color="primary"
+                  color="newPrimary"
                   hide-details
                   @update:model-value="setIsRanked"
                   @keydown.enter.stop="(e) => e.target.click()"


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [#1199 ](https://github.com/cuttle-cards/cuttle/issues/1199)
- Resolves #1199 - color of switch changed to newPrimary

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
PFA the screenshot of the fix on the ranked/casual switch button
[
<img width="1440" alt="Screenshot 2025-06-06 at 11 36 31 PM" src="https://github.com/user-attachments/assets/a259e8a5-f60d-4bea-b3da-0c8f451e30e4" />
](url)
