### PR TITLE
Fix/seven scuttle jacked target

### DIFF
--- a/api/helpers/game-states/moves/seven-scuttle/execute.js
+++ b/api/helpers/game-states/moves/seven-scuttle/execute.js
@@ -48,7 +48,8 @@ module.exports = {
 
     // Move both cards to scrap and cleanup seven
     const { oneOff } = result;
-    result.scrap.push(oneOff, targetCard, playedCard);
+    result.scrap.push(oneOff, targetCard, ...targetCard.attachments, playedCard);
+    targetCard.attachments = [];
 
     result.turn++;
 

--- a/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
@@ -539,7 +539,7 @@ describe('Playing SEVENS', () => {
       assertSnackbar(SnackBarError.ILLEGAL_SCUTTLE);
     });
 
-    it('Scuttles a card with two jacks on it via a seven one-off', () => {
+    it('Scuttles a card with a jack on it via a seven one-off', () => {
       // Setup: p0 has a point card and a seven, p1 has a jack, topCard is larger than the point card
       cy.loadGameFixture(0, {
         p0Hand: [ Card.FOUR_OF_DIAMONDS, Card.SEVEN_OF_CLUBS ],

--- a/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
@@ -538,6 +538,71 @@ describe('Playing SEVENS', () => {
       cy.get('[data-opponent-point-card=5-3]').click();
       assertSnackbar(SnackBarError.ILLEGAL_SCUTTLE);
     });
+
+    it.only('Scuttles a card with two jacks on it via a seven one-off', () => {
+      // Setup: p0 has a point card and a seven, p1 has a jack, topCard is larger than the point card
+      cy.loadGameFixture(0, {
+        p0Hand: [ Card.FOUR_OF_DIAMONDS, Card.SEVEN_OF_CLUBS ],
+        p0Points: [],
+        p0FaceCards: [],
+        p1Hand: [ Card.JACK_OF_CLUBS ],
+        p1Points: [],
+        p1FaceCards: [],
+        topCard: Card.SIX_OF_CLUBS, // larger than FOUR_OF_DIAMONDS
+        secondCard: Card.TWO_OF_SPADES,
+      });
+
+      // p0 plays points (four of diamonds)
+      cy.get('[data-player-hand-card=4-1]').click(); // Four of diamonds
+      cy.get('[data-move-choice=points]').click();
+
+      assertGameState(0, {
+        p0Hand: [ Card.SEVEN_OF_CLUBS ],
+        p0Points: [ Card.FOUR_OF_DIAMONDS ],
+        p0FaceCards: [],
+        p1Hand: [ Card.JACK_OF_CLUBS ],
+        p1Points: [],
+        p1FaceCards: [],
+        scrap: [],
+        topCard: Card.SIX_OF_CLUBS,
+        secondCard: Card.TWO_OF_SPADES,
+      });
+
+      // p1 jacks the four of diamonds
+      cy.playJackOpponent(Card.JACK_OF_CLUBS, Card.FOUR_OF_DIAMONDS);
+
+      assertGameState(0, {
+        p0Hand: [ Card.SEVEN_OF_CLUBS ],
+        p0Points: [],
+        p0FaceCards: [],
+        p1Hand: [],
+        p1Points: [ Card.FOUR_OF_DIAMONDS ],
+        p1FaceCards: [],
+        scrap: [],
+        topCard: Card.SIX_OF_CLUBS,
+        secondCard: Card.TWO_OF_SPADES,
+      });
+
+      // p0 plays seven as a one-off
+      cy.playOneOffAndResolveAsPlayer(Card.SEVEN_OF_CLUBS);
+      cy.get('#waiting-for-opponent-counter-scrim').should('not.exist');
+
+      // p0 chooses topCard (six of clubs) to scuttle with
+      cy.get('[data-top-card=6-0]').click();
+      cy.get('[data-move-choice=scuttle]').click();
+      cy.get('[data-opponent-point-card=4-1]').click();
+
+      assertGameState(0, {
+        p0Hand: [],
+        p0Points: [],
+        p0FaceCards: [],
+        p1Hand: [],
+        p1Points: [],
+        p1FaceCards: [],
+        scrap: [ Card.SEVEN_OF_CLUBS, Card.SIX_OF_CLUBS, Card.FOUR_OF_DIAMONDS ],
+        topCard: Card.TWO_OF_SPADES,
+      });
+    });
   }); // End seven scuttle describe()
 
   describe('Playing untargeted one-offs from a seven', () => {

--- a/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
@@ -539,7 +539,7 @@ describe('Playing SEVENS', () => {
       assertSnackbar(SnackBarError.ILLEGAL_SCUTTLE);
     });
 
-    it.only('Scuttles a card with two jacks on it via a seven one-off', () => {
+    it('Scuttles a card with two jacks on it via a seven one-off', () => {
       // Setup: p0 has a point card and a seven, p1 has a jack, topCard is larger than the point card
       cy.loadGameFixture(0, {
         p0Hand: [ Card.FOUR_OF_DIAMONDS, Card.SEVEN_OF_CLUBS ],
@@ -590,7 +590,7 @@ describe('Playing SEVENS', () => {
       // p0 chooses topCard (six of clubs) to scuttle with
       cy.get('[data-top-card=6-0]').click();
       cy.get('[data-move-choice=scuttle]').click();
-      cy.get('[data-opponent-point-card=4-1]').click();
+      cy.get('[data-opponent-point-card=4-1]').click({ force: true });
 
       assertGameState(0, {
         p0Hand: [],
@@ -599,7 +599,7 @@ describe('Playing SEVENS', () => {
         p1Hand: [],
         p1Points: [],
         p1FaceCards: [],
-        scrap: [ Card.SEVEN_OF_CLUBS, Card.SIX_OF_CLUBS, Card.FOUR_OF_DIAMONDS ],
+        scrap: [ Card.SEVEN_OF_CLUBS, Card.SIX_OF_CLUBS, Card.FOUR_OF_DIAMONDS, Card.JACK_OF_CLUBS ],
         topCard: Card.TWO_OF_SPADES,
       });
     });


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes bug where you can't play a seven one-off and then scuttle from the deck if the target had any jacks on it. 
## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
It's a near-duplicate of #1201 which fixed the same issue for non-seven scuttling

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
