### PR TITLE
Standardize use of quotes to utilize escapes rather than double quotes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,7 +77,7 @@ module.exports = {
     'no-case-declarations': 'error',
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-    quotes: [ 'error', 'single', { avoidEscape: true, allowTemplateLiterals: true } ],
+    quotes: [ 'error', 'single', { allowTemplateLiterals: true } ],
     semi: [ 'error', 'always' ],
     curly: 'error',
     'vue/html-closing-bracket-newline': [

--- a/api/helpers/game-states/find-target-card.js
+++ b/api/helpers/game-states/find-target-card.js
@@ -3,7 +3,7 @@ const TargetType = require('../../../utils/TargetType.json');
 module.exports = {
   friendlyName: 'Find target card',
 
-  description: "Finds card specified by its ID on the requested player's board. Returns null if not found",
+  description: 'Finds card specified by its ID on the requested player\'s board. Returns null if not found',
 
   inputs: {
     targetId: {

--- a/api/helpers/game-states/moves/concede/execute.js
+++ b/api/helpers/game-states/moves/concede/execute.js
@@ -22,7 +22,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/concede/validate.js
+++ b/api/helpers/game-states/moves/concede/validate.js
@@ -22,7 +22,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/counter/execute.js
+++ b/api/helpers/game-states/moves/counter/execute.js
@@ -27,7 +27,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/counter/validate.js
+++ b/api/helpers/game-states/moves/counter/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/draw/execute.js
+++ b/api/helpers/game-states/moves/draw/execute.js
@@ -25,7 +25,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/draw/validate.js
+++ b/api/helpers/game-states/moves/draw/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/face-card/execute.js
+++ b/api/helpers/game-states/moves/face-card/execute.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/face-card/validate.js
+++ b/api/helpers/game-states/moves/face-card/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/jack/execute.js
+++ b/api/helpers/game-states/moves/jack/execute.js
@@ -28,7 +28,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/jack/validate.js
+++ b/api/helpers/game-states/moves/jack/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/one-off/execute.js
+++ b/api/helpers/game-states/moves/one-off/execute.js
@@ -30,7 +30,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/one-off/validate.js
+++ b/api/helpers/game-states/moves/one-off/validate.js
@@ -31,7 +31,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/pass/execute.js
+++ b/api/helpers/game-states/moves/pass/execute.js
@@ -25,7 +25,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/pass/validate.js
+++ b/api/helpers/game-states/moves/pass/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/points/execute.js
+++ b/api/helpers/game-states/moves/points/execute.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/points/validate.js
+++ b/api/helpers/game-states/moves/points/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/resolve-five/execute.js
+++ b/api/helpers/game-states/moves/resolve-five/execute.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/resolve-five/validate.js
+++ b/api/helpers/game-states/moves/resolve-five/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/resolve-four/execute.js
+++ b/api/helpers/game-states/moves/resolve-four/execute.js
@@ -27,7 +27,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/resolve-four/validate.js
+++ b/api/helpers/game-states/moves/resolve-four/validate.js
@@ -30,7 +30,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/resolve-three/execute.js
+++ b/api/helpers/game-states/moves/resolve-three/execute.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/resolve-three/validate.js
+++ b/api/helpers/game-states/moves/resolve-three/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/resolve/execute.js
+++ b/api/helpers/game-states/moves/resolve/execute.js
@@ -27,7 +27,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/resolve/validate.js
+++ b/api/helpers/game-states/moves/resolve/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/scuttle/execute.js
+++ b/api/helpers/game-states/moves/scuttle/execute.js
@@ -27,7 +27,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/scuttle/validate.js
+++ b/api/helpers/game-states/moves/scuttle/validate.js
@@ -30,7 +30,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-discard/execute.js
+++ b/api/helpers/game-states/moves/seven-discard/execute.js
@@ -28,7 +28,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-discard/validate.js
+++ b/api/helpers/game-states/moves/seven-discard/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-face-card/execute.js
+++ b/api/helpers/game-states/moves/seven-face-card/execute.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-face-card/validate.js
+++ b/api/helpers/game-states/moves/seven-face-card/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-jack/execute.js
+++ b/api/helpers/game-states/moves/seven-jack/execute.js
@@ -28,7 +28,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-jack/validate.js
+++ b/api/helpers/game-states/moves/seven-jack/validate.js
@@ -30,7 +30,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-one-off/execute.js
+++ b/api/helpers/game-states/moves/seven-one-off/execute.js
@@ -31,7 +31,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-one-off/validate.js
+++ b/api/helpers/game-states/moves/seven-one-off/validate.js
@@ -30,7 +30,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-points/execute.js
+++ b/api/helpers/game-states/moves/seven-points/execute.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-points/validate.js
+++ b/api/helpers/game-states/moves/seven-points/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-scuttle/execute.js
+++ b/api/helpers/game-states/moves/seven-scuttle/execute.js
@@ -27,7 +27,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/seven-scuttle/validate.js
+++ b/api/helpers/game-states/moves/seven-scuttle/validate.js
@@ -30,7 +30,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/stalemate-accept/execute.js
+++ b/api/helpers/game-states/moves/stalemate-accept/execute.js
@@ -28,7 +28,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/stalemate-accept/validate.js
+++ b/api/helpers/game-states/moves/stalemate-accept/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/stalemate-reject/execute.js
+++ b/api/helpers/game-states/moves/stalemate-reject/execute.js
@@ -28,7 +28,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/stalemate-reject/validate.js
+++ b/api/helpers/game-states/moves/stalemate-reject/validate.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/stalemate-request/execute.js
+++ b/api/helpers/game-states/moves/stalemate-request/execute.js
@@ -28,7 +28,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     }
   },

--- a/api/helpers/game-states/moves/stalemate-request/validate.js
+++ b/api/helpers/game-states/moves/stalemate-request/validate.js
@@ -30,7 +30,7 @@ module.exports = {
     },
     priorStates: {
       type: 'ref',
-      description: "List of packed gameStateRows for this game's prior states",
+      description: 'List of packed gameStateRows for this game\'s prior states',
       required: true,
     },
   },

--- a/api/helpers/game-states/your-turn-to-counter.js
+++ b/api/helpers/game-states/your-turn-to-counter.js
@@ -2,7 +2,7 @@ module.exports = {
   friendlyName: 'Is your chance to counter',
 
   description:
-    "Verifies whether it is the requesting player's opportunity to counter. Returns `true` if so and `false` otherwise",
+    'Verifies whether it is the requesting player\'s opportunity to counter. Returns `true` if so and `false` otherwise',
 
   inputs: {
     currentState: {

--- a/app.js
+++ b/app.js
@@ -39,7 +39,7 @@ process.chdir(__dirname);
     console.error(
       'When you run `sails lift`, your app will still use a local `./node_modules/sails` dependency if it exists,',
     );
-    console.error("but if it doesn't, the app will run with the global sails instead!");
+    console.error('but if it doesn\'t, the app will run with the global sails instead!');
     return;
   }
 

--- a/tests/e2e/fixtures/snackbarError.js
+++ b/tests/e2e/fixtures/snackbarError.js
@@ -1,15 +1,15 @@
 const SnackBarError = {
-  NOT_YOUR_TURN: "It's not your turn",
+  NOT_YOUR_TURN: 'It\'s not your turn',
   ILLEGAL_SCUTTLE:
-    "You can only scuttle if your card's rank is higher, or the rank is the same, and your suit is higher (Clubs < Diamonds < Hearts < Spades)",
+    'You can only scuttle if your card\'s rank is higher, or the rank is the same, and your suit is higher (Clubs < Diamonds < Hearts < Spades)',
   FROZEN_CARD: 'That card is frozen! You must wait a turn to play it',
   NOT_IN_GAME: 'You are not a player in this game!',
   GAME_IS_FULL: `Cannot join that game because it's already full`,
-  CANT_FIND_GAME: "Can't find game",
+  CANT_FIND_GAME: 'Can\'t find game',
   ONE_OFF: {
     THREE_EMPTY_SCRAP: 'You can only play a 3 as a one-off if there are cards in the scrap pile',
     FOUR_EMPTY_HAND: 'You cannot play a 4 as a one-off while your opponent has no cards in hand',
-    EMPTY_DECK: "You can't play that one-off unless there are cards in the deck",
+    EMPTY_DECK: 'You can\'t play that one-off unless there are cards in the deck',
   }
 };
 

--- a/tests/e2e/playground/specs/videoPlayground.spec.js
+++ b/tests/e2e/playground/specs/videoPlayground.spec.js
@@ -140,7 +140,7 @@ describe('Video Playground', () => {
 
     cy.get('[data-player-hand-card=4-3]').click();
     cy.get('[data-move-choice=points]').click();
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
     cy.wait(1000);
 
     cy.playJackOpponent(Card.JACK_OF_DIAMONDS, Card.FOUR_OF_SPADES);
@@ -476,7 +476,7 @@ describe('Video Playground', () => {
     cy.get('[data-player-hand-card]').should('have.length', 3);
     cy.get('[data-player-hand-card=10-3]').click();
     cy.get('[data-move-choice=points]').click();
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
     cy.playJackOpponent(Card.JACK_OF_DIAMONDS, Card.TEN_OF_SPADES);
     cy.wait(2000);
     cy.get('#turn-indicator').contains('YOUR TURN');

--- a/tests/e2e/specs/in-game/basicMoves.spec.js
+++ b/tests/e2e/specs/in-game/basicMoves.spec.js
@@ -21,7 +21,7 @@ describe('Game Basic Moves - P0 Perspective', () => {
     // Play points (ace of spades)
     cy.get('[data-player-hand-card=1-3]').click(); // ace of spades
     cy.get('[data-move-choice=points]').click();
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
 
     // Attempt to play out of turn
     cy.get('[data-player-hand-card=1-0]').click(); // ace of clubs
@@ -99,7 +99,7 @@ describe('Game Basic Moves - P0 Perspective', () => {
     cy.get('[data-player-hand-card=1-3]').click(); // ace of spades
     cy.get('[data-move-choice=scuttle]')
       .should('have.class', 'v-card--disabled')
-      .should('contain', "It's not your turn")
+      .should('contain', 'It\'s not your turn')
       .click({ force: true });
     cy.get('[data-opponent-point-card=1-1]').click(); // ace of diamonds
     // Test that Error snackbar says its not your turn
@@ -140,7 +140,7 @@ describe('Game Basic Moves - P0 Perspective', () => {
         Card.ACE_OF_DIAMONDS,
       ],
     });
-    cy.log("Player (p0) scuttled opponent's last point card");
+    cy.log('Player (p0) scuttled opponent\'s last point card');
 
     cy.scuttleOpponent(Card.TEN_OF_CLUBS, Card.TWO_OF_CLUBS);
     assertGameState(0, {
@@ -321,7 +321,7 @@ describe('Game Basic Moves - P0 Perspective', () => {
     cy.get('[data-player-hand-card=11-1]').click();
     cy.get('[data-move-choice=jack]')
       .should('have.class', 'v-card--disabled')
-      .should('contain', "You cannot jack your opponent's points while they have a queen")
+      .should('contain', 'You cannot jack your opponent\'s points while they have a queen')
       .click({ force: true });
     cy.get('#player-hand-targeting').should('be.visible');
     cy.get('[data-opponent-point-card=1-1]').click();
@@ -642,7 +642,7 @@ describe('Play Jacks', () => {
     });
 
     cy.get('[data-player-hand-card]').should('have.length', 2);
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
 
     // Opponent plays jack
     cy.playJackOpponent(Card.JACK_OF_DIAMONDS, Card.TEN_OF_SPADES);
@@ -686,7 +686,7 @@ describe('Play Jacks', () => {
 
     cy.get('[data-player-hand-card]').should('have.length', 3);
     // Attempt to play king out of turn
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
 
     // Opponent plays 2nd jack
     cy.playJackOpponent(Card.JACK_OF_DIAMONDS, Card.TEN_OF_HEARTS);
@@ -716,7 +716,7 @@ describe('Play Jacks', () => {
       scrap: [],
     });
 
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
 
     // Opponent plays 4th jack
     cy.playJackOpponent(Card.JACK_OF_SPADES, Card.TEN_OF_HEARTS);

--- a/tests/e2e/specs/in-game/game-over/rankedMatches.spec.js
+++ b/tests/e2e/specs/in-game/game-over/rankedMatches.spec.js
@@ -184,7 +184,7 @@ describe('Creating And Updating Ranked Matches', () => {
     cy.get('#deck').should('contain', '(0)')
       .should('contain', 'PASS')
       .click();
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
     cy.passOpponent();
     cy.get('#turn-indicator').contains('YOUR TURN');
     cy.get('#deck').should('contain', '(0)')
@@ -225,7 +225,7 @@ describe('Creating And Updating Ranked Matches', () => {
     cy.get('#deck').should('contain', '(0)')
       .should('contain', 'PASS')
       .click();
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
     cy.passOpponent();
     cy.get('#turn-indicator').contains('YOUR TURN');
     cy.get('#deck').should('contain', '(0)')

--- a/tests/e2e/specs/in-game/game-over/rematch.spec.js
+++ b/tests/e2e/specs/in-game/game-over/rematch.spec.js
@@ -353,7 +353,7 @@ describe('Creating And Updating Casual Games With Rematch', () => {
     cy.get('#deck').should('contain', '(0)')
       .should('contain', 'PASS')
       .click();
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
     cy.passOpponent();
 
     assertStalemate({ wins: 2, losses: 1, stalemates: 1 });
@@ -503,7 +503,7 @@ describe('Spectating Rematches', () => {
       cy.get('[data-opponent-hand-card]').should('have.length', 2);
       cy.recoverSessionOpponent(playerOne);
       cy.passOpponent();
-      cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+      cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
       cy.recoverSessionOpponent(playerTwo);
       cy.passOpponent();
       cy.get('#turn-indicator').contains('YOUR TURN');

--- a/tests/e2e/specs/in-game/game-over/winConditions.spec.js
+++ b/tests/e2e/specs/in-game/game-over/winConditions.spec.js
@@ -199,7 +199,7 @@ describe('Stalemates', () => {
       .click();
     cy.log('Should log the passing');
     cy.get('#history').contains(`${myUser.username} passed`);
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
     cy.passOpponent();
     cy.get('#history').contains(`${opponentOne.username} passed`);
     cy.get('#turn-indicator').contains('YOUR TURN');
@@ -233,13 +233,13 @@ describe('Stalemates', () => {
       .click();
     cy.log('Deck empty');
 
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
     cy.passOpponent();
     cy.get('#turn-indicator').contains('YOUR TURN');
     cy.get('#deck').should('contain', '(0)')
       .should('contain', 'PASS')
       .click();
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
     cy.passOpponent();
 
     assertStalemate();
@@ -331,7 +331,7 @@ describe('Stalemates', () => {
 
       // Draw card to take turn
       cy.get('#deck').click();
-      cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+      cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
 
       // Request stalemate again - now allowed
       cy.get('#game-menu-activator').click();

--- a/tests/e2e/specs/in-game/layout.spec.js
+++ b/tests/e2e/specs/in-game/layout.spec.js
@@ -255,7 +255,7 @@ describe.skip('Aesthetic tests', () => {
     });
 
     cy.get('[data-player-hand-card]').should('have.length', 3);
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
 
     // opponent plays 2nd Jack
     cy.playJackOpponent(Card.JACK_OF_DIAMONDS, Card.TEN_OF_HEARTS);
@@ -285,7 +285,7 @@ describe.skip('Aesthetic tests', () => {
       scrap: [],
     });
 
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
 
     // Opponent plays 4th jack
     cy.playJackOpponent(Card.JACK_OF_SPADES, Card.TEN_OF_HEARTS);
@@ -328,7 +328,7 @@ describe.skip('Aesthetic tests', () => {
     });
 
     cy.get('[data-player-hand-card]').should('have.length', 3);
-    cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+    cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
 
     // Opponent plays 2nd jack
     cy.playJackOpponent(Card.JACK_OF_DIAMONDS, Card.TEN_OF_HEARTS);

--- a/tests/e2e/specs/in-game/one-offs/0_countering.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/0_countering.spec.js
@@ -550,7 +550,7 @@ describe('Opponent May Counter vs Opponent Must Resolve', () => {
             expect(true).to.eq(false, 'Expected request to draw card to error');
           } catch (err) {
             const errors = [
-              "Can't play while waiting for opponent to counter",
+              'Can\'t play while waiting for opponent to counter',
               'game.snackbar.global.notInMainPhase',
             ];
             expect(err).to.be.oneOf(errors);

--- a/tests/e2e/specs/in-game/one-offs/4_fours.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/4_fours.spec.js
@@ -218,7 +218,7 @@ describe('FOURS', () => {
       cy.get('#cannot-counter-dialog').should('be.visible')
         .get('[data-cy=cannot-counter-resolve]')
         .click();
-      cy.log("Player resolves opponent's Four");
+      cy.log('Player resolves opponent\'s Four');
 
       // Four Dialog appears (you must discard)
       cy.get('#four-discard-dialog').should('be.visible');

--- a/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/7_sevens/player_sevens.spec.js
@@ -96,7 +96,7 @@ describe('Playing SEVENS', () => {
       .click();
     cy.get('[data-move-choice=jack]')
       .should('have.class', 'v-card--disabled')
-      .should('contain', "You cannot jack your opponent's points while they have a queen")
+      .should('contain', 'You cannot jack your opponent\'s points while they have a queen')
       .click({ force: true });
     cy.get('#player-hand-targeting').should('be.visible');
     cy.get('[data-opponent-point-card=10-2]').click();
@@ -329,7 +329,7 @@ describe('Playing SEVENS', () => {
       cy.get('#deck').find('#empty-deck-text')
         .should('contain', 'PASS');
 
-      cy.get('#turn-indicator').contains("OPPONENT'S TURN");
+      cy.get('#turn-indicator').contains('OPPONENT\'S TURN');
     });
   });
 

--- a/tests/e2e/specs/in-game/one-offs/9_nines.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/9_nines.spec.js
@@ -542,7 +542,7 @@ describe('Playing NINES', () => {
       });
 
       // Step 4
-      cy.log("STEP 4- P0 Jacks P1's 10");
+      cy.log('STEP 4- P0 Jacks P1\'s 10');
       cy.get('[data-player-hand-card=11-3]').click(); // Jack of spades
       cy.get('[data-move-choice=jack]').click();
       cy.get('#player-hand-targeting').should('be.visible');

--- a/tests/e2e/specs/in-game/reconnecting.spec.js
+++ b/tests/e2e/specs/in-game/reconnecting.spec.js
@@ -1093,7 +1093,7 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
-    cy.get('#turn-indicator').should('contain', "OPPONENT'S TURN");
+    cy.get('#turn-indicator').should('contain', 'OPPONENT\'S TURN');
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });
@@ -1147,7 +1147,7 @@ describe('Reconnecting after game is over', () => {
     });
 
     cy.get('[data-opponent-hand-card]').should('have.length', 5);
-    cy.get('#turn-indicator').should('contain', "OPPONENT'S TURN");
+    cy.get('#turn-indicator').should('contain', 'OPPONENT\'S TURN');
     cy.drawCardOpponent();
     cy.get('[data-opponent-hand-card]').should('have.length', 6);
   });

--- a/tests/e2e/specs/out-of-game/authentication.spec.js
+++ b/tests/e2e/specs/out-of-game/authentication.spec.js
@@ -52,7 +52,7 @@ describe('Auth - Page Content', () => {
     cy.get('[data-cy=password]').type(myUser.password);
     cy.get('[data-cy=username]').type(myUser.username + '{enter}');
     cy.get('[data-cy="user-menu"]').click();
-    cy.get("[data-nav='Log Out']").click();
+    cy.get('[data-nav=\'Log Out\']').click();
     cy.visit('/');
     cy.location('pathname').should('eq', '/login');
     cy.clearLocalStorage();

--- a/tests/e2e/specs/out-of-game/home.spec.js
+++ b/tests/e2e/specs/out-of-game/home.spec.js
@@ -48,7 +48,7 @@ describe('Home - Page Content', () => {
 
   it('Logs user out', () => {
     cy.get('[data-cy="user-menu"]').click();
-    cy.get("[data-nav='Log Out']").click();
+    cy.get('[data-nav=\'Log Out\']').click();
     cy.contains('p', 'Log In to get Started!');
     cy.get('[data-nav=Home]').should('not.exist');
   });

--- a/tests/e2e/specs/out-of-game/lobby.spec.js
+++ b/tests/e2e/specs/out-of-game/lobby.spec.js
@@ -556,7 +556,7 @@ describe('Lobby invite links', () => {
     cy.visit('/');
     cy.readyOpponent(gameId);
     cy.get('[data-cy=user-menu]').click();
-    cy.get("[data-nav='Log Out']").click();
+    cy.get('[data-nav=\'Log Out\']').click();
     cy.visit(`/lobby/${gameId}`);
     cy.url().should('include', `/login/${gameId}`);
     cy.get('[data-cy=password]').type(myUser.password);

--- a/tests/e2e/specs/out-of-game/navigation.spec.js
+++ b/tests/e2e/specs/out-of-game/navigation.spec.js
@@ -13,7 +13,7 @@ function verifyAuthenticatedLinks() {
   cy.location('pathname').should('equal', '/stats');
   // Log out
   cy.get('[data-cy="user-menu"]').click();
-  cy.get("[data-nav='Log Out']").click();
+  cy.get('[data-nav=\'Log Out\']').click();
   cy.location('pathname').should('equal', '/login');
 }
 
@@ -35,7 +35,7 @@ function verifyUnauthenticatedLinks() {
   cy.signupPlayer(playerOne);
   cy.vueRoute('/rules');
   cy.get('[data-cy="user-menu"]').click();
-  cy.get("[data-nav='Log Out']").click();
+  cy.get('[data-nav=\'Log Out\']').click();
   cy.get('[data-cy=rules-link]').click();
   cy.location('pathname').should('equal', '/rules');
 

--- a/tests/e2e/specs/out-of-game/stats.spec.js
+++ b/tests/e2e/specs/out-of-game/stats.spec.js
@@ -94,14 +94,14 @@ describe('Stats Page', () => {
     // Data Table
     cy.get('th').should('have.length', 16);
     cy.get('[data-rank=Player2]').contains(1);
-    cy.get("[data-week-1='Player1']").contains('W: 4, P: 5');
-    cy.get("[data-week-total='Player1']").contains('W: 7, P: 9');
+    cy.get('[data-week-1=\'Player1\']').contains('W: 4, P: 5');
+    cy.get('[data-week-total=\'Player1\']').contains('W: 7, P: 9');
     cy.get('[data-week-total=Player2]').contains('W: 7, P: 9');
-    cy.get("[data-week-1='Player5']").contains('W: 1, P: 3');
-    cy.get("[data-week-2='Player4']").contains('W: 0, P: 1');
+    cy.get('[data-week-1=\'Player5\']').contains('W: 1, P: 3');
+    cy.get('[data-week-2=\'Player4\']').contains('W: 0, P: 1');
     cy.get('tr.active-user-stats').contains(playerOne.username);
     // Player result menus (Week without losses)
-    cy.get("[data-week-1='Player1']").click();
+    cy.get('[data-week-1=\'Player1\']').click();
     cy.get('[data-players-beaten=Player1-week-1]').should('contain', 'Player2, Player3, Player4');
     cy.get('[data-players-lost-to=Player1-week-1]').should('not.contain', 'Player');
     cy.get('[data-players-lost-to=Player1-week-1]').should('contain', 'None');
@@ -114,7 +114,7 @@ describe('Stats Page', () => {
     cy.get('[data-players-beaten=Player1-week-1').should('not.exist');
     cy.get('[data-players-lost-to=Player1-week-1').should('not.exist');
     // Player result menus (Week with losses)
-    cy.get("[data-week-1='Player2']").click();
+    cy.get('[data-week-1=\'Player2\']').click();
     cy.get('[data-players-beaten=Player2-week-1]').should('contain', 'Player3, Player4');
     cy.get('[data-players-lost-to=Player2-week-1]').should('contain', 'Player1');
     cy.get('[data-player-results=Player2-week-1]').should('contain', 'Player2 Week 1');
@@ -127,7 +127,7 @@ describe('Stats Page', () => {
     cy.get('[data-players-beaten=Player2-week-1').should('not.exist');
     cy.get('[data-players-lost-to=Player2-week-1').should('not.exist');
     // Player result menus (Total)
-    cy.get("[data-week-total='Player3']").click();
+    cy.get('[data-week-total=\'Player3\']').click();
     cy.get('[data-players-beaten=Player3-week-total]').should('contain', 'Player5 (2), Player4 (1)');
     cy.get('[data-players-lost-to=Player3-week-total]').should(
       'contain',
@@ -156,8 +156,8 @@ describe('Stats Page', () => {
       .should('contain', '5');
 
     // Incomplete match should not contribute to points
-    cy.get("[data-week-3='Player1']").should('not.exist');
-    cy.get("[data-week-3='Player2']").should('not.exist');
+    cy.get('[data-week-3=\'Player1\']').should('not.exist');
+    cy.get('[data-week-3=\'Player2\']').should('not.exist');
   });
 
   it('Filters table to display wins, points, or both', () => {
@@ -167,7 +167,7 @@ describe('Stats Page', () => {
     cy.get('[data-cy=metric-select]').click();
     cy.contains('Points Only').click();
     // Only points are displayed
-    cy.get("[data-week-1='Player1']").contains('5')
+    cy.get('[data-week-1=\'Player1\']').contains('5')
       .should('not.contain', 'W:');
     cy.get('th').should('have.length', 16);
     // Switch to wins only
@@ -175,9 +175,9 @@ describe('Stats Page', () => {
     cy.contains('Wins Only').click();
     cy.get('th').should('have.length', 16);
     // Only wins are displayed
-    cy.get("[data-week-1='Player1']").contains('4')
+    cy.get('[data-week-1=\'Player1\']').contains('4')
       .should('not.contain', 'P:');
-    cy.get("[points-1='Player1']").should('not.exist');
+    cy.get('[points-1=\'Player1\']').should('not.exist');
   });
 
   it('Filters table to show selected weeks', () => {

--- a/tests/e2e/support/helpers.js
+++ b/tests/e2e/support/helpers.js
@@ -202,7 +202,7 @@ export function playOutOfTurn(moveName) {
   // Specified move choice should be disabled
   cy.get(`[data-move-choice=${moveName}]`)
     .should('have.class', 'v-card--disabled')
-    .should('contain', "It's not your turn")
+    .should('contain', 'It\'s not your turn')
     .click({ force: true });
   // Back end should fire error that move is illegal after click is forced
   assertSnackbar(SnackBarError.NOT_YOUR_TURN);

--- a/tests/unit/fixtures/gameStates/resolveNine.js
+++ b/tests/unit/fixtures/gameStates/resolveNine.js
@@ -113,7 +113,7 @@ export const resolveNine = {
       lock: null,
       lockedAt: null,
       log: [
-        "The 9♣️ one-off resolves, returning the J♣️ to definitelyNotTheGovernment6969's hand. It cannot be played next turn.",
+        'The 9♣️ one-off resolves, returning the J♣️ to definitelyNotTheGovernment6969\'s hand. It cannot be played next turn.',
       ],
       match: null,
       name: 'Test Game',

--- a/tests/unit/specs/sails/game-state.spec.js
+++ b/tests/unit/specs/sails/game-state.spec.js
@@ -10,7 +10,7 @@ function stripDbAttributes(obj) {
   attributesToRemove.forEach((attr) => delete obj[attr]);
 }
 
-describe("Converting GameState's and GameStateRow's and emitting sockets for Points", () => {
+describe('Converting GameState\'s and GameStateRow\'s and emitting sockets for Points', () => {
   beforeEach(async () => {
     await sails.helpers.wipeDatabase();
   });


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## #1181

- Resolves #1181

## Please check the following

- [x] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [x] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change

Standardized all string quotes to use single quotes consistently across the codebase. Removed avoidEscape option from ESLint and updated relevant strings to escape ' instead of using double quotes.