### PR TITLE
fix(HomeView.vue): clear game store state on created

### DIFF
--- a/src/routes/home/HomeView.vue
+++ b/src/routes/home/HomeView.vue
@@ -145,8 +145,9 @@
 </template>
 <script>
 import { mapStores } from 'pinia';
-import { useGameListStore } from '@/stores/gameList';
 import { useI18n } from 'vue-i18n';
+import { useGameListStore } from '@/stores/gameList';
+import { useGameStore } from '@/stores/game';
 import GameListItem from '@/routes/home/components/GameListItem.vue';
 import CreateGameDialog from '@/routes/home/components/CreateGameDialog.vue';
 import BaseSnackbar from '@/components/BaseSnackbar.vue';
@@ -186,7 +187,7 @@ export default {
     };
   },
   computed: {
-    ...mapStores(useGameListStore),
+    ...mapStores(useGameListStore, useGameStore),
     playableGameList() {
       return this.gameListStore.openGames;
     },
@@ -212,6 +213,7 @@ export default {
     }
   },
   async created() {
+    this.gameStore.resetState();
     await this.gameListStore.requestGameList();
     this.loadingData = false;
     this.tab = this.$route.path;


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Hoping this clears up issues where players were directed to old games after creating a new one from the home view.
## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
