### PR TITLE
feat(GameMenu.vue): add icons for concede and request stalemate

### DIFF
--- a/src/routes/game/components/GameMenu.vue
+++ b/src/routes/game/components/GameMenu.vue
@@ -30,7 +30,11 @@
         </v-list-item>
         <!-- Concede Dialog (Initiate + Confirm) -->
         <template v-else>
-          <v-list-item data-cy="concede-initiate" prepend-icon="mdi-skull" @click="shownDialog = 'concede'">
+          <v-list-item
+            data-cy="concede-initiate"
+            prepend-icon="mdi-flag-variant-outline"
+            @click="shownDialog = 'concede'"
+          >
             {{ t('game.menus.gameMenu.concede') }}
           </v-list-item>
           <v-list-item data-cy="stalemate-initiate" prepend-icon="mdi-handshake" @click="shownDialog = 'stalemate'">

--- a/src/routes/game/components/GameMenu.vue
+++ b/src/routes/game/components/GameMenu.vue
@@ -30,10 +30,10 @@
         </v-list-item>
         <!-- Concede Dialog (Initiate + Confirm) -->
         <template v-else>
-          <v-list-item data-cy="concede-initiate" @click="shownDialog = 'concede'">
+          <v-list-item data-cy="concede-initiate" prepend-icon="mdi-skull" @click="shownDialog = 'concede'">
             {{ t('game.menus.gameMenu.concede') }}
           </v-list-item>
-          <v-list-item data-cy="stalemate-initiate" @click="shownDialog = 'stalemate'">
+          <v-list-item data-cy="stalemate-initiate" prepend-icon="mdi-handshake" @click="shownDialog = 'stalemate'">
             {{ t('game.menus.gameMenu.stalemate') }}
           </v-list-item>
         </template>


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Adds icons to the game menu for concede and stalemate

![image](https://github.com/user-attachments/assets/fb89f4d7-b186-4752-ac09-489fe0764f07)


## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
