### PR TITLE
fix(ScrapPile.vue): prevent card entering transition when 3 resolves

### DIFF
--- a/src/routes/game/components/ScrapPile.vue
+++ b/src/routes/game/components/ScrapPile.vue
@@ -14,7 +14,7 @@
         @touchstart="isLongPressing = false"
       >
         <div id="scrap" ref="scrap" class="d-flex flex-column align-center">
-          <TransitionGroup name="scrap">
+          <TransitionGroup :name="disableEnterTransition ? 'no-transition' : 'scrap'">
             <GameCard
               v-for="(card, index) in scrapDisplay"
               :key="`scrap-card-${card.id}`"
@@ -113,6 +113,7 @@ import { useDisplay } from 'vuetify';
 import { useI18n } from 'vue-i18n';
 import { onLongPress } from '@vueuse/core';
 import { useGameStore } from '_/src/stores/game';
+import MoveType from '_/utils/MoveType';
 import CardListSortable from '@/routes/game/components/CardListSortable.vue';
 import BaseDialog from '@/components/BaseDialog.vue';
 import GameCard from '@/routes/game/components/GameCard.vue';
@@ -137,6 +138,10 @@ const threesTransition = computed(() => gameStore.lastEventPlayerChoosing ? `thr
 
 // Threes transition
 const threeTarget = computed(() => gameStore.lastEventThreeTarget);
+const disableEnterTransition = computed(() => {
+  // Disable scrap-enter transition when three reorders the top 10 cards
+  return gameStore.lastEventChange === MoveType.RESOLVE_THREE && !threeTarget.value;
+});
 
 // Tidying + messing up pile
 const scrapWrapper = useTemplateRef('scrap');


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->

Fixes visual bug with scrap where three animation would show a card entering the scrap (due to it 'entering' the last 10 cards via the three target leaving) .


https://github.com/user-attachments/assets/389d8d42-cb23-40d8-8c79-568625a81c69



## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
N/A

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
