### PR TITLE
fix(leave-lobby): add check that game status is CREATED

### DIFF
--- a/api/controllers/game/leave-lobby.js
+++ b/api/controllers/game/leave-lobby.js
@@ -7,7 +7,6 @@ module.exports = async function (req, res) {
     const promisePlayer = userService.findUser({ userId: req.session.usr });
     const [ game, player ] = await Promise.all([ promiseGame, promisePlayer ]);
   
-    // no-op if the game is complete
     if (game.status !== GameStatus.CREATED) {
       return res.badRequest({ message: 'Can\'t quit game once it\'s started' });
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number
Games are somewhat frequently losing reference to who's p0 and/or p1 (it's null even when game is finished). This looks to be due to accidental use of the leave-lobby endpoint after a game has finished (eg by pressing the back button to get to the lobby, then hitting the leave lobby button). Adding a check to error if that happens when it's not supposed to, and switching to router.replace() when navigating from lobby to game view to prevent back button from bringing you to the lobby after game completes

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
