### PR TITLE
Feat/add god combo playground tests

### DIFF
--- a/tests/e2e/playground/specs/videoPlayground.spec.js
+++ b/tests/e2e/playground/specs/videoPlayground.spec.js
@@ -1,4 +1,5 @@
 import { Card } from '../../fixtures/cards';
+import { assertGameState } from '../../support/helpers';
 
 /**
  * Video Playground
@@ -490,6 +491,62 @@ describe('Video Playground', () => {
     cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
     cy.resolveOpponent();
   });
+
+  it.only('Loses to god combo', () => {
+    cy.loadGameFixture(0, {
+      p0Hand: [
+        Card.SIX_OF_DIAMONDS,
+        Card.SEVEN_OF_CLUBS,
+        Card.EIGHT_OF_CLUBS,
+        Card.NINE_OF_DIAMONDS,
+        Card.JACK_OF_HEARTS
+      ],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [ Card.TEN_OF_SPADES, Card.TWO_OF_HEARTS ],
+      p1Points: [],
+      p1FaceCards: [ Card.KING_OF_CLUBS, Card.KING_OF_DIAMONDS, Card.QUEEN_OF_HEARTS ],
+    });
+
+    cy.wait(2000);
+
+    cy.get('[data-player-hand-card=6-1]').click();
+    cy.wait(500);
+    cy.get('[data-move-choice=oneOff]').click();
+
+    cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
+    cy.wait(1000);
+
+    cy.counterOpponent(Card.TWO_OF_HEARTS);
+    cy.get('#cannot-counter-dialog')
+      .should('be.visible');
+    cy.wait(1000);
+
+    cy.get('#cannot-counter-dialog')
+      .should('be.visible')
+      .get('[data-cy=cannot-counter-resolve]')
+      .click();
+
+    assertGameState(0, {
+      p0Hand: [
+        Card.SEVEN_OF_CLUBS,
+        Card.EIGHT_OF_CLUBS,
+        Card.NINE_OF_DIAMONDS,
+        Card.JACK_OF_HEARTS
+      ],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [ Card.TEN_OF_SPADES ],
+      p1Points: [],
+      p1FaceCards: [ Card.KING_OF_CLUBS, Card.KING_OF_DIAMONDS, Card.QUEEN_OF_HEARTS ],
+      scrap: [
+        Card.SIX_OF_DIAMONDS,
+        Card.TWO_OF_HEARTS
+      ]
+    });
+
+    cy.playPointsOpponent(Card.TEN_OF_SPADES);
+  });
 });
 
 describe('Playground as p1', () => {
@@ -498,7 +555,7 @@ describe('Playground as p1', () => {
     cy.setupGameAsP1();
   });
 
-  it.only('Has God combo', () => {
+  it('Has God combo', () => {
     cy.loadGameFixture(1, {
       p0Hand: [
         Card.SIX_OF_DIAMONDS,

--- a/tests/e2e/playground/specs/videoPlayground.spec.js
+++ b/tests/e2e/playground/specs/videoPlayground.spec.js
@@ -491,3 +491,55 @@ describe('Video Playground', () => {
     cy.resolveOpponent();
   });
 });
+
+describe('Playground as p1', () => {
+  beforeEach(() => {
+    cy.viewport(1920, 1080);
+    cy.setupGameAsP1();
+  });
+
+  it.only('Has God combo', () => {
+    cy.loadGameFixture(1, {
+      p0Hand: [
+        Card.SIX_OF_DIAMONDS,
+        Card.SEVEN_OF_CLUBS,
+        Card.EIGHT_OF_CLUBS,
+        Card.NINE_OF_DIAMONDS,
+        Card.JACK_OF_HEARTS
+      ],
+      p0Points: [],
+      p0FaceCards: [],
+      p1Hand: [ Card.TEN_OF_SPADES, Card.TWO_OF_HEARTS ],
+      p1Points: [],
+      p1FaceCards: [ Card.KING_OF_CLUBS, Card.KING_OF_DIAMONDS, Card.QUEEN_OF_HEARTS ],
+    });
+
+    cy.wait(2000);
+
+    cy.playOneOffOpponent(Card.SIX_OF_DIAMONDS);
+
+    // Player Counters
+    cy.get('#counter-dialog')
+      .should('be.visible')
+      .get('[data-cy=counter]')
+      .click();
+    cy.wait(1000);
+
+
+    cy.get('#choose-two-dialog')
+      .should('be.visible')
+      .get('[data-counter-dialog-card=2-2]')
+      .click();
+    cy.wait(1000);
+    cy.get('#waiting-for-opponent-counter-scrim').should('be.visible');
+
+    // Opponent Resolves
+    cy.resolveOpponent();
+    cy.wait(1000);
+    cy.get('#turn-indicator').contains('YOUR TURN');
+
+    cy.get('[data-player-hand-card=10-3]').click();
+    cy.wait(500);
+    cy.get('[data-move-choice=points]').click();
+  });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Adds tests to the videoPlayground.spec.js for winning and losing via god combo. Purely for creating silly videos. I used it to make these and wanted to keep the source code:


![Kuleshov Effect - Cuttle God Combo medium](https://github.com/user-attachments/assets/0bdf1271-5c16-4cca-9302-42d54e9e8105)

![Kuleshov Effect - Losing to God Combo](https://github.com/user-attachments/assets/0079a789-bd29-4b5b-b491-f6833c7641f1)



## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
