### PR TITLE
Fix/replays on ranked games

### DIFF
--- a/api/helpers/add-game-to-match.js
+++ b/api/helpers/add-game-to-match.js
@@ -25,7 +25,22 @@ module.exports = {
       const player1Id = game.p0?.id ?? game.p0;
       const player2Id = game.p1?.id ?? game.p1;
 
+      if (game.match) {
+        const match = await Match.findOne(game.match).populate('games');
+        match.games = match.games.filter((matchGame) => matchGame.id <= game.id);
+        const p1Wins = match.games.filter((matchGame) => matchGame.winner = match.player1);
+        const p2Wins = match.games.filter((matchGame) => matchGame.winner = match.player2);
+
+        // Compute winner based on games played prior to current game
+        match.winner = p1Wins >= 2 ? 
+          match.player1 : p2Wins >= 2 ?
+            match.player2 : null;
+
+        return exits.success(match);
+      }
+
       let relevantMatch = await sails.helpers.findOrCreateCurrentMatch(player1Id, player2Id);
+
       if (!relevantMatch) {
         return exits.error(new Error('Could not add game to match'));
       }

--- a/api/helpers/add-game-to-match.js
+++ b/api/helpers/add-game-to-match.js
@@ -28,8 +28,8 @@ module.exports = {
       if (game.match) {
         const match = await Match.findOne(game.match).populate('games');
         match.games = match.games.filter((matchGame) => matchGame.id <= game.id);
-        const p1Wins = match.games.filter((matchGame) => matchGame.winner = match.player1);
-        const p2Wins = match.games.filter((matchGame) => matchGame.winner = match.player2);
+        const p1Wins = match.games.filter((matchGame) => matchGame.winner === match.player1).length;
+        const p2Wins = match.games.filter((matchGame) => matchGame.winner === match.player2).length;
 
         // Compute winner based on games played prior to current game
         match.winner = p1Wins >= 2 ? 

--- a/tests/e2e/specs/in-game/game-over/rankedMatches.spec.js
+++ b/tests/e2e/specs/in-game/game-over/rankedMatches.spec.js
@@ -1,5 +1,5 @@
 import GameStatus from '../../../../../utils/GameStatus.json';
-import { assertLoss, assertVictory, assertStalemate } from '../../../support/helpers';
+import { assertLoss, assertVictory, assertStalemate, setupSeasons } from '../../../support/helpers';
 import { seasonFixtures } from '../../../fixtures/statsFixtures';
 import { playerOne, playerTwo, playerThree } from '../../../fixtures/userFixtures';
 import { Card } from '../../../fixtures/cards';
@@ -26,49 +26,7 @@ function validateGameResult({ status, winner }, expectedWinner) {
 
 describe('Creating And Updating Ranked Matches', () => {
   beforeEach(function () {
-    cy.wipeDatabase();
-    cy.visit('/');
-
-    // Set up season
-    const [ , diamondsSeason ] = seasonFixtures;
-    diamondsSeason.startTime = dayjs.utc().subtract(2, 'week')
-      .subtract(1, 'day')
-      .toDate();
-    diamondsSeason.endTime = dayjs.utc().add(11, 'weeks')
-      .toDate();
-    cy.loadSeasonFixture([ diamondsSeason ]);
-    // Sign up to players and store their id's for comparison to match data
-    cy.signupOpponent(playerOne).as('playerOneId');
-    cy.signupOpponent(playerThree).as('playerThreeId');
-    // Opponent will be player 2 (the last one we log in as)
-    cy.signupOpponent(playerTwo)
-      .as('playerTwoId')
-      .then(function () {
-        // Create match from last week, which current games don't count towards
-        const oldMatchBetweenPlayers = {
-          player1: this.playerOneId,
-          player2: this.playerTwoId,
-          winner: this.playerOneId,
-          startTime: dayjs.utc().subtract(1, 'week')
-            .subtract(1, 'day')
-            .toDate(),
-          endTime: dayjs.utc().subtract(1, 'week')
-            .subtract(1, 'day')
-            .toDate(),
-        };
-
-        const currentMatchWithDifferentOpponent = {
-          player1: this.playerOneId,
-          player2: this.playerThreeId,
-          winner: null,
-          startTime: dayjs.utc().subtract(1, 'hour')
-            .toDate(),
-          endTime: dayjs.utc().subtract(1, 'hour')
-            .toDate(),
-        };
-
-        cy.loadMatchFixtures([ oldMatchBetweenPlayers, currentMatchWithDifferentOpponent ]);
-      });
+    setupSeasons();
     // Log in as playerOne
     cy.loginPlayer(playerOne);
     cy.setupGameAsP0(true, true);

--- a/tests/e2e/specs/in-game/game-over/rankedMatches.spec.js
+++ b/tests/e2e/specs/in-game/game-over/rankedMatches.spec.js
@@ -1,7 +1,6 @@
 import GameStatus from '../../../../../utils/GameStatus.json';
 import { assertLoss, assertVictory, assertStalemate, setupSeasons } from '../../../support/helpers';
-import { seasonFixtures } from '../../../fixtures/statsFixtures';
-import { playerOne, playerTwo, playerThree } from '../../../fixtures/userFixtures';
+import { playerOne } from '../../../fixtures/userFixtures';
 import { Card } from '../../../fixtures/cards';
 
 const dayjs = require('dayjs');

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -1,9 +1,14 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import { setupGameBetweenTwoUnseenPlayers, assertGameState, assertGameOverAsSpectator, assertSnackbar } from '../../../support/helpers';
-import { myUser, playerOne, playerTwo, playerThree } from '../../../fixtures/userFixtures';
+import {
+  setupSeasons,
+  setupGameBetweenTwoUnseenPlayers,
+  assertGameState,
+  assertGameOverAsSpectator,
+  assertSnackbar
+} from '../../../support/helpers';
+import { myUser, playerOne, playerTwo } from '../../../fixtures/userFixtures';
 import { Card } from '../../../fixtures/cards';
-import { seasonFixtures } from '../../../fixtures/statsFixtures';
 import GameStatus from '../../../../../utils/GameStatus.json';
 
 dayjs.extend(utc);
@@ -461,49 +466,7 @@ describe('Rewatching finished games', () => {
 
   describe('Rewatching ranked matches', () => {
     beforeEach(() => {
-      cy.wipeDatabase();
-      cy.visit('/');
-  
-      // Set up season
-      const [ , diamondsSeason ] = seasonFixtures;
-      diamondsSeason.startTime = dayjs.utc().subtract(2, 'week')
-        .subtract(1, 'day')
-        .toDate();
-      diamondsSeason.endTime = dayjs.utc().add(11, 'weeks')
-        .toDate();
-      cy.loadSeasonFixture([ diamondsSeason ]);
-      // Sign up to players and store their id's for comparison to match data
-      cy.signupOpponent(playerOne).as('playerOneId');
-      cy.signupOpponent(playerThree).as('playerThreeId');
-      // Opponent will be player 2 (the last one we log in as)
-      cy.signupOpponent(playerTwo)
-        .as('playerTwoId')
-        .then(function () {
-          // Create match from last week, which current games don't count towards
-          const oldMatchBetweenPlayers = {
-            player1: this.playerOneId,
-            player2: this.playerTwoId,
-            winner: this.playerOneId,
-            startTime: dayjs.utc().subtract(1, 'week')
-              .subtract(1, 'day')
-              .toDate(),
-            endTime: dayjs.utc().subtract(1, 'week')
-              .subtract(1, 'day')
-              .toDate(),
-          };
-  
-          const currentMatchWithDifferentOpponent = {
-            player1: this.playerOneId,
-            player2: this.playerThreeId,
-            winner: null,
-            startTime: dayjs.utc().subtract(1, 'hour')
-              .toDate(),
-            endTime: dayjs.utc().subtract(1, 'hour')
-              .toDate(),
-          };
-  
-          cy.loadMatchFixtures([ oldMatchBetweenPlayers, currentMatchWithDifferentOpponent ]);
-        });
+      setupSeasons();
     });
 
     it.only('Rewatches a ranked match', () => {

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -460,7 +460,7 @@ describe('Rewatching finished games', () => {
   });
 
   describe('Rewatching ranked matches', () => {
-    it('Rewatches a ranked match', () => {
+    beforeEach(() => {
       cy.wipeDatabase();
       cy.visit('/');
   
@@ -504,6 +504,9 @@ describe('Rewatching finished games', () => {
   
           cy.loadMatchFixtures([ oldMatchBetweenPlayers, currentMatchWithDifferentOpponent ]);
         });
+    });
+
+    it.only('Rewatches a ranked match', () => {
 
       setupGameBetweenTwoUnseenPlayers('replay', true);
       cy.get('@replayGameId').then((gameId) => {

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -492,6 +492,10 @@ describe('Rewatching finished games', () => {
           cy.get('[data-cy=skip-forward]').click();
           assertGameOverAsSpectator({ p1Wins: 0, p2Wins: 1, stalemates: 0, winner: 'p2', isRanked: true });
           cy.reload();
+          assertGameOverAsSpectator({ p1Wins: 0, p2Wins: 1, stalemates: 0, winner: 'p2', isRanked: true });
+
+          cy.get('[data-cy=gameover-rematch]').click();
+          cy.url().should('include', `spectate/${rematchGameId}?gameStateIndex=0`);
         });
       });
 

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -469,7 +469,7 @@ describe('Rewatching finished games', () => {
       setupSeasons();
     });
 
-    it.only('Rewatches a ranked match', () => {
+    it('Rewatches a ranked match', () => {
 
       setupGameBetweenTwoUnseenPlayers('replay', true);
       cy.get('@replayGameId').then((gameId) => {

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -496,6 +496,10 @@ describe('Rewatching finished games', () => {
 
           cy.get('[data-cy=gameover-rematch]').click();
           cy.url().should('include', `spectate/${rematchGameId}?gameStateIndex=0`);
+
+          cy.get('[data-cy=skip-forward]').click();
+          cy.url().should('include', `spectate/${rematchGameId}?gameStateIndex=-1`);
+          assertGameOverAsSpectator({ p1Wins: 0, p2Wins: 2, stalemates: 0, winner: 'p2', isRanked: true, rematchWasDeclined: true });
         });
       });
 

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -1,8 +1,9 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { setupGameBetweenTwoUnseenPlayers, assertGameState, assertGameOverAsSpectator, assertSnackbar } from '../../../support/helpers';
-import { myUser, playerOne, playerTwo } from '../../../fixtures/userFixtures';
+import { myUser, playerOne, playerTwo, playerThree } from '../../../fixtures/userFixtures';
 import { Card } from '../../../fixtures/cards';
+import { seasonFixtures } from '../../../fixtures/statsFixtures';
 import GameStatus from '../../../../../utils/GameStatus.json';
 
 dayjs.extend(utc);
@@ -455,6 +456,79 @@ describe('Rewatching finished games', () => {
         cy.wait(1000);
         cy.get('#game-over-dialog').should('not.exist');
       });
+    });
+  });
+
+  describe('Rewatching ranked matches', () => {
+    it('Rewatches a ranked match', () => {
+      cy.wipeDatabase();
+      cy.visit('/');
+  
+      // Set up season
+      const [ , diamondsSeason ] = seasonFixtures;
+      diamondsSeason.startTime = dayjs.utc().subtract(2, 'week')
+        .subtract(1, 'day')
+        .toDate();
+      diamondsSeason.endTime = dayjs.utc().add(11, 'weeks')
+        .toDate();
+      cy.loadSeasonFixture([ diamondsSeason ]);
+      // Sign up to players and store their id's for comparison to match data
+      cy.signupOpponent(playerOne).as('playerOneId');
+      cy.signupOpponent(playerThree).as('playerThreeId');
+      // Opponent will be player 2 (the last one we log in as)
+      cy.signupOpponent(playerTwo)
+        .as('playerTwoId')
+        .then(function () {
+          // Create match from last week, which current games don't count towards
+          const oldMatchBetweenPlayers = {
+            player1: this.playerOneId,
+            player2: this.playerTwoId,
+            winner: this.playerOneId,
+            startTime: dayjs.utc().subtract(1, 'week')
+              .subtract(1, 'day')
+              .toDate(),
+            endTime: dayjs.utc().subtract(1, 'week')
+              .subtract(1, 'day')
+              .toDate(),
+          };
+  
+          const currentMatchWithDifferentOpponent = {
+            player1: this.playerOneId,
+            player2: this.playerThreeId,
+            winner: null,
+            startTime: dayjs.utc().subtract(1, 'hour')
+              .toDate(),
+            endTime: dayjs.utc().subtract(1, 'hour')
+              .toDate(),
+          };
+  
+          cy.loadMatchFixtures([ oldMatchBetweenPlayers, currentMatchWithDifferentOpponent ]);
+        });
+
+      setupGameBetweenTwoUnseenPlayers('replay', true);
+      cy.get('@replayGameId').then((gameId) => {
+        cy.recoverSessionOpponent(playerOne);
+        cy.concedeOpponent(gameId);
+        cy.rematchOpponent({ gameId, rematch: true, skipDomAssertion: true });
+        cy.recoverSessionOpponent(playerTwo);
+        cy.rematchOpponent({ gameId, rematch: true, skipDomAssertion: true });
+        cy.get(`@game${gameId}RematchId`).then((rematchGameId) => {
+          cy.recoverSessionOpponent(playerOne);
+          cy.concedeOpponent(rematchGameId);
+          cy.rematchOpponent({ gameId: rematchGameId, rematch: false, skipDomAssertion: true });
+          cy.recoverSessionOpponent(playerTwo);
+          cy.rematchOpponent({ gameId: rematchGameId, rematch: false, skipDomAssertion: true });
+
+          cy.visit('/');
+          cy.signupPlayer(myUser);
+          cy.vueRoute(`/spectate/${gameId}`);
+
+          cy.get('[data-cy=skip-forward]').click();
+          assertGameOverAsSpectator({ p1Wins: 0, p2Wins: 1, stalemates: 0, winner: 'p2', isRanked: true });
+          cy.reload();
+        });
+      });
+
     });
   });
 

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -225,9 +225,10 @@ Cypress.Commands.add('loginPlayer', (player) => {
   cy.log(`Logged in as player ${player.username}`);
 });
 
-Cypress.Commands.add('createGameOpponent', (name) => {
+Cypress.Commands.add('createGameOpponent', (name, isRanked = false) => {
   cy.makeSocketRequest('game', '', {
     gameName: name,
+    isRanked
   });
 });
 

--- a/tests/e2e/support/helpers.js
+++ b/tests/e2e/support/helpers.js
@@ -1,5 +1,10 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import { SnackBarError } from '../fixtures/snackbarError';
-import { playerOne, playerTwo } from '../fixtures/userFixtures';
+import { playerOne, playerTwo, playerThree } from '../fixtures/userFixtures';
+import { seasonFixtures } from '../fixtures/statsFixtures';
+
+dayjs.extend(utc);
 
 export function hasValidSuitAndRank(card) {
   if (!Object.prototype.hasOwnProperty.call(card, 'rank')) {
@@ -294,6 +299,52 @@ function assertDomMatchesFixture(pNum, fixture, spectating) {
   if (fixture.scrap) {
     cy.get('#scrap').contains(`(${fixture.scrap.length})`);
   }
+}
+
+export function setupSeasons() {
+  cy.wipeDatabase();
+  cy.visit('/');
+
+  // Set up season
+  const [ , diamondsSeason ] = seasonFixtures;
+  diamondsSeason.startTime = dayjs.utc().subtract(2, 'week')
+    .subtract(1, 'day')
+    .toDate();
+  diamondsSeason.endTime = dayjs.utc().add(11, 'weeks')
+    .toDate();
+  cy.loadSeasonFixture([ diamondsSeason ]);
+  // Sign up to players and store their id's for comparison to match data
+  cy.signupOpponent(playerOne).as('playerOneId');
+  cy.signupOpponent(playerThree).as('playerThreeId');
+  // Opponent will be player 2 (the last one we log in as)
+  cy.signupOpponent(playerTwo)
+    .as('playerTwoId')
+    .then(function () {
+      // Create match from last week, which current games don't count towards
+      const oldMatchBetweenPlayers = {
+        player1: this.playerOneId,
+        player2: this.playerTwoId,
+        winner: this.playerOneId,
+        startTime: dayjs.utc().subtract(1, 'week')
+          .subtract(1, 'day')
+          .toDate(),
+        endTime: dayjs.utc().subtract(1, 'week')
+          .subtract(1, 'day')
+          .toDate(),
+      };
+
+      const currentMatchWithDifferentOpponent = {
+        player1: this.playerOneId,
+        player2: this.playerThreeId,
+        winner: null,
+        startTime: dayjs.utc().subtract(1, 'hour')
+          .toDate(),
+        endTime: dayjs.utc().subtract(1, 'hour')
+          .toDate(),
+      };
+
+      cy.loadMatchFixtures([ oldMatchBetweenPlayers, currentMatchWithDifferentOpponent ]);
+    });
 }
 
 /**

--- a/tests/e2e/support/helpers.js
+++ b/tests/e2e/support/helpers.js
@@ -516,8 +516,8 @@ export function assertStalemate(score = null) {
     });
 }
 
-export function setupGameBetweenTwoUnseenPlayers(gameName) {
-  cy.createGameOpponent(gameName).then(({ gameId }) => {
+export function setupGameBetweenTwoUnseenPlayers(gameName, isRanked = false) {
+  cy.createGameOpponent(gameName, isRanked).then(({ gameId }) => {
     cy.wrap(gameId).as(`${gameName}GameId`);
     cy.recoverSessionOpponent(playerOne);
     cy.subscribeOpponent(gameId);

--- a/tests/e2e/support/helpers.js
+++ b/tests/e2e/support/helpers.js
@@ -625,7 +625,7 @@ export function assertGameOverAsSpectator({ p1Wins, p2Wins, stalemates, winner, 
 
   const isRankedIcon = isRanked ? 'ranked-icon' : 'casual-icon';
   const rankedIconVisibility = rematchWasDeclined ? 'not.exist' : 'be.visible';
-  const bannerMessage = matchIsOver ? 'Good Match!' : rematchWasDeclined ? 'Player left - click to go home.' : 'Continue Spectating?';
+  const bannerMessage = rematchWasDeclined ? 'Player left - click to go home.' : matchIsOver ? 'Good Match!'  : 'Continue Spectating?';
   cy.get('[data-cy=continue-match-banner]')
     .should('be.visible')
     .should('contain', bannerMessage)


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

Fixes bug where rewatching a ranked match incorrectly sets the game to unranked when you hit the final state and incorrectly computes wins/losses.

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
