### PR TITLE
Feat/log in as spectator

### DIFF
--- a/src/routes/game/components/dialogs/components/ReauthenticateDialog.vue
+++ b/src/routes/game/components/dialogs/components/ReauthenticateDialog.vue
@@ -56,6 +56,7 @@
 import { mapStores } from 'pinia';
 import { useAuthStore } from '@/stores/auth';
 import { useGameStore } from '@/stores/game';
+import { useGameHistoryStore } from '@/stores/gameHistory';
 import BaseDialog from '@/components/BaseDialog.vue';
 import BaseSnackbar from '@/components/BaseSnackbar.vue';
 import { useI18n } from 'vue-i18n';
@@ -86,7 +87,7 @@ export default {
     };
   },
   computed: {
-    ...mapStores(useAuthStore, useGameStore),
+    ...mapStores(useAuthStore, useGameStore, useGameHistoryStore),
     show: {
       get() {
         return this.modelValue;
@@ -108,7 +109,11 @@ export default {
           password: this.password,
         });
 
-        await this.gameStore.requestGameState(this.gameStore.id);
+        if (this.gameHistoryStore.isSpectating) {
+          await this.gameStore.requestSpectate(this.gameStore.id, this.gameHistoryStore.currentGameStateIndex);
+        } else {
+          await this.gameStore.requestGameState(this.gameStore.id);
+        }
         this.clearSnackBar();
         this.clearForm();
         this.isLoggingIn = false;

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -506,6 +506,7 @@ export const useGameStore = defineStore('game', {
         this.updateGame(res.body.game);
         return handleInGameEvents(res.body, route);
       } catch (err) {
+        // Swallow 401 error so we can authenticate from GameView
         if (authStore.mustReauthenticate) {
           this.id = gameId;
           return;

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -497,6 +497,7 @@ export const useGameStore = defineStore('game', {
     },
 
     async requestSpectate(gameId, gameStateIndex = 0, route = null) {
+      const authStore = useAuthStore();
       const slug = `${gameId}/spectate?gameStateIndex=${gameStateIndex}`;
       try {
         this.resetState();
@@ -505,6 +506,10 @@ export const useGameStore = defineStore('game', {
         this.updateGame(res.body.game);
         return handleInGameEvents(res.body, route);
       } catch (err) {
+        if (authStore.mustReauthenticate) {
+          this.id = gameId;
+          return;
+        }
         const message = err?.message ?? err ?? `Unable to spectate game ${gameId}`;
         throw(new Error(message));
       }

--- a/src/stores/gameHistory.js
+++ b/src/stores/gameHistory.js
@@ -28,8 +28,7 @@ export const useGameHistoryStore = defineStore('gameHistory', () => {
     if (
       isNaN(index) || 
       !isFinite(index) || 
-      index < 0 || 
-      index >= gameStates.value.length
+      index < 0
     ) {
       return -1;
     }

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -363,10 +363,17 @@ describe('Rewatching finished games', () => {
     });
 
     it('Navigates directly to a particular state of a finished game', () => {
-      cy.loginPlayer(playerOne);
+
       cy.get('@replayGameId').then((gameId) => {
         cy.visit(`/spectate/${gameId}?gameStateIndex=2`);
       });
+
+      cy.get('#reauthenticate-dialog').should('be.visible');
+      cy.get('[data-cy=username]').click()
+        .type(playerOne.username);
+      cy.get('[data-cy=password]').click()
+        .type(playerOne.password);
+      cy.get('[data-cy=login]').click();
 
       cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
 


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Enables users to navigate directly to a highlight clip/spectate link and log in from the GameView if not already authenticated
## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #1221

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
