### PR TITLE
chore(game.js): remove broken and useless requestUnsubscribeFromGame()

### DIFF
--- a/src/routes/game/components/GameOverlays.vue
+++ b/src/routes/game/components/GameOverlays.vue
@@ -204,17 +204,13 @@ export default {
     },
     async goHome() {
       this.leavingGame = true;
-      try {
-        await this.gameStore.requestUnsubscribeFromGame();
-      } finally {
-        this.leavingGame = false;
-        this.$router.push('/');
-        this.gameStore.setGameOver({
-          gameOver: false,
-          conceded: false,
-          winner: null,
-        });
-      }
+      this.leavingGame = false;
+      this.$router.push('/');
+      this.gameStore.setGameOver({
+        gameOver: false,
+        conceded: false,
+        winner: null,
+      });
     },
   },
 };

--- a/src/routes/game/components/dialogs/components/gameOver/GameOverDialog.vue
+++ b/src/routes/game/components/dialogs/components/gameOver/GameOverDialog.vue
@@ -274,8 +274,6 @@ export default {
       if (!this.gameHistoryStore.isSpectating) {
         await this.gameStore.requestRematch({ gameId: this.gameStore.id, rematch: false });
       }
-
-      await this.gameStore.requestUnsubscribeFromGame();
     },
     async rematch() {
       try {

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -657,16 +657,6 @@ export const useGameStore = defineStore('game', () => {
   async function rejectStalemate() {
     await makeSocketRequest('stalemate-reject', { moveType: MoveType.STALEMATE_REJECT });
   }
-  async function requestUnsubscribeFromGame() {
-    return new Promise((resolve, reject) => {
-      io.socket.get('/api/game/over', (res, jwres) => {
-        if (jwres.statusCode === 200) {
-          resetState();
-        }
-        return handleGameResponse(jwres, resolve, reject);
-      });
-    });
-  }
   async function requestRematch({ gameId: gameIdArg, rematch = true }) {
     await makeSocketRequest('rematch', { gameId: gameIdArg, rematch });
   }
@@ -794,7 +784,6 @@ export const useGameStore = defineStore('game', () => {
     requestStalemate,
     acceptStalemate,
     rejectStalemate,
-    requestUnsubscribeFromGame,
     requestRematch,
     addSpectator,
   };


### PR DESCRIPTION
Stumbled on the fact that this method calls an unmapped endpoint

<!-- Thanks for contributing to Cuttle! 🎉 -->

## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
