### PR TITLE
Fix/replay links for live games

### DIFF
--- a/api/controllers/game/spectate/join.js
+++ b/api/controllers/game/spectate/join.js
@@ -65,8 +65,12 @@ module.exports = async function (req, res) {
     }
     const gameState = unpackGamestate(game.gameStates.at(gameStateIndex));
     const socketEvent = await createSocketEvent(game, gameState);
-    Game.publish([ game.id ], socketEvent);
-
+    // Only notify others that a spectator joined, do not send full game state
+    Game.publish([ game.id ], {
+      gameId: game.id,
+      change: 'spectatorJoined',
+      username: spectator.username,
+    });
 
     return res.ok(socketEvent);
 

--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -45,7 +45,6 @@ export async function handleInGameEvents(evData, newRoute = null) {
     case SocketEvent.DELETE_DECK:
     case SocketEvent.CONCEDE:
     case SocketEvent.RE_LOGIN:
-    case SocketEvent.SPECTATOR_JOINED:
     case SocketEvent.RESOLVE:
     case SocketEvent.FIZZLE:
     case SocketEvent.TARGETED_ONE_OFF:

--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -129,6 +129,11 @@ export async function handleInGameEvents(evData, newRoute = null) {
         gameStore.removeSpectator(evData.username);
       }
       break;
+    case SocketEvent.SPECTATOR_JOINED:
+      if (gameStore.id === evData.gameId) {
+        gameStore.addSpectator(evData.username);
+      }
+      break;
   }
 
   // Validate current route & navigate if incorrect

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -776,7 +776,7 @@ export const useGameStore = defineStore('game', {
     },
 
     addSpectator(username) {
-      if (!username) return;
+      if (!username) {return;}
       if (!this.spectatingUsers.includes(username)) {
         this.spectatingUsers.push(username);
       }

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -775,5 +775,12 @@ export const useGameStore = defineStore('game', {
       });
     },
 
+    addSpectator(username) {
+      if (!username) return;
+      if (!this.spectatingUsers.includes(username)) {
+        this.spectatingUsers.push(username);
+      }
+    },
+
   }, // End actions
 }); // End game store

--- a/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
+++ b/tests/e2e/specs/in-game/one-offs/5_fives.spec.js
@@ -275,7 +275,7 @@ describe('FIVES', () => {
         cy.get('[data-cy=submit-five-dialog]').click();
         cy.get('[data-cy=five-discard-dialog]').should('not.exist');
 
-        cy.get('[data-player-hand-card]').should('have.length', 5);
+        cy.get('[data-player-hand-card]', { timeout: 6000 }).should('have.length', 5);
 
         cy.playPointsOpponent(Card.FOUR_OF_CLUBS);
         cy.get('[data-opponent-point-card=4-0]').should('be.visible');

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -405,64 +405,64 @@ describe('Rewatching finished games', () => {
     });
   }); // end describe('Creating highlight clips')
   
-    describe('Replaying other game states', () => {
-      it('Watches a replay of a game that ends via passes', () => {
-        setupGameBetweenTwoUnseenPlayers('replay');
+  describe('Replaying other game states', () => {
+    it('Watches a replay of a game that ends via passes', () => {
+      setupGameBetweenTwoUnseenPlayers('replay');
 
-        cy.get('@replayGameId').then((gameId) => {
-          cy.loadGameFixture(0, {
-            p0Hand: [ Card.ACE_OF_CLUBS ],
-            p0Points: [],
-            p0FaceCards: [],
-            p1Hand: [ Card.ACE_OF_DIAMONDS ],
-            p1Points: [],
-            p1FaceCards: [],
-            deck: [],
-          }, gameId);
+      cy.get('@replayGameId').then((gameId) => {
+        cy.loadGameFixture(0, {
+          p0Hand: [ Card.ACE_OF_CLUBS ],
+          p0Points: [],
+          p0FaceCards: [],
+          p1Hand: [ Card.ACE_OF_DIAMONDS ],
+          p1Points: [],
+          p1FaceCards: [],
+          deck: [],
+        }, gameId);
 
-          cy.recoverSessionOpponent(playerOne);
-          cy.passOpponent(gameId);
-          cy.recoverSessionOpponent(playerTwo);
-          cy.passOpponent(gameId);
+        cy.recoverSessionOpponent(playerOne);
+        cy.passOpponent(gameId);
+        cy.recoverSessionOpponent(playerTwo);
+        cy.passOpponent(gameId);
 
-          cy.recoverSessionOpponent(playerOne);
-          cy.passOpponent(gameId);
+        cy.recoverSessionOpponent(playerOne);
+        cy.passOpponent(gameId);
 
-          cy.visit('/');
-          cy.signupPlayer(myUser);
-          cy.vueRoute(`/spectate/${gameId}`);
-        });
-
-        cy.url().should('contain', '?gameStateIndex=0');
-        // Wait and verify game over dialog doesn't appear
-        cy.wait(1000);
-        cy.get('#game-over-dialog').should('not.exist');
-        // Step forward to state 1 (loaded fixture)
-        cy.get('[data-cy=playback-controls]')
-          .find('[data-cy=step-forward]')
-          .click();
-        cy.url().should('contain', '?gameStateIndex=1');
-        // Step forward to state 2 (pass)
-        cy.get('[data-cy=playback-controls]')
-          .find('[data-cy=step-forward]')
-          .click();
-        cy.url().should('contain', '?gameStateIndex=2');
-        // Wait and verify game over dialog doesn't appear
-        cy.wait(1000);
-        cy.get('#game-over-dialog').should('not.exist');
-        // Step forward to state 3 (pass)
-        cy.get('[data-cy=playback-controls]')
-          .find('[data-cy=step-forward]')
-          .click();
-        cy.url().should('contain', '?gameStateIndex=3');
-        // Step forward to state 4 (pass; stalemate)
-        cy.get('[data-cy=playback-controls]')
-          .find('[data-cy=step-forward]')
-          .click();
-
-        assertGameOverAsSpectator({ p1Wins: 0, p2Wins:0, stalemates: 1, winner: null, isRanked: false });
+        cy.visit('/');
+        cy.signupPlayer(myUser);
+        cy.vueRoute(`/spectate/${gameId}`);
       });
+
+      cy.url().should('contain', '?gameStateIndex=0');
+      // Wait and verify game over dialog doesn't appear
+      cy.wait(1000);
+      cy.get('#game-over-dialog').should('not.exist');
+      // Step forward to state 1 (loaded fixture)
+      cy.get('[data-cy=playback-controls]')
+        .find('[data-cy=step-forward]')
+        .click();
+      cy.url().should('contain', '?gameStateIndex=1');
+      // Step forward to state 2 (pass)
+      cy.get('[data-cy=playback-controls]')
+        .find('[data-cy=step-forward]')
+        .click();
+      cy.url().should('contain', '?gameStateIndex=2');
+      // Wait and verify game over dialog doesn't appear
+      cy.wait(1000);
+      cy.get('#game-over-dialog').should('not.exist');
+      // Step forward to state 3 (pass)
+      cy.get('[data-cy=playback-controls]')
+        .find('[data-cy=step-forward]')
+        .click();
+      cy.url().should('contain', '?gameStateIndex=3');
+      // Step forward to state 4 (pass; stalemate)
+      cy.get('[data-cy=playback-controls]')
+        .find('[data-cy=step-forward]')
+        .click();
+
+      assertGameOverAsSpectator({ p1Wins: 0, p2Wins:0, stalemates: 1, winner: null, isRanked: false });
     });
+  });
 
   describe('Error handling', () => {
     it('Prevents spectating a game that has no gamestates', function() {

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -7,7 +7,7 @@ import {
   assertGameOverAsSpectator,
   assertSnackbar
 } from '../../../support/helpers';
-import { myUser, playerOne, playerTwo } from '../../../fixtures/userFixtures';
+import { myUser, playerOne, playerTwo, playerThree } from '../../../fixtures/userFixtures';
 import { Card } from '../../../fixtures/cards';
 import GameStatus from '../../../../../utils/GameStatus.json';
 import { createAndFinishCasualMatch, rewatchCasualMatch, createAndPlayGameWithOneOffs } from './replayHelpers';
@@ -387,7 +387,7 @@ describe('Rewatching finished games', () => {
       });
     });
 
-    it('Does not affect live game state when a spectator joins at gameStateIndex=0', () => {
+    it.only('Does not affect live game state when a spectator joins at gameStateIndex=0', () => {
       // Setup a game as p0
       cy.setupGameAsP0();
       cy.get('@gameId').then((gameId) => {
@@ -396,7 +396,7 @@ describe('Rewatching finished games', () => {
         // Assert p0 has 6 cards in hand (initial 5 + 1 drawn)
         cy.get('#player-hand-cards .player-card').should('have.length', 6);
         // Sign up another user as opponent/other user
-        cy.signupOpponent({ username: 'spectator', password: 'password' });
+        cy.signupOpponent(playerThree);
         // Use cy.setOpponentToSpectate to subscribe the new user to the game at gameStateIndex=0
         cy.setOpponentToSpectate(gameId, 0);
         cy.wait(1000);

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -387,7 +387,7 @@ describe('Rewatching finished games', () => {
       });
     });
 
-    it.only('Does not affect live game state when a spectator joins at gameStateIndex=0', () => {
+    it('Does not affect live game state when a spectator joins at gameStateIndex=0', () => {
       // Setup a game as p0
       cy.setupGameAsP0();
       cy.get('@gameId').then((gameId) => {

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -387,6 +387,24 @@ describe('Rewatching finished games', () => {
       });
     });
 
+    it.only('does not affect live game state when a spectator joins at gameStateIndex=0', () => {
+      // Setup a game as p0
+      cy.setupGameAsP0();
+      cy.get('@gameId').then((gameId) => {
+        // Have p0 draw a card
+        cy.get('#deck').click();
+        // Assert p0 has 6 cards in hand (initial 5 + 1 drawn)
+        cy.get('#player-hand-cards .player-card').should('have.length', 6);
+        // Sign up another user as opponent/other user
+        cy.signupOpponent({ username: 'spectator', password: 'password' });
+        // Use cy.setOpponentToSpectate to subscribe the new user to the game at gameStateIndex=0
+        cy.setOpponentToSpectate(gameId, 0);
+        cy.wait(1000);
+        cy.get('#player-hand-cards .player-card').should('have.length', 6);
+      });
+    });
+  }); // end describe('Creating highlight clips')
+  
     describe('Replaying other game states', () => {
       it('Watches a replay of a game that ends via passes', () => {
         setupGameBetweenTwoUnseenPlayers('replay');
@@ -445,7 +463,6 @@ describe('Rewatching finished games', () => {
         assertGameOverAsSpectator({ p1Wins: 0, p2Wins:0, stalemates: 1, winner: null, isRanked: false });
       });
     });
-  });
 
   describe('Error handling', () => {
     it('Prevents spectating a game that has no gamestates', function() {

--- a/tests/e2e/specs/in-game/spectating/replays.spec.js
+++ b/tests/e2e/specs/in-game/spectating/replays.spec.js
@@ -387,7 +387,7 @@ describe('Rewatching finished games', () => {
       });
     });
 
-    it.only('does not affect live game state when a spectator joins at gameStateIndex=0', () => {
+    it('Does not affect live game state when a spectator joins at gameStateIndex=0', () => {
       // Setup a game as p0
       cy.setupGameAsP0();
       cy.get('@gameId').then((gameId) => {

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -243,8 +243,12 @@ Cypress.Commands.add('subscribeOpponent', (gameId) => {
   cy.makeSocketRequest(`game/${gameId}`, 'join');
 });
 
-Cypress.Commands.add('setOpponentToSpectate', (gameId) => {
-  cy.makeSocketRequest('game', 'spectate', { gameId }, 'POST', gameId);
+Cypress.Commands.add('setOpponentToSpectate', (gameId, gameStateIndex = undefined) => {
+  let slug = 'spectate';
+  if (typeof gameStateIndex === 'number' && !isNaN(gameStateIndex)) {
+    slug = `${gameId}/spectate?gameStateIndex=${gameStateIndex}`;
+  }
+  cy.makeSocketRequest('game', slug, { gameId }, 'POST', gameId);
 });
 
 Cypress.Commands.add('setOpponentToLeaveSpectate', (gameId) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes bug where going to a spectate link for a specific old gamestate would publish an update that puts all subscribers on the old state
## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
