### PR TITLE
fix: handle reconnect in lobby

### DIFF
--- a/src/plugins/sockets/connectivityEvents.js
+++ b/src/plugins/sockets/connectivityEvents.js
@@ -3,7 +3,8 @@ import { useGameStore } from '@/stores/game';
 import { useGameHistoryStore } from '@/stores/gameHistory';
 import { useGameListStore } from '@/stores/gameList';
 import router from '@/router.js';
-import { ROUTE_NAME_GAME, ROUTE_NAME_SPECTATE, ROUTE_NAME_HOME } from '@/router';
+import { ROUTE_NAME_GAME, ROUTE_NAME_SPECTATE, ROUTE_NAME_HOME, ROUTE_NAME_LOBBY } from '@/router';
+import GameStatus from '_/utils/GameStatus.json';
 
 export async function handleConnect() {
   const authStore = useAuthStore();
@@ -33,6 +34,22 @@ export async function handleConnect() {
       }
 
       return gameStore.requestSpectate(gameId, gameHistoryStore.currentGameStateIndex);
+    }
+    case ROUTE_NAME_LOBBY: {
+      const gameId = Number(router.currentRoute.value.params.gameId);
+      if (!Number.isInteger(gameId)) {
+        router.push({ name: ROUTE_NAME_HOME });
+        return;
+      }
+      try {
+        const { game } = await gameStore.requestSubscribe(gameId);
+        if (game.status === GameStatus.STARTED) {
+          router.push({ name: ROUTE_NAME_GAME, params: { gameId } });
+        }
+      } catch (err) {
+        router.push({ name: ROUTE_NAME_HOME });
+      }
+      return;
     }
     case ROUTE_NAME_HOME: {
       return gameListStore.requestGameList();

--- a/tests/e2e/specs/out-of-game/lobby.spec.js
+++ b/tests/e2e/specs/out-of-game/lobby.spec.js
@@ -459,7 +459,7 @@ describe('Lobby - P0 Perspective', () => {
     cy.get('[data-cy=opponent-indicator] [data-cy="lobby-card-container"]').should('have.class', 'ready');
   });
 
-  it('Brings you into the game when readying after game has started', function () {
+  it('Brings you into the game when reconnecting after game has started', function () {
     const { gameId } = this.gameSummary;
     cy.get('[data-cy=my-indicator]').contains(myUser.username);
     cy.get('[data-cy=ready-button]').click();

--- a/tests/e2e/specs/out-of-game/lobby.spec.js
+++ b/tests/e2e/specs/out-of-game/lobby.spec.js
@@ -418,6 +418,47 @@ describe('Lobby - P0 Perspective', () => {
     });
   });
 
+  it('Shows opponent joining on socket reconnect', function () {
+    const { gameId } = this.gameSummary;
+    cy.get('[data-cy=my-indicator]').contains(myUser.username);
+
+    cy.window()
+      .its('cuttle.authStore')
+      .then((store) => store.disconnectSocket());
+
+    cy.signupOpponent(opponentOne);
+    cy.subscribeOpponent(gameId);
+
+    cy.wait(1000);
+    cy.get('[data-cy=opponent-indicator]').should('not.contain', opponentOne.username);
+    cy.window()
+      .its('cuttle.authStore')
+      .then((store) => store.reconnectSocket());
+
+    cy.get('[data-cy=opponent-indicator]').should('contain', opponentOne.username);
+  });
+
+  it('Shows opponent readying on socket reconnect', function () {
+    const { gameId } = this.gameSummary;
+    cy.get('[data-cy=my-indicator]').contains(myUser.username);
+    cy.signupOpponent(opponentOne);
+    cy.subscribeOpponent(gameId);
+    cy.get('[data-cy=opponent-indicator]').should('contain', opponentOne.username);
+
+    cy.window()
+      .its('cuttle.authStore')
+      .then((store) => store.disconnectSocket());
+
+    cy.readyOpponent(gameId);
+    cy.wait(1000);
+
+    cy.window()
+      .its('cuttle.authStore')
+      .then((store) => store.reconnectSocket());
+
+    cy.get('[data-cy=opponent-indicator] [data-cy="lobby-card-container"]').should('have.class', 'ready');
+  });
+
   it('Brings you into the game when readying after game has started', function () {
     const { gameId } = this.gameSummary;
     cy.get('[data-cy=my-indicator]').contains(myUser.username);
@@ -435,7 +476,6 @@ describe('Lobby - P0 Perspective', () => {
       .its('cuttle.authStore')
       .then((store) => store.reconnectSocket());
 
-    cy.get('[data-cy=ready-button]').click();
     assertGameStarted();
   });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Adds reconnect logic for LobbyView page to download latest state on socket reconnect
## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #414 

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
