### PR TITLE
refactor(game.js): rewrite as setup store

### DIFF
--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -1,3 +1,4 @@
+import { ref, computed } from 'vue';
 import { defineStore } from 'pinia';
 import { useAuthStore } from '@/stores/auth';
 import { useGameHistoryStore } from '@/stores/gameHistory';
@@ -49,7 +50,6 @@ class GameCard {
         12: 'Q',
         13: 'K',
       }[card.rank] ?? card.rank;
-    // Stringify Suit
     const str_suit = [ '♣️', '♦️', '♥️', '♠️' ][card.suit];
     this.createdAt = card.createdAt;
     this.updatedAt = card.updatedAt;
@@ -68,719 +68,680 @@ const createGameCard = (card) => {
   return new GameCard(card);
 };
 
-export const useGameStore = defineStore('game', {
-  state: () => ({
-    id: null,
-    chat: [],
-    deck: [],
-    log: [],
-    name: null,
-    p0Ready: false,
-    p1Ready: false,
-    p0Rematch: null,
-    p1Rematch: null,
-    rematchGameId: null,
-    phase: null,
-    passes: 0,
-    players: [],
-    spectatingUsers: [],
-    scrap: [],
-    turn: 0,
-    twos: [],
-    myPNum: null,
-    topCard: null,
-    secondCard: null,
-    oneOff: null,
-    oneOffTarget: null,
-    isRanked: false,
-    showIsRankedChangedAlert: false,
-    // Threes
-    lastEventCardChosen: null,
-    lastEventPlayerChoosing: false,
-    // Fours
-    lastEventDiscardedCards: null,
-    // Last Event
-    lastEventChange: null,
-    lastEventOneOffRank: null,
-    lastEventTargetType: null,
-    lastEventPlayedBy: null,
+export const useGameStore = defineStore('game', () => {
+  // State
+  const id = ref(null);
+  const chat = ref([]);
+  const deck = ref([]);
+  const log = ref([]);
+  const name = ref(null);
+  const p0Ready = ref(false);
+  const p1Ready = ref(false);
+  const p0Rematch = ref(null);
+  const p1Rematch = ref(null);
+  const rematchGameId = ref(null);
+  const phase = ref(null);
+  const passes = ref(0);
+  const players = ref([]);
+  const spectatingUsers = ref([]);
+  const scrap = ref([]);
+  const turn = ref(0);
+  const twos = ref([]);
+  const myPNum = ref(null);
+  const topCard = ref(null);
+  const secondCard = ref(null);
+  const oneOff = ref(null);
+  const oneOffTarget = ref(null);
+  const isRanked = ref(false);
+  const showIsRankedChangedAlert = ref(false);
+  // Threes
+  const lastEventCardChosen = ref(null);
+  const lastEventPlayerChoosing = ref(false);
+  // Fours
+  const lastEventDiscardedCards = ref(null);
+  // Last Event
+  const lastEventChange = ref(null);
+  const lastEventOneOffRank = ref(null);
+  const lastEventTargetType = ref(null);
+  const lastEventPlayedBy = ref(null);
+  // GameOver
+  const gameIsOver = ref(false);
+  const winnerPNum = ref(null);
+  const conceded = ref(false);
+  const currentMatch = ref(null);
+  const iWantToContinueSpectating = ref(false);
+  const status = ref(GameStatus.ARCHIVED);
 
-    // GameOver
-    gameIsOver: false,
-    winnerPNum: null,
-    conceded: false,
-    currentMatch: null,
-    iWantToContinueSpectating: false,
-  }),
-  getters: {
-    player: (state) => {
-      return state.players[state.myPNum];
-    },
-    playerPointTotal: (state) => {
-      if (!state.player) {
-        return 0;
-      }
-      return state.player?.points?.reduce((total, card) => total + card.rank, 0) || 0;
-    },
-    playerQueenCount: (state) => {
-      return queenCount(state.player);
-    },
-    playerUsername: (state) => {
-      if (!state.player) {
-        return null;
-      }
-      return state.player.username;
-    },
-    opponent: (state) => {
-      if (state.players.length < 2) {
-        return null;
-      }
-      return state.players[(state.myPNum + 1) % 2];
-    },
-    opponentIsReady: (state) => {
-      if (!state.opponent) {
-        return null;
-      }
-      return state.myPNum === 0 ? state.p1Ready : state.p0Ready;
-    },
-    opponentUsername: (state) => {
-      if (!state.opponent) {
-        return null;
-      }
-      return state.opponent.username;
-    },
-    opponentPointTotal: (state) => {
-      if (!state.opponent) {
-        return 0;
-      }
-      return state.opponent?.points?.reduce((total, card) => total + card.rank, 0) || 0;
-    },
-    opponentQueenCount: (state) => {
-      return queenCount(state.opponent);
-    },
-    playerWins: (state) => {
-      return state.gameIsOver && state.winnerPNum === state.myPNum;
-    },
-    resolvingSeven: (state) => {
-      return state.phase === GamePhase.RESOLVING_SEVEN;
-    },
-    isPlayersTurn: (state) => {
-      return state.turn % 2 === state.myPNum;
-    },
-    hasGlassesEight: (state) => {
-      return state.player?.faceCards?.filter((card) => card.rank === 8).length > 0 ?? false;
-    },
-    iWantRematch: (state) => {
-      if (state.myPNum === null) {
-        return false;
-      }
-      const key = `p${state.myPNum}Rematch`;
-      return state[key];
-    },
-    // `null` if deciding, false if declined, true if accepted
-    opponentWantsRematch: (state) => {
-      if (state.myPNum === null) {
-        return false;
-      }
-      const key = `p${(state.myPNum + 1) % 2}Rematch`;
-      return state[key];
-    },
-    opponentDeclinedRematch() {
-      return this.opponentWantsRematch === false;
-    },
-    someoneDeclinedRematch() {
-      return this.iWantRematch === false || this.opponentDeclinedRematch;
-    },
-    waitingForOpponentToCounter() {
-      const counteringPhase = this.phase === GamePhase.COUNTERING;
-      const numTwosIsEven = this.twos.length % 2 === 0;
-      
-      return counteringPhase && this.isPlayersTurn === numTwosIsEven;
-    },
-    myTurnToCounter() {
-      const counteringPhase = this.phase === GamePhase.COUNTERING;
-      const numTwosIsEven = this.twos.length % 2 === 0;
-      
-      return counteringPhase && this.isPlayersTurn !== numTwosIsEven;
-    },
-    waitingForOpponentToPickFromScrap() {
-      return this.phase === GamePhase.RESOLVING_THREE && !this.isPlayersTurn;
-    },
-    pickingFromScrap() {
-      return this.phase === GamePhase.RESOLVING_THREE && this.isPlayersTurn;
-    },
-    showResolveFour() {
-      return this.phase === GamePhase.RESOLVING_FOUR && !this.isPlayersTurn;
-    },
-    waitingForOpponentToDiscard() {
-      switch (this.phase) {
-        case GamePhase.RESOLVING_FOUR:
-          return this.isPlayersTurn;
-        case GamePhase.RESOLVING_FIVE:
-          return !this.isPlayersTurn;
-        default:
-          return false;
-      }
-    },
-    showResolveFive() {
-      return this.phase === GamePhase.RESOLVING_FIVE && this.isPlayersTurn;
-    },
-    playingFromDeck() {
-      return this.phase === GamePhase.RESOLVING_SEVEN &&
-        this.isPlayersTurn;
-    },
-    waitingForOpponentToPlayFromDeck() {
-      return this.phase === GamePhase.RESOLVING_SEVEN &&
-        !this.isPlayersTurn;
-    },
-    waitingForOpponentToStalemate() {
-      return this.phase === GamePhase.CONSIDERING_STALEMATE && this.lastEventPlayedBy === this.myPNum;
-    },
-    consideringOpponentStalemateRequest() {
-      return this.phase === GamePhase.CONSIDERING_STALEMATE && this.lastEventPlayedBy !== this.myPNum;
-    },
-  },
-  actions: {
-    updateGame(newGame) {
-      this.lastEventChange = newGame.lastEvent?.change ?? null;
-      this.lastEventOneOffRank = newGame.lastEvent?.oneOff?.rank ?? null;
-      this.lastEventTargetType = newGame.lastEvent?.oneOffTargetType ?? null;
-      this.lastEventCardChosen = newGame.lastEvent?.chosenCard ?? null;
-      this.lastEventPlayerChoosing = newGame.lastEvent?.pNum === this.myPNum ?? null;
-      this.lastEventDiscardedCards = newGame.lastEvent?.discardedCards ?? null;
-      this.lastEventPlayedBy = newGame.lastEvent?.pNum ?? null;
-      this.id = newGame.id ?? this.id;
-      this.turn = newGame.turn ?? this.turn;
-      // this.chat = cloneDeep(newGame.chat);
-      this.deck = newGame.deck?.map((card) => createGameCard(card)) ?? this.deck;
-      this.scrap = newGame.scrap?.map((card) => createGameCard(card)) ?? this.scrap;
-      this.log = cloneDeep(newGame.log) ?? this.log;
-      this.name = newGame.name ?? this.name;
-      this.p0Ready = newGame.p0Ready ?? this.p0Ready;
-      this.p1Ready = newGame.p1Ready ?? this.p1Ready;
-      this.passes = newGame.passes ?? this.passes;
-      this.players =
-        newGame.players?.map((player) =>
-          setPlayers(player, this.myPNum, this.hasGlassesEight, this.isSpectating),
-        ) ?? this.players;
-      this.spectatingUsers = newGame.spectatingUsers ?? this.spectatingUsers;
-      this.twos = newGame.twos?.map((card) => createGameCard(card)) ?? this.twos;
-      this.topCard = createGameCard(newGame.topCard) ?? null;
-      this.secondCard = createGameCard(newGame.secondCard) ?? null;
-      this.oneOff = createGameCard(newGame.oneOff) ?? null;
-      this.oneOffTarget = createGameCard(newGame.oneOffTarget) ?? null;
-      this.isRanked = newGame.isRanked ?? this.isRanked;
-      this.currentMatch = newGame.currentMatch ?? this.currentMatch;
-      this.p0Rematch = newGame.p0Rematch ?? null;
-      this.p1Rematch = newGame.p1Rematch ?? null;
-      this.rematchGameId = newGame.rematchGame ?? null;
-      this.gameIsOver = newGame.gameIsOver ?? false;
-      this.status = newGame.status ?? GameStatus.ARCHIVED;
-      this.phase = newGame.phase =  newGame.phase ?? GamePhase.MAIN;
-    
-      const gameHistoryStore = useGameHistoryStore();
-      gameHistoryStore.gameStates = newGame.gameStates ?? [];
-    },
-    opponentJoined(newPlayer) {
-      this.players.push(cloneDeep(newPlayer));
-      this.players.sort((player, opponent) => player.pNum - opponent.pNum);
-    },
-    removeSpectator(username) {
-      this.spectatingUsers = this.spectatingUsers.filter((spectator) => spectator !== username);
-    },
-    resetState() {
-      this.$reset();
-    },
-    updateReady(pNum) {
-      if (pNum === 0) {
-        this.p0Ready = !this.p0Ready;
-      } else {
-        this.p1Ready = !this.p1Ready;
-      }
-    },
-    opponentLeft() {
-      const opponentPnum = this.opponent.pNum;
-      this[`p${opponentPnum}Ready`] = false;
+  // Stores
+  const authStore = useAuthStore();
+  const gameHistoryStore = useGameHistoryStore();
 
-      this.players = this.players.filter((player) => player.pNum === this.myPNum);
-    },
-    // Game Over
-    setGameOver({ gameOver, conceded, winner, currentMatch }) {
-      this.gameIsOver = gameOver;
-      this.conceded = conceded;
-      this.winnerPNum = winner;
-      this.currentMatch = currentMatch;
-    },
-    resetPNumIfNullThenUpdateGame(game) {
-      this.resetPNumIfNull(game);
-      this.updateGame(game);
-    },
-    setRematch({ pNum, rematch }) {
-      this[`p${pNum}Rematch`] = rematch;
-    },
-    resetPNumIfNull(game) {
-      const authStore = useAuthStore();
-      const gameHistoryStore = useGameHistoryStore();
-      // Set my pNum if it is null
-      if (this.myPNum === null) {
-        let myPNum = game.players.findIndex(({ username }) => username === authStore.username);
-        if (myPNum === -1) {
-          myPNum = null;
-        }
-        if (gameHistoryStore.isSpectating) {
-          myPNum = 0;
-        }
-        this.myPNum = myPNum;
+  // Computed (getters)
+  const player = computed(() => players.value[myPNum.value]);
+  const playerPointTotal = computed(() => player.value?.points?.reduce((total, card) => total + card.rank, 0) || 0);
+  const playerQueenCount = computed(() => queenCount(player.value));
+  const playerUsername = computed(() => player.value?.username ?? null);
+  const opponent = computed(() => players.value.length < 2 ? null : players.value[(myPNum.value + 1) % 2]);
+  const opponentIsReady = computed(() => opponent.value ? (myPNum.value === 0 ? p1Ready.value : p0Ready.value) : null);
+  const opponentUsername = computed(() => opponent.value?.username ?? null);
+  const opponentPointTotal = computed(() => opponent.value?.points?.reduce((total, card) => total + card.rank, 0) || 0);
+  const opponentQueenCount = computed(() => queenCount(opponent.value));
+  const playerWins = computed(() => gameIsOver.value && winnerPNum.value === myPNum.value);
+  const resolvingSeven = computed(() => phase.value === GamePhase.RESOLVING_SEVEN);
+  const isPlayersTurn = computed(() => turn.value % 2 === myPNum.value);
+  const hasGlassesEight = computed(() => player.value?.faceCards?.filter((card) => card.rank === 8).length > 0 ?? false);
+  const iWantRematch = computed(() => {
+    if (myPNum.value === null) return false;
+    const key = myPNum.value === 0 ? p0Rematch : p1Rematch;
+    return key.value;
+  });
+  const opponentWantsRematch = computed(() => {
+    if (myPNum.value === null) return false;
+    const key = myPNum.value === 0 ? p1Rematch : p0Rematch;
+    return key.value;
+  });
+  const opponentDeclinedRematch = computed(() => opponentWantsRematch.value === false);
+  const someoneDeclinedRematch = computed(() => iWantRematch.value === false || opponentDeclinedRematch.value);
+  const waitingForOpponentToCounter = computed(() => {
+    const counteringPhase = phase.value === GamePhase.COUNTERING;
+    const numTwosIsEven = twos.value.length % 2 === 0;
+    return counteringPhase && isPlayersTurn.value === numTwosIsEven;
+  });
+  const myTurnToCounter = computed(() => {
+    const counteringPhase = phase.value === GamePhase.COUNTERING;
+    const numTwosIsEven = twos.value.length % 2 === 0;
+    return counteringPhase && isPlayersTurn.value !== numTwosIsEven;
+  });
+  const waitingForOpponentToPickFromScrap = computed(() => phase.value === GamePhase.RESOLVING_THREE && !isPlayersTurn.value);
+  const pickingFromScrap = computed(() => phase.value === GamePhase.RESOLVING_THREE && isPlayersTurn.value);
+  const showResolveFour = computed(() => phase.value === GamePhase.RESOLVING_FOUR && !isPlayersTurn.value);
+  const waitingForOpponentToDiscard = computed(() => {
+    switch (phase.value) {
+      case GamePhase.RESOLVING_FOUR:
+        return isPlayersTurn.value;
+      case GamePhase.RESOLVING_FIVE:
+        return !isPlayersTurn.value;
+      default:
+        return false;
+    }
+  });
+  const showResolveFive = computed(() => phase.value === GamePhase.RESOLVING_FIVE && isPlayersTurn.value);
+  const playingFromDeck = computed(() => phase.value === GamePhase.RESOLVING_SEVEN && isPlayersTurn.value);
+  const waitingForOpponentToPlayFromDeck = computed(() => phase.value === GamePhase.RESOLVING_SEVEN && !isPlayersTurn.value);
+  const waitingForOpponentToStalemate = computed(() => phase.value === GamePhase.CONSIDERING_STALEMATE && lastEventPlayedBy.value === myPNum.value);
+  const consideringOpponentStalemateRequest = computed(() => phase.value === GamePhase.CONSIDERING_STALEMATE && lastEventPlayedBy.value !== myPNum.value);
+
+  // Actions
+  function updateGame(newGame) {
+    lastEventChange.value = newGame.lastEvent?.change ?? null;
+    lastEventOneOffRank.value = newGame.lastEvent?.oneOff?.rank ?? null;
+    lastEventTargetType.value = newGame.lastEvent?.oneOffTargetType ?? null;
+    lastEventCardChosen.value = newGame.lastEvent?.chosenCard ?? null;
+    lastEventPlayerChoosing.value = newGame.lastEvent?.pNum === myPNum.value ?? null;
+    lastEventDiscardedCards.value = newGame.lastEvent?.discardedCards ?? null;
+    lastEventPlayedBy.value = newGame.lastEvent?.pNum ?? null;
+    id.value = newGame.id ?? id.value;
+    turn.value = newGame.turn ?? turn.value;
+    deck.value = newGame.deck?.map((card) => createGameCard(card)) ?? deck.value;
+    scrap.value = newGame.scrap?.map((card) => createGameCard(card)) ?? scrap.value;
+    log.value = cloneDeep(newGame.log) ?? log.value;
+    name.value = newGame.name ?? name.value;
+    p0Ready.value = newGame.p0Ready ?? p0Ready.value;
+    p1Ready.value = newGame.p1Ready ?? p1Ready.value;
+    passes.value = newGame.passes ?? passes.value;
+    players.value = newGame.players?.map((player) => setPlayers(player, myPNum.value, hasGlassesEight.value, gameHistoryStore.isSpectating)) ?? players.value;
+    spectatingUsers.value = newGame.spectatingUsers ?? spectatingUsers.value;
+    twos.value = newGame.twos?.map((card) => createGameCard(card)) ?? twos.value;
+    topCard.value = createGameCard(newGame.topCard) ?? null;
+    secondCard.value = createGameCard(newGame.secondCard) ?? null;
+    oneOff.value = createGameCard(newGame.oneOff) ?? null;
+    oneOffTarget.value = createGameCard(newGame.oneOffTarget) ?? null;
+    isRanked.value = newGame.isRanked ?? isRanked.value;
+    currentMatch.value = newGame.currentMatch ?? currentMatch.value;
+    p0Rematch.value = newGame.p0Rematch ?? null;
+    p1Rematch.value = newGame.p1Rematch ?? null;
+    rematchGameId.value = newGame.rematchGame ?? null;
+    gameIsOver.value = newGame.gameIsOver ?? false;
+    status.value = newGame.status ?? GameStatus.ARCHIVED;
+    phase.value = newGame.phase ?? GamePhase.MAIN;
+    gameHistoryStore.gameStates = newGame.gameStates ?? [];
+  }
+  function opponentJoined(newPlayer) {
+    players.value.push(cloneDeep(newPlayer));
+    players.value.sort((player, opponent) => player.pNum - opponent.pNum);
+  }
+  function removeSpectator(username) {
+    spectatingUsers.value = spectatingUsers.value.filter((spectator) => spectator !== username);
+  }
+  function resetState() {
+    id.value = null;
+    chat.value = [];
+    deck.value = [];
+    log.value = [];
+    name.value = null;
+    p0Ready.value = false;
+    p1Ready.value = false;
+    p0Rematch.value = null;
+    p1Rematch.value = null;
+    rematchGameId.value = null;
+    phase.value = null;
+    passes.value = 0;
+    players.value = [];
+    spectatingUsers.value = [];
+    scrap.value = [];
+    turn.value = 0;
+    twos.value = [];
+    myPNum.value = null;
+    topCard.value = null;
+    secondCard.value = null;
+    oneOff.value = null;
+    oneOffTarget.value = null;
+    isRanked.value = false;
+    showIsRankedChangedAlert.value = false;
+    lastEventCardChosen.value = null;
+    lastEventPlayerChoosing.value = false;
+    lastEventDiscardedCards.value = null;
+    lastEventChange.value = null;
+    lastEventOneOffRank.value = null;
+    lastEventTargetType.value = null;
+    lastEventPlayedBy.value = null;
+    gameIsOver.value = false;
+    winnerPNum.value = null;
+    conceded.value = false;
+    currentMatch.value = null;
+    iWantToContinueSpectating.value = false;
+    status.value = GameStatus.ARCHIVED;
+  }
+  function updateReady(pNumArg) {
+    if (pNumArg === 0) {
+      p0Ready.value = !p0Ready.value;
+    } else {
+      p1Ready.value = !p1Ready.value;
+    }
+  }
+  function opponentLeft() {
+    const opponentPnum = opponent.value.pNum;
+    if (opponentPnum === 0) {
+      p0Ready.value = false;
+    } else {
+      p1Ready.value = false;
+    }
+    players.value = players.value.filter((player) => player.pNum === myPNum.value);
+  }
+  function setGameOver({ gameOver, conceded: c, winner, currentMatch: cm }) {
+    gameIsOver.value = gameOver;
+    conceded.value = c;
+    winnerPNum.value = winner;
+    currentMatch.value = cm;
+  }
+  function resetPNumIfNullThenUpdateGame(game) {
+    resetPNumIfNull(game);
+    updateGame(game);
+  }
+  function setRematch({ pNum: p, rematch }) {
+    if (p === 0) {
+      p0Rematch.value = rematch;
+    } else {
+      p1Rematch.value = rematch;
+    }
+  }
+  function resetPNumIfNull(game) {
+    // Set my pNum if it is null
+    if (myPNum.value === null) {
+      let myPNumLocal = game.players.findIndex(({ username }) => username === authStore.username);
+      if (myPNumLocal === -1) {
+        myPNumLocal = null;
       }
-    },
-    /**
-     * Updates gamestate to animate scuttle. First removes card from op hand
-     * and places it on top of player's point card, then waits 1s
-     * and updates complete game which will put both cards in the scrap
-     * @returns void
-     */
-    async processScuttle({ game, playedCardId, targetCardId, playedBy }) {
-      // Update in one step if this player scuttled or if pNum is not set
-      if (!this.player) {
-        this.resetPNumIfNullThenUpdateGame(game);
+      if (gameHistoryStore.isSpectating) {
+        myPNumLocal = 0;
+      }
+      myPNum.value = myPNumLocal;
+    }
+  }
+  async function processScuttle({ game, playedCardId, targetCardId, playedBy }) {
+    if (!player.value) {
+      resetPNumIfNullThenUpdateGame(game);
+      return;
+    }
+    const scuttlingPlayer = players.value[playedBy];
+    const scuttledPlayer = players.value[(playedBy + 1) % 2];
+    const playedCardIndex = scuttlingPlayer.hand.findIndex((card) => card.id === playedCardId);
+    const targetCardIndex = scuttledPlayer.points.findIndex((card) => card.id === targetCardId);
+    if (playedCardIndex === -1 || targetCardIndex === -1) {
+      resetPNumIfNullThenUpdateGame(game);
+      return;
+    }
+    const [ playedCard ] = scuttlingPlayer.hand.splice(playedCardIndex, 1);
+    const targetCard = scuttledPlayer.points[targetCardIndex];
+    targetCard.scuttledBy = playedCard;
+    await sleep(1000);
+    resetPNumIfNullThenUpdateGame(game);
+  }
+  async function processThrees(chosenCard, game) {
+    phase.value = GamePhase.MAIN;
+    lastEventCardChosen.value = chosenCard;
+    await sleep(1000);
+    resetPNumIfNullThenUpdateGame(game);
+  }
+  async function processFours(discardedCards, game) {
+    phase.value = GamePhase.MAIN;
+    lastEventDiscardedCards.value = discardedCards;
+    await sleep(1000);
+    resetPNumIfNullThenUpdateGame(game);
+  }
+  async function processFives(discardedCards, game) {
+    phase.value = GamePhase.MAIN;
+    lastEventDiscardedCards.value = discardedCards;
+    if (discardedCards?.length) {
+      await sleep(1000);
+      opponent.value.hand = opponent.value.hand.filter((card) => !discardedCards.includes(card.id));
+      player.value.hand = player.value.hand.filter((card) => !discardedCards.includes(card.id));
+      await sleep(1000);
+    }
+    resetPNumIfNullThenUpdateGame(game);
+  }
+  function handleGameResponse(jwres, resolve, reject) {
+    switch (jwres.statusCode) {
+      case 200:
+        return resolve(jwres);
+      case 401:
+        authStore.mustReauthenticate = true;
+        return reject(jwres.body.message);
+      default:
+        return reject(jwres.body.message);
+    }
+  }
+  function transformGameUrl(slug) {
+    switch (slug) {
+      case 'draw':
+      case 'points':
+      case 'faceCard':
+      case 'scuttle':
+      case 'untargetedOneOff':
+      case 'targetedOneOff':
+      case 'jack':
+      case 'counter':
+      case 'resolve':
+      case 'resolveThree':
+      case 'resolveFour':
+      case 'resolveFive':
+      case 'seven/points':
+      case 'seven/scuttle':
+      case 'seven/faceCard':
+      case 'seven/jack':
+      case 'seven/untargetedOneOff':
+      case 'seven/targetedOneOff':
+      case 'pass':
+      case 'concede':
+      case 'stalemate':
+      case 'stalemate-accept':
+      case 'stalemate-reject':
+        return `/api/game/${id.value}/move`;
+      case 'rematch':
+        return `/api/game/${id.value}/rematch`;
+      default:
+        return `/api/game/${slug}`;
+    }
+  }
+  function makeSocketRequest(slug, data, method = 'POST') {
+    const url = transformGameUrl(slug);
+    return new Promise((resolve, reject) => {
+      io.socket.request(
+        {
+          method,
+          url,
+          data,
+        },
+        (_res, jwres) => {
+          return handleGameResponse(jwres, resolve, reject);
+        },
+      );
+    });
+  }
+  async function requestSubscribe(gameId) {
+    return new Promise((resolve, reject) => {
+      io.socket.post(
+        `/api/game/${gameId}/join`,
+        (res, jwres) => {
+          if (jwres.statusCode === 200) {
+            resetState();
+            myPNum.value = res.pNum;
+            updateGame(res.game);
+            return resolve(res);
+          }
+          const message = res.message ?? 'error subscribing';
+          return reject(new Error(message));
+        },
+      );
+    });
+  }
+  function requestGameState(gameId, gameStateIndex = -1, route = null) {
+    return new Promise((resolve, reject) => {
+      io.socket.get(`/api/game/${gameId}?gameStateIndex=${gameStateIndex}`, (res, jwres) => {
+        switch (jwres.statusCode) {
+          case 200:
+            resetState();
+            resetPNumIfNullThenUpdateGame(res.game);
+            return handleInGameEvents(res, route).then(() => {
+              return resolve(res);
+            });
+          case 401:
+            authStore.mustReauthenticate = true;
+            return resolve(jwres.body.message);
+          default:
+            return reject(jwres.body.message);
+        }
+      });
+    });
+  }
+  async function requestSpectate(gameId, gameStateIndex = 0, route = null) {
+    const slug = `${gameId}/spectate?gameStateIndex=${gameStateIndex}`;
+    try {
+      resetState();
+      const res = await makeSocketRequest(slug, {});
+      myPNum.value = 0;
+      updateGame(res.body.game);
+      return handleInGameEvents(res.body, route);
+    } catch (err) {
+      if (authStore.mustReauthenticate) {
+        id.value = gameId;
         return;
       }
-
-      const scuttlingPlayer = this.players[playedBy];
-      const scuttledPlayer = this.players[(playedBy + 1) % 2];
-
-      // Remove played card from scuttling player's hand and temporarily add to target's attachments
-      const playedCardIndex = scuttlingPlayer.hand.findIndex((card) => card.id === playedCardId);
-      const targetCardIndex = scuttledPlayer.points.findIndex((card) => card.id === targetCardId);
-
-      // Update game in one-step if moved cards are not found
-      if (playedCardIndex === -1 || targetCardIndex === -1) {
-        this.resetPNumIfNullThenUpdateGame(game);
-        return;
-      }
-
-      const [ playedCard ] = scuttlingPlayer.hand.splice(playedCardIndex, 1);
-      const targetCard = scuttledPlayer.points[targetCardIndex];
-      targetCard.scuttledBy = playedCard;
-
-      // Finish complete update of the game state after 1s
-      await sleep(1000);
-      this.resetPNumIfNullThenUpdateGame(game);
-    },
-    async processThrees(chosenCard, game) {
-      this.phase = GamePhase.MAIN;
-      this.lastEventCardChosen = chosenCard;
-
-      await sleep(1000);
-      this.resetPNumIfNullThenUpdateGame(game);
-    },
-    async processFours(discardedCards, game) {
-      this.phase = GamePhase.MAIN;
-      this.lastEventDiscardedCards = discardedCards;
-
-      await sleep(1000);
-      this.resetPNumIfNullThenUpdateGame(game);
-    },
-    async processFives(discardedCards, game) {
-      this.phase = GamePhase.MAIN;
-      this.lastEventDiscardedCards = discardedCards;
-
-      // Animate discard then update full game to animate draw
-      if (discardedCards?.length) {
-        await sleep(1000);
-        this.opponent.hand = this.opponent.hand.filter((card) => !discardedCards.includes(card.id));
-        this.player.hand = this.player.hand.filter((card) => !discardedCards.includes(card.id));
-        await sleep(1000);
-      }
-
-      this.resetPNumIfNullThenUpdateGame(game);
-    },
-    handleGameResponse: (jwres, resolve, reject) => {
-      const authStore = useAuthStore();
-      switch (jwres.statusCode) {
-        case 200:
-          return resolve(jwres);
-        case 401:
-          authStore.mustReauthenticate = true;
-          return reject(jwres.body.message);
-        default:
-          return reject(jwres.body.message);
-      }
-    },
-    // TODO #1198: clean this up to remove the unused slugs
-    transformGameUrl(slug) {
-      switch (slug) {
-        case 'draw':
-        case 'points':
-        case 'faceCard':
-        case 'scuttle':
-        case 'untargetedOneOff':
-        case 'targetedOneOff':
-        case 'jack':
-        case 'counter':
-        case 'resolve':
-        case 'resolveThree':
-        case 'resolveFour':
-        case 'resolveFive':
-        case 'seven/points':
-        case 'seven/scuttle':
-        case 'seven/faceCard':
-        case 'seven/jack':
-        case 'seven/untargetedOneOff':
-        case 'seven/targetedOneOff':
-        case 'pass':
-        case 'concede':
-        case 'stalemate':
-        case 'stalemate-accept':
-        case 'stalemate-reject':
-          // add all the move-making ones here
-          return `/api/game/${this.id}/move`;
-        case 'rematch':
-          return `/api/game/${this.id}/rematch`;
-        default:
-          return `/api/game/${slug}`;
-      }
-    },
-    makeSocketRequest(slug, data, method = 'POST') {
-      const url = this.transformGameUrl(slug);
-      return new Promise((resolve, reject) => {
-        io.socket.request(
-          {
-            method,
-            url,
-            data,
-          },
-          (_res, jwres) => {
-            return this.handleGameResponse(jwres, resolve, reject);
-          },
-        );
-      });
-    },
-    async requestSubscribe(gameId) {
-      return new Promise((resolve, reject) => {
-        io.socket.post(
-          `/api/game/${gameId}/join`,
-          (res, jwres) => {
-            if (jwres.statusCode === 200) {
-              this.resetState();
-              this.myPNum = res.pNum;
-              this.updateGame(res.game);
-              return resolve(res);
-            }
-            const message = res.message ?? 'error subscribing';
-            return reject(new Error(message));
-          },
-        );
-      });
-    },
-
-    requestGameState(gameId, gameStateIndex = -1, route = null) {
-      const authStore = useAuthStore();
-      return new Promise((resolve, reject) => {
-        io.socket.get(`/api/game/${gameId}?gameStateIndex=${gameStateIndex}`, (res, jwres) => {
-          switch (jwres.statusCode) {
-            case 200:
-              this.resetState();
-              this.resetPNumIfNullThenUpdateGame(res.game);
-              return handleInGameEvents(res, route).then(() => {
-                return resolve(res);
-              });
-            case 401:
-              authStore.mustReauthenticate = true;
-              // resolve so we can navigate to gameview & login there
-              return resolve(jwres.body.message);
-            default:
-              return reject(jwres.body.message);
-          }
-        });
-      });
-    },
-
-    async requestSpectate(gameId, gameStateIndex = 0, route = null) {
-      const authStore = useAuthStore();
-      const slug = `${gameId}/spectate?gameStateIndex=${gameStateIndex}`;
-      try {
-        this.resetState();
-        const res = await this.makeSocketRequest(slug, {});
-        this.myPNum = 0;
-        this.updateGame(res.body.game);
-        return handleInGameEvents(res.body, route);
-      } catch (err) {
-        // Swallow 401 error so we can authenticate from GameView
-        if (authStore.mustReauthenticate) {
-          this.id = gameId;
-          return;
+      const message = err?.message ?? err ?? `Unable to spectate game ${gameId}`;
+      throw(new Error(message));
+    }
+  }
+  async function requestSpectateLeave() {
+    return new Promise((resolve, reject) => {
+      io.socket.delete(`/api/game/${id.value}/spectate`, (_res, jwres) => {
+        if (jwres.statusCode === 200) {
+          resetState();
+          return resolve();
         }
-        const message = err?.message ?? err ?? `Unable to spectate game ${gameId}`;
-        throw(new Error(message));
-      }
-    },
-    async requestSpectateLeave() {
-      return new Promise((resolve, reject) => {
-        io.socket.delete(`/api/game/${this.id}/spectate`, (_res, jwres) => {
+        return reject(new Error('Error leaving game as spectator'));
+      });
+    });
+  }
+  async function requestLeaveLobby() {
+    return new Promise((resolve, reject) => {
+      io.socket.post(`/api/game/${id.value}/leave`, (res, jwres) => {
+        if (jwres.statusCode === 200) {
+          resetState();
+          return resolve();
+        }
+        return reject(new Error('Error leaving lobby'));
+      });
+    });
+  }
+  async function requestReady() {
+    return new Promise((resolve, reject) => {
+      io.socket.post(`/api/game/${id.value}/ready`, (res, jwres) => {
+        if (jwres.statusCode === 200) {
+          return resolve();
+        }
+        if (jwres.statusCode === 409) {
+          return reject({ message: res.message, gameId: id.value, code: res.code });
+        }
+        return reject(new Error('Error readying for game'));
+      });
+    });
+  }
+  async function requestSetIsRanked({ isRanked: isRankedArg }) {
+    return new Promise((resolve, reject) => {
+      io.socket.patch(
+        `/api/game/${id.value}/is-ranked`,
+        {
+          isRanked: isRankedArg,
+        },
+        (res, jwres) => {
           if (jwres.statusCode === 200) {
-            this.resetState();
-            return resolve();
+            return resolve(res);
           }
-          return reject(new Error('Error leaving game as spectator'));
-        });
+          const modeName = isRankedArg ? 'ranked' : 'casual';
+          return reject(new Error(`Unable to change game to ${modeName}`));
+        },
+      );
+    });
+  }
+  async function requestDrawCard() {
+    const moveType = MoveType.DRAW;
+    await makeSocketRequest('draw', { moveType });
+  }
+  async function requestPlayPoints(cardIdArg) {
+    const moveType = MoveType.POINTS;
+    await makeSocketRequest('points', { moveType, cardId: cardIdArg });
+  }
+  async function requestPlayFaceCard(cardIdArg) {
+    const moveType = MoveType.FACE_CARD;
+    await makeSocketRequest('faceCard', { moveType, cardId: cardIdArg });
+  }
+  async function requestScuttle(cardData) {
+    const moveType = MoveType.SCUTTLE;
+    const { cardId, targetId } = cardData;
+    await makeSocketRequest('scuttle', { moveType, cardId, targetId });
+  }
+  async function requestPlayOneOff(cardIdArg) {
+    const moveType = MoveType.ONE_OFF;
+    await makeSocketRequest('untargetedOneOff', { moveType, cardId: cardIdArg });
+    return Promise.resolve();
+  }
+  async function requestPlayTargetedOneOff({ cardId, targetId, pointId, targetType }) {
+    const moveType = MoveType.ONE_OFF;
+    await makeSocketRequest('targetedOneOff', { moveType, cardId, targetId, pointId, targetType });
+  }
+  async function requestPlayJack({ cardId, targetId }) {
+    const moveType = MoveType.JACK;
+    await makeSocketRequest('jack', { moveType, cardId, targetId });
+  }
+  async function requestDiscard({ cardId1, cardId2 }) {
+    const moveType = MoveType.RESOLVE_FOUR;
+    const reqData = cardId2 ? { moveType, cardId1, cardId2 } : { moveType, cardId1 };
+    await makeSocketRequest('resolveFour', reqData);
+  }
+  async function requestResolve() {
+    const moveType = MoveType.RESOLVE;
+    await makeSocketRequest('resolve', { moveType });
+  }
+  async function requestResolveThree(cardIdArg) {
+    const moveType = MoveType.RESOLVE_THREE;
+    await makeSocketRequest('resolveThree', { moveType, cardId: cardIdArg });
+  }
+  async function requestResolveFive(cardIdArg) {
+    const moveType = MoveType.RESOLVE_FIVE;
+    await makeSocketRequest('resolveFive', { moveType, cardId: cardIdArg });
+  }
+  async function requestCounter(twoId) {
+    const moveType = MoveType.COUNTER;
+    await makeSocketRequest('counter', { moveType, cardId: twoId });
+  }
+  async function requestPlayPointsSeven({ cardId, index }) {
+    await makeSocketRequest('seven/points', { moveType: MoveType.SEVEN_POINTS, cardId, index });
+  }
+  async function requestScuttleSeven({ cardId, index, targetId }) {
+    await makeSocketRequest('seven/scuttle', { moveType: MoveType.SEVEN_SCUTTLE, cardId, index, targetId });
+  }
+  async function requestPlayJackSeven({ cardId, index, targetId }) {
+    await makeSocketRequest('seven/jack', { moveType: MoveType.SEVEN_JACK, cardId, index, targetId });
+  }
+  async function requestResolveSevenDoubleJacks({ cardId, index }) {
+    await makeSocketRequest('seven/jack', { moveType: MoveType.SEVEN_DISCARD, cardId, index });
+  }
+  async function requestPlayFaceCardSeven({ index, cardId }) {
+    await makeSocketRequest('seven/faceCard', { moveType: MoveType.SEVEN_FACE_CARD, cardId, index });
+  }
+  async function requestPlayOneOffSeven({ cardId, index }) {
+    await makeSocketRequest('seven/untargetedOneOff', { moveType: MoveType.SEVEN_ONE_OFF, cardId, index });
+  }
+  async function requestPlayTargetedOneOffSeven({ cardId, index, targetId, pointId, targetType }) {
+    await makeSocketRequest('seven/targetedOneOff', { moveType: MoveType.SEVEN_ONE_OFF, cardId, targetId, pointId, targetType, index });
+  }
+  async function requestPass() {
+    const moveType = MoveType.PASS;
+    await makeSocketRequest('pass', { moveType });
+  }
+  async function requestConcede() {
+    await makeSocketRequest('concede', { moveType: MoveType.CONCEDE });
+  }
+  async function requestStalemate() {
+    await makeSocketRequest('stalemate', { moveType: MoveType.STALEMATE_REQUEST });
+  }
+  async function acceptStalemate() {
+    await makeSocketRequest('stalemate-accept', { moveType: MoveType.STALEMATE_ACCEPT });
+  }
+  async function rejectStalemate() {
+    await makeSocketRequest('stalemate-reject', { moveType: MoveType.STALEMATE_REJECT });
+  }
+  async function requestUnsubscribeFromGame() {
+    return new Promise((resolve, reject) => {
+      io.socket.get('/api/game/over', (res, jwres) => {
+        if (jwres.statusCode === 200) {
+          resetState();
+        }
+        return handleGameResponse(jwres, resolve, reject);
       });
-    },
-    async requestLeaveLobby() {
-      return new Promise((resolve, reject) => {
-        io.socket.post(`/api/game/${this.id}/leave`, (res, jwres) => {
-          if (jwres.statusCode === 200) {
-            this.resetState();
-            return resolve();
-          }
-          return reject(new Error('Error leaving lobby'));
-        });
+    });
+  }
+  async function requestRematch({ gameId: gameIdArg, rematch = true }) {
+    await makeSocketRequest('rematch', { gameId: gameIdArg, rematch });
+  }
+  async function requestJoinRematch({ oldGameId }) {
+    return new Promise((resolve, reject) => {
+      io.socket.get('/api/game/join-rematch', { oldGameId }, (res, jwres) => {
+        if (jwres.statusCode === 200) {
+          resetState();
+        }
+        return handleGameResponse(jwres, resolve, reject);
       });
-    },
-    async requestReady() {
-      return new Promise((resolve, reject) => {
-        io.socket.post(`/api/game/${this.id}/ready`, (res, jwres) => {
-          if (jwres.statusCode === 200) {
-            return resolve();
-          }
-          // If game has already started, throw specific signal so lobbyview can handle it
-          if (jwres.statusCode === 409) {
-            return reject({ message: res.message, gameId: this.id, code: res.code });
-          }
-          return reject(new Error('Error readying for game'));
-        });
-      });
-    },
-    async requestSetIsRanked({ isRanked }) {
-      return new Promise((resolve, reject) => {
-        io.socket.patch(
-          `/api/game/${this.id}/is-ranked`,
-          {
-            isRanked,
-          },
-          (res, jwres) => {
-            if (jwres.statusCode === 200) {
-              return resolve(res);
-            }
-            const modeName = isRanked ? 'ranked' : 'casual';
-            return reject(new Error(`Unable to change game to ${modeName}`));
-          },
-        );
-      });
-    },
-    ///////////////////
-    // In-Game Moves //
-    ///////////////////
-    async requestDrawCard() {
-      const moveType = MoveType.DRAW;
-      await this.makeSocketRequest('draw', { moveType });
-    },
-    async requestPlayPoints(cardId) {
-      const moveType = MoveType.POINTS;
-      await this.makeSocketRequest('points', { moveType, cardId });
-    },
-    async requestPlayFaceCard(cardId) {
-      const moveType = MoveType.FACE_CARD;
-      await this.makeSocketRequest('faceCard', { moveType, cardId });
-    },
-    /**
-     *
-     * @param cardData @example {cardId: number, targetId: number}
-     */
-    async requestScuttle(cardData) {
-      const moveType = MoveType.SCUTTLE;
-      const { cardId, targetId } = cardData;
-      await this.makeSocketRequest('scuttle', { moveType, cardId, targetId });
-    },
+    });
+  }
+  function addSpectator(username) {
+    if (!username) return;
+    if (!spectatingUsers.value.includes(username)) {
+      spectatingUsers.value.push(username);
+    }
+  }
 
-    async requestPlayOneOff(cardId) {
-      const moveType = MoveType.ONE_OFF;
-      await this.makeSocketRequest('untargetedOneOff', {
-        moveType,
-        cardId,
-      });
-      return Promise.resolve();
-    },
-
-    async requestPlayTargetedOneOff({ cardId, targetId, pointId, targetType }) {
-      const moveType = MoveType.ONE_OFF;
-      await this.makeSocketRequest('targetedOneOff', {
-        moveType,
-        cardId,
-        targetId,
-        pointId,
-        targetType,
-      });
-    },
-
-    async requestPlayJack({ cardId, targetId }) {
-
-      const moveType = MoveType.JACK;
-      await this.makeSocketRequest('jack', {
-        moveType,
-        cardId,
-        targetId,
-      });
-    },
-
-    /**
-     *
-     * @param {required} cardId1
-     * @param {optional} cardId2
-     */
-    async requestDiscard({ cardId1, cardId2 }) {
-      const moveType = MoveType.RESOLVE_FOUR;
-      const reqData = cardId2 ? { moveType, cardId1, cardId2 } : { moveType, cardId1 };
-
-      await this.makeSocketRequest('resolveFour', reqData);
-    },
-
-    async requestResolve() {
-      const moveType = MoveType.RESOLVE;
-      await this.makeSocketRequest('resolve', { moveType });
-    },
-
-    async requestResolveThree(cardId) {
-      const moveType = MoveType.RESOLVE_THREE;
-
-      await this.makeSocketRequest('resolveThree', {
-        moveType,
-        cardId,
-      });
-    },
-
-    async requestResolveFive(cardId) {
-      const moveType = MoveType.RESOLVE_FIVE;
-
-      await this.makeSocketRequest('resolveFive', { moveType, cardId });
-    },
-
-    async requestCounter(twoId) {
-      const moveType = MoveType.COUNTER;
-
-      await this.makeSocketRequest('counter', {
-        moveType,
-        cardId: twoId,
-      });
-    },
-
-    ////////////
-    // Sevens //
-    ////////////
-    async requestPlayPointsSeven({ cardId, index }) {
-      await this.makeSocketRequest('seven/points', {
-        moveType: MoveType.SEVEN_POINTS,
-        cardId,
-        index, // 0 if topCard, 1 if secondCard
-      });
-    },
-
-    async requestScuttleSeven({ cardId, index, targetId }) {
-      await this.makeSocketRequest('seven/scuttle', {
-        moveType: MoveType.SEVEN_SCUTTLE,
-        cardId,
-        index,
-        targetId,
-      });
-    },
-
-    async requestPlayJackSeven({ cardId, index, targetId }) {
-      await this.makeSocketRequest('seven/jack', {
-        moveType: MoveType.SEVEN_JACK,
-        cardId,
-        index, // 0 if topCard, 1 if secondCard
-        targetId,
-      });
-    },
-
-    async requestResolveSevenDoubleJacks({ cardId, index }) {
-      await this.makeSocketRequest('seven/jack', {
-        moveType: MoveType.SEVEN_DISCARD,
-        cardId,
-        index, // 0 if topCard, 1 if secondCard
-      });
-    },
-
-    async requestPlayFaceCardSeven({ index, cardId }) {
-      await this.makeSocketRequest('seven/faceCard', {
-        moveType: MoveType.SEVEN_FACE_CARD,
-        cardId,
-        index,
-      });
-    },
-
-    async requestPlayOneOffSeven({ cardId, index }) {
-      await this.makeSocketRequest('seven/untargetedOneOff', {
-        moveType: MoveType.SEVEN_ONE_OFF,
-        cardId,
-        index, // 0 if topCard, 1 if secondCard
-      });
-    },
-
-    async requestPlayTargetedOneOffSeven({ cardId, index, targetId, pointId, targetType }) {
-      await this.makeSocketRequest('seven/targetedOneOff', {
-        moveType: MoveType.SEVEN_ONE_OFF,
-        cardId,
-        targetId,
-        pointId,
-        targetType,
-        index, // 0 if topCard, 1 if secondCard
-      });
-    },
-
-    async requestPass() {
-      const moveType = MoveType.PASS;
-      await this.makeSocketRequest('pass', { moveType });
-    },
-
-    async requestConcede() {
-      await this.makeSocketRequest('concede', { moveType: MoveType.CONCEDE });
-    },
-
-    async requestStalemate() {
-      await this.makeSocketRequest('stalemate', { moveType: MoveType.STALEMATE_REQUEST });
-    },
-
-    async acceptStalemate() {
-      await this.makeSocketRequest('stalemate-accept', { moveType: MoveType.STALEMATE_ACCEPT });
-    },
-
-    async rejectStalemate() {
-      await this.makeSocketRequest('stalemate-reject', { moveType: MoveType.STALEMATE_REJECT });
-    },
-
-    async requestUnsubscribeFromGame() {
-      return new Promise((resolve, reject) => {
-        io.socket.get('/api/game/over', (res, jwres) => {
-          if (jwres.statusCode === 200) {
-            this.resetState();
-          }
-          return this.handleGameResponse(jwres, resolve, reject);
-        });
-      });
-    },
-
-    async requestRematch({ gameId, rematch = true }) {
-      await this.makeSocketRequest('rematch', { gameId, rematch });
-    },
-
-    async requestJoinRematch({ oldGameId }) {
-      return new Promise((resolve, reject) => {
-        io.socket.get('/api/game/join-rematch', { oldGameId }, (res, jwres) => {
-          if (jwres.statusCode === 200) {
-            this.resetState();
-          }
-          return this.handleGameResponse(jwres, resolve, reject);
-        });
-      });
-    },
-
-    addSpectator(username) {
-      if (!username) {return;}
-      if (!this.spectatingUsers.includes(username)) {
-        this.spectatingUsers.push(username);
-      }
-    },
-
-  }, // End actions
-}); // End game store
+  return {
+    // State
+    id,
+    chat,
+    deck,
+    log,
+    name,
+    p0Ready,
+    p1Ready,
+    p0Rematch,
+    p1Rematch,
+    rematchGameId,
+    phase,
+    passes,
+    players,
+    spectatingUsers,
+    scrap,
+    turn,
+    twos,
+    myPNum,
+    topCard,
+    secondCard,
+    oneOff,
+    oneOffTarget,
+    isRanked,
+    showIsRankedChangedAlert,
+    lastEventCardChosen,
+    lastEventPlayerChoosing,
+    lastEventDiscardedCards,
+    lastEventChange,
+    lastEventOneOffRank,
+    lastEventTargetType,
+    lastEventPlayedBy,
+    gameIsOver,
+    winnerPNum,
+    conceded,
+    currentMatch,
+    iWantToContinueSpectating,
+    status,
+    // Getters
+    player,
+    playerPointTotal,
+    playerQueenCount,
+    playerUsername,
+    opponent,
+    opponentIsReady,
+    opponentUsername,
+    opponentPointTotal,
+    opponentQueenCount,
+    playerWins,
+    resolvingSeven,
+    isPlayersTurn,
+    hasGlassesEight,
+    iWantRematch,
+    opponentWantsRematch,
+    opponentDeclinedRematch,
+    someoneDeclinedRematch,
+    waitingForOpponentToCounter,
+    myTurnToCounter,
+    waitingForOpponentToPickFromScrap,
+    pickingFromScrap,
+    showResolveFour,
+    waitingForOpponentToDiscard,
+    showResolveFive,
+    playingFromDeck,
+    waitingForOpponentToPlayFromDeck,
+    waitingForOpponentToStalemate,
+    consideringOpponentStalemateRequest,
+    // Actions
+    updateGame,
+    opponentJoined,
+    removeSpectator,
+    resetState,
+    updateReady,
+    opponentLeft,
+    setGameOver,
+    resetPNumIfNullThenUpdateGame,
+    setRematch,
+    resetPNumIfNull,
+    processScuttle,
+    processThrees,
+    processFours,
+    processFives,
+    handleGameResponse,
+    transformGameUrl,
+    makeSocketRequest,
+    requestSubscribe,
+    requestGameState,
+    requestSpectate,
+    requestSpectateLeave,
+    requestLeaveLobby,
+    requestReady,
+    requestSetIsRanked,
+    requestDrawCard,
+    requestPlayPoints,
+    requestPlayFaceCard,
+    requestScuttle,
+    requestPlayOneOff,
+    requestPlayTargetedOneOff,
+    requestPlayJack,
+    requestDiscard,
+    requestResolve,
+    requestResolveThree,
+    requestResolveFive,
+    requestCounter,
+    requestPlayPointsSeven,
+    requestScuttleSeven,
+    requestPlayJackSeven,
+    requestResolveSevenDoubleJacks,
+    requestPlayFaceCardSeven,
+    requestPlayOneOffSeven,
+    requestPlayTargetedOneOffSeven,
+    requestPass,
+    requestConcede,
+    requestStalemate,
+    acceptStalemate,
+    rejectStalemate,
+    requestUnsubscribeFromGame,
+    requestRematch,
+    requestJoinRematch,
+    addSpectator,
+  };
+});
+// End game store

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -131,12 +131,16 @@ export const useGameStore = defineStore('game', () => {
   const isPlayersTurn = computed(() => turn.value % 2 === myPNum.value);
   const hasGlassesEight = computed(() => player.value?.faceCards?.filter((card) => card.rank === 8).length > 0 ?? false);
   const iWantRematch = computed(() => {
-    if (myPNum.value === null) return false;
+    if (myPNum.value === null) {
+      return false;
+    }
     const key = myPNum.value === 0 ? p0Rematch : p1Rematch;
     return key.value;
   });
   const opponentWantsRematch = computed(() => {
-    if (myPNum.value === null) return false;
+    if (myPNum.value === null) {
+      return false;
+    }
     const key = myPNum.value === 0 ? p1Rematch : p0Rematch;
     return key.value;
   });
@@ -615,7 +619,9 @@ export const useGameStore = defineStore('game', () => {
     });
   }
   function addSpectator(username) {
-    if (!username) return;
+    if (!username) {
+      return;
+    }
     if (!spectatingUsers.value.includes(username)) {
       spectatingUsers.value.push(username);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Refactors the `game` store as a setup store to allow it to utilize composables e.g. `useRoute()`
## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
