### PR TITLE
test(profile.spec.js): add assertion to slown down test

### DIFF
--- a/tests/e2e/specs/out-of-game/profile.spec.js
+++ b/tests/e2e/specs/out-of-game/profile.spec.js
@@ -81,7 +81,9 @@ describe('Profile Page', () => {
       cy.loginPlayer(myUser);
       cy.vueRoute('/my-profile');
 
-      cy.get('[data-cy="game-list-item"]').should('have.length.below', 21);
+      cy.get('[data-cy="game-list-item"]')
+        .should('have.length.above', 5)
+        .should('have.length.below', 21);
 
       cy.get('[data-cy="game-list"]').scrollTo('bottom', { ensureScrollable: false });
       cy.contains('[data-cy="game-list-item"]', 'Game 20', { timeout: 5000 })


### PR DESCRIPTION
Should help with flakiness in `it('Loads more games on scroll')`: https://cloud.cypress.io/projects/i8bxr8/runs/3068/overview/18b9abdd-b917-4ea1-b6de-0e2aa5864b03/replay?att=1&roarHideRunsWithDiffGroupsAndTags=1&runStatus=FAILED&runStatus=RUNNING&runStatus=CANCELLED&runStatus=ERRORED&runStatus=OVERLIMIT&runStatus=PASSED&ts=1764693011235
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
