### PR TITLE
Style/seven animations

### DIFF
--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -62,7 +62,7 @@ export async function handleInGameEvents(evData, newRoute = null) {
       break;
     case SocketEvent.RESOLVE:
       if (evData.game.lastEvent?.oneOff?.rank === 7) {
-        await gameStore.s(evData.game);
+        await gameStore.processSevens(evData.game);
       } else {
         gameStore.updateGame(evData.game);
       }

--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -45,7 +45,6 @@ export async function handleInGameEvents(evData, newRoute = null) {
     case SocketEvent.DELETE_DECK:
     case SocketEvent.CONCEDE:
     case SocketEvent.RE_LOGIN:
-    case SocketEvent.RESOLVE:
     case SocketEvent.FIZZLE:
     case SocketEvent.TARGETED_ONE_OFF:
     case SocketEvent.ONE_OFF:
@@ -60,6 +59,13 @@ export async function handleInGameEvents(evData, newRoute = null) {
     case SocketEvent.STALEMATE_ACCEPT:
     case SocketEvent.STALEMATE_REJECT:
       gameStore.updateGame(evData.game);
+      break;
+    case SocketEvent.RESOLVE:
+      if (evData.game.lastEvent?.oneOff?.rank === 7) {
+        await gameStore.processResolveSeven(evData.game);
+      } else {
+        gameStore.updateGame(evData.game);
+      }
       break;
     case SocketEvent.SCUTTLE:
     case SocketEvent.SEVEN_SCUTTLE:

--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -62,7 +62,7 @@ export async function handleInGameEvents(evData, newRoute = null) {
       break;
     case SocketEvent.RESOLVE:
       if (evData.game.lastEvent?.oneOff?.rank === 7) {
-        await gameStore.processSeven(evData.game);
+        await gameStore.s(evData.game);
       } else {
         gameStore.updateGame(evData.game);
       }

--- a/src/plugins/sockets/inGameEvents.js
+++ b/src/plugins/sockets/inGameEvents.js
@@ -62,7 +62,7 @@ export async function handleInGameEvents(evData, newRoute = null) {
       break;
     case SocketEvent.RESOLVE:
       if (evData.game.lastEvent?.oneOff?.rank === 7) {
-        await gameStore.processResolveSeven(evData.game);
+        await gameStore.processSeven(evData.game);
       } else {
         gameStore.updateGame(evData.game);
       }

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -166,7 +166,10 @@
               >
                 <div
                   class="seven-card-wrapper"
-                  :class="{ 'seven-card-offset': !gameStore.firstCardRevealed }"
+                  :class="{
+                    'seven-card-offset': !gameStore.firstCardRevealed,
+                    'seven-card-revealing': gameStore.firstCardRevealed,
+                  }"
                 >
                   <GameCard
                     :suit="gameStore.firstCardRevealed ? topCard?.suit : undefined"
@@ -180,7 +183,10 @@
                 </div>
                 <div
                   class="seven-card-wrapper"
-                  :class="{ 'seven-card-offset': !gameStore.secondCardRevealed }"
+                  :class="{
+                    'seven-card-offset': !gameStore.secondCardRevealed,
+                    'seven-card-revealing': gameStore.secondCardRevealed,
+                  }"
                 >
                   <GameCard
                     :suit="gameStore.secondCardRevealed ? secondCard?.suit : undefined"
@@ -1229,15 +1235,30 @@ export default {
       }
 
       & .seven-card-wrapper {
-        transition: transform var(--duration-slow);
+        // `translate` and `rotate` are independent CSS properties — no `transform` conflict
+        transition: translate var(--duration-slow);
 
         &.seven-card-offset {
-          transform: rotate(12deg) translateX(72px);
+          translate: 72px 0;
         }
       }
 
       & .resolving-seven-card {
         width: 9.5rem;
+      }
+
+      // Rotation builds up in sync with each card's slide-in
+      & .seven-animating .seven-card-wrapper {
+        animation: sevenWrapperRotateIn var(--duration-normal) ease-out both;
+      }
+
+      & .seven-animating .seven-card-wrapper:nth-child(2) {
+        animation-delay: calc(var(--duration-normal) + var(--duration-slow));
+      }
+
+      // On reveal, rotation returns to neutral (higher specificity overrides RotateIn)
+      & .seven-animating .seven-card-wrapper.seven-card-revealing {
+        animation: sevenWrapperRotateOut var(--duration-slow) ease-out both;
       }
 
       & .seven-animating .resolving-seven-card {

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -155,40 +155,48 @@
               </h1>
             </template>
 
-            <Transition name="seven-reveal">
+            <div
+              v-if="gameStore.resolvingSeven || gameStore.showingSevenReveal"
+              class="seven-reveal-outer"
+              :class="{ 'seven-animating': gameStore.showingSevenReveal }"
+            >
               <div
-                v-if="gameStore.resolvingSeven || gameStore.showingSevenReveal"
-                class="seven-reveal-outer"
+                id="seven-reveal-inner"
+                class="d-flex"
               >
                 <div
-                  id="seven-reveal-inner"
-                  class="d-flex"
-                  :class="{ 'seven-pre-flip': gameStore.showingSevenReveal }"
+                  class="seven-card-wrapper"
+                  :class="{ 'seven-card-offset': !gameStore.firstCardRevealed }"
                 >
                   <GameCard
-                    :suit="gameStore.showingSevenReveal ? undefined : topCard?.suit"
-                    :rank="gameStore.showingSevenReveal ? undefined : topCard?.rank"
-                    :data-top-card="!gameStore.showingSevenReveal && topCard
+                    :suit="gameStore.firstCardRevealed ? topCard?.suit : undefined"
+                    :rank="gameStore.firstCardRevealed ? topCard?.rank : undefined"
+                    :data-top-card="(gameStore.firstCardRevealed && topCard)
                       ? `${topCard.rank}-${topCard.suit}` : undefined"
                     :is-selected="topCardIsSelected"
                     class="mb-4 resolving-seven-card"
                     @click="selectTopCard"
                   />
+                </div>
+                <div
+                  class="seven-card-wrapper"
+                  :class="{ 'seven-card-offset': !gameStore.secondCardRevealed }"
+                >
                   <GameCard
-                    :suit="gameStore.showingSevenReveal ? undefined : secondCard?.suit"
-                    :rank="gameStore.showingSevenReveal ? undefined : secondCard?.rank"
-                    :data-second-card="!gameStore.showingSevenReveal && secondCard
+                    :suit="gameStore.secondCardRevealed ? secondCard?.suit : undefined"
+                    :rank="gameStore.secondCardRevealed ? secondCard?.rank : undefined"
+                    :data-second-card="(gameStore.secondCardRevealed && secondCard)
                       ? `${secondCard.rank}-${secondCard.suit}` : undefined"
                     :is-selected="secondCardIsSelected"
                     class="mb-4 resolving-seven-card"
                     @click="selectSecondCard"
                   />
                 </div>
-                <p v-if="gameStore.resolvingSeven" class="seven-reveal-label mt-2">
-                  {{ t('game.playFromDeck') }}
-                </p>
               </div>
-            </Transition>
+              <p class="seven-reveal-label mt-2">
+                {{ t('game.playFromDeck') }}
+              </p>
+            </div>
           </v-card>
           <ScrapPile :scrap="scrap" />
         </div>
@@ -1191,7 +1199,7 @@ export default {
       background: rgba(0, 0, 0, 0.32);
       opacity: 0;
       border-radius: 9px;
-      transition: opacity var(--duration-slow);
+      transition: opacity var(--duration-normal);
       pointer-events: none;
     }
     &.reveal-top-two {
@@ -1212,10 +1220,6 @@ export default {
         overflow: visible;
       }
 
-      & #seven-reveal-inner {
-        transition: transform var(--duration-fast) ease-in;
-      }
-
       & .seven-reveal-label {
         position: absolute;
         top: 0.5rem;
@@ -1224,8 +1228,24 @@ export default {
         color: white;
       }
 
+      & .seven-card-wrapper {
+        transition: transform var(--duration-slow);
+
+        &.seven-card-offset {
+          transform: rotate(12deg) translateX(72px);
+        }
+      }
+
       & .resolving-seven-card {
         width: 9.5rem;
+      }
+
+      & .seven-animating .resolving-seven-card {
+        animation: sevenCardSlideIn var(--duration-normal) ease-out both;
+      }
+
+      & .seven-animating .seven-card-wrapper:nth-child(2) .resolving-seven-card {
+        animation-delay: calc(var(--duration-normal) + var(--duration-slow));
       }
     }
     & #empty-deck-text {

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -1205,30 +1205,31 @@ export default {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    background-color: rgba(255, 255, 255, 0);
-    background-size: cover;
+    background-color: transparent;
     margin: 10px;
     height: 29vh;
     width: calc(29vh / 1.3);
+    isolation: isolate;
     transition: width var(--duration-fast) ease-in-out;
-    background-image: url('/img/game/bg-deck.png');
     contain: var(--contain-isolated);
     &::before {
       content: '';
       position: absolute;
       inset: 0;
-      background: rgba(0, 0, 0, 0.32);
-      opacity: 0;
-      border-radius: 9px;
-      transition: opacity var(--duration-normal);
+      background-image: url('/img/game/bg-deck.png');
+      background-size: cover;
+      border-radius: inherit;
+      filter: brightness(1);
+      transition: filter var(--duration-normal);
       pointer-events: none;
+      z-index: -1;
     }
     &.reveal-top-two {
       z-index: 1;
       overflow: visible;
       contain: none;
       &::before {
-        opacity: 1;
+        filter: brightness(0.68);
       }
 
       & .seven-reveal-outer {

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -569,6 +569,8 @@ export default {
         case 'jack':
         case 'sevenJack':
           return Transitions.SLIDE_UP;
+        case 'sevenPoints':
+          return Transitions.SLIDE_UP_LEFT;
         default:
           return Transitions.SLIDE_DOWN_LEFT;
       }
@@ -582,6 +584,12 @@ export default {
       ) {
         return Transitions.SLIDE_DOWN;
       }
+
+      // Playing from the deck
+      if (this.gameStore.lastEventChange === 'sevenFaceCard') {
+        return Transitions.SLIDE_UP_LEFT;
+      }
+
       // Defaults in below (from hand) out left (to scrap)
       return Transitions.SLIDE_DOWN_LEFT;
     },

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -1232,7 +1232,6 @@ export default {
         width: 100%;
         text-align: center;
         color: rgba(var(--v-theme-base-light));
-        // color: white;
         font-size: 32px;
         font-weight: bold;
         font-family: Changa;
@@ -1240,7 +1239,6 @@ export default {
 
       & .seven-card-wrapper {
         margin-top: 32px;
-        // `translate` and `rotate` are independent CSS properties — no `transform` conflict
         transition: translate var(--duration-slow);
 
         &.seven-card-offset {

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -142,11 +142,11 @@
         <div id="field-left">
           <v-card
             id="deck"
-            :class="{ 'reveal-top-two': gameStore.resolvingSeven || gameStore.showingSevenReveal }"
+            :class="{ 'reveal-top-two': gameStore.resolvingSeven }"
             elevation="0"
             @click="drawCard"
           >
-            <template v-if="!gameStore.resolvingSeven && !gameStore.showingSevenReveal">
+            <template v-if="!gameStore.resolvingSeven">
               <v-card-actions class="c-deck-count">
                 ({{ deckLength }})
               </v-card-actions>
@@ -156,7 +156,7 @@
             </template>
 
             <div
-              v-if="gameStore.resolvingSeven || gameStore.showingSevenReveal"
+              v-if="gameStore.resolvingSeven"
               class="seven-reveal-outer"
               :class="{ 'seven-animating': gameStore.showingSevenReveal }"
             >

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -142,11 +142,11 @@
         <div id="field-left">
           <v-card
             id="deck"
-            :class="{ 'reveal-top-two': gameStore.resolvingSeven }"
+            :class="{ 'reveal-top-two': gameStore.resolvingSeven || gameStore.showingSevenReveal }"
             elevation="0"
             @click="drawCard"
           >
-            <template v-if="!gameStore.resolvingSeven">
+            <template v-if="!gameStore.resolvingSeven && !gameStore.showingSevenReveal">
               <v-card-actions class="c-deck-count">
                 ({{ deckLength }})
               </v-card-actions>
@@ -155,31 +155,40 @@
               </h1>
             </template>
 
-            <template v-if="gameStore.resolvingSeven">
-              <p class="mt-2">
-                {{ t('game.playFromDeck') }}
-              </p>
-              <div class="d-flex">
-                <GameCard
-                  v-if="topCard"
-                  :suit="topCard.suit"
-                  :rank="topCard.rank"
-                  :data-top-card="`${topCard.rank}-${topCard.suit}`"
-                  :is-selected="topCardIsSelected"
-                  class="mb-4 resolving-seven-card"
-                  @click="selectTopCard"
-                />
-                <GameCard
-                  v-if="secondCard"
-                  :suit="secondCard.suit"
-                  :rank="secondCard.rank"
-                  :data-second-card="`${secondCard.rank}-${secondCard.suit}`"
-                  :is-selected="secondCardIsSelected"
-                  class="mb-4 resolving-seven-card"
-                  @click="selectSecondCard"
-                />
+            <Transition name="seven-reveal">
+              <div
+                v-if="gameStore.resolvingSeven || gameStore.showingSevenReveal"
+                class="seven-reveal-outer"
+              >
+                <div
+                  id="seven-reveal-inner"
+                  class="d-flex"
+                  :class="{ 'seven-pre-flip': gameStore.showingSevenReveal }"
+                >
+                  <GameCard
+                    :suit="gameStore.showingSevenReveal ? undefined : topCard?.suit"
+                    :rank="gameStore.showingSevenReveal ? undefined : topCard?.rank"
+                    :data-top-card="!gameStore.showingSevenReveal && topCard
+                      ? `${topCard.rank}-${topCard.suit}` : undefined"
+                    :is-selected="topCardIsSelected"
+                    class="mb-4 resolving-seven-card"
+                    @click="selectTopCard"
+                  />
+                  <GameCard
+                    :suit="gameStore.showingSevenReveal ? undefined : secondCard?.suit"
+                    :rank="gameStore.showingSevenReveal ? undefined : secondCard?.rank"
+                    :data-second-card="!gameStore.showingSevenReveal && secondCard
+                      ? `${secondCard.rank}-${secondCard.suit}` : undefined"
+                    :is-selected="secondCardIsSelected"
+                    class="mb-4 resolving-seven-card"
+                    @click="selectSecondCard"
+                  />
+                </div>
+                <p v-if="gameStore.resolvingSeven" class="seven-reveal-label mt-2">
+                  {{ t('game.playFromDeck') }}
+                </p>
               </div>
-            </template>
+            </Transition>
           </v-card>
           <ScrapPile :scrap="scrap" />
         </div>
@@ -1175,12 +1184,45 @@ export default {
     transition: width var(--duration-fast) ease-in-out;
     background-image: url('/img/game/bg-deck.png');
     contain: var(--contain-isolated);
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.32);
+      opacity: 0;
+      border-radius: 9px;
+      transition: opacity var(--duration-slow);
+      pointer-events: none;
+    }
     &.reveal-top-two {
-      color: white;
-      background-image: none;
-      width: calc(29vh * 1.5);
-      max-width: 300px;
       z-index: 1;
+      overflow: visible;
+      contain: none;
+      &::before {
+        opacity: 1;
+      }
+
+      & .seven-reveal-outer {
+        flex: 1;
+        align-self: stretch;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+        overflow: visible;
+      }
+
+      & #seven-reveal-inner {
+        transition: transform var(--duration-fast) ease-in;
+      }
+
+      & .seven-reveal-label {
+        position: absolute;
+        top: 0.5rem;
+        width: 100%;
+        text-align: center;
+        color: white;
+      }
 
       & .resolving-seven-card {
         width: 9.5rem;

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -1228,13 +1228,18 @@ export default {
 
       & .seven-reveal-label {
         position: absolute;
-        top: 0.5rem;
+        top: -42px;
         width: 100%;
         text-align: center;
-        color: white;
+        color: rgba(var(--v-theme-base-light));
+        // color: white;
+        font-size: 32px;
+        font-weight: bold;
+        font-family: Changa;
       }
 
       & .seven-card-wrapper {
+        margin-top: 32px;
         // `translate` and `rotate` are independent CSS properties — no `transform` conflict
         transition: translate var(--duration-slow);
 

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -1244,9 +1244,8 @@ export default {
 
       & .seven-reveal-label {
         position: absolute;
-        top: -42px;
+        top: -48px;
         width: 100%;
-        text-align: center;
         color: rgba(var(--v-theme-base-light));
         font-size: 32px;
         font-weight: bold;

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -1539,6 +1539,17 @@ export default {
     & #deck {
       height: 13vh;
       width: calc(13vh / 1.3);
+
+      &.reveal-top-two .resolving-seven-card {
+        width: calc(13vh / 1.3);
+      }
+
+      &.reveal-top-two .seven-reveal-label {
+        font-size: 18px;
+        width: max-content;
+        left: 50%;
+        transform: translate(-50%, 24px);
+      }
     }
   }
   #opponent-hand {

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -1541,7 +1541,7 @@ export default {
       width: calc(13vh / 1.3);
 
       &.reveal-top-two .resolving-seven-card {
-        width: calc(13vh / 1.3);
+        width: calc(13vh / 1.7);
       }
 
       &.reveal-top-two .seven-reveal-label {

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -600,7 +600,7 @@ export default {
         case 'sevenJack':
           return Transitions.SLIDE_DOWN;
         case 'sevenPoints':
-          return this.$vuetify.display.xs ? Transitions.SLIDE_DOWN : Transitions.ENTER_FROM_LOWER_LEFT;
+          return this.$vuetify.display.xs ? Transitions.SLIDE_DOWN : Transitions.ENTER_FROM_LEFT;
         case 'resolve':
           // Different one-offs cause different direction transitions
           switch (this.gameStore.lastEventOneOffRank) {
@@ -637,7 +637,7 @@ export default {
       }
       // Playing from the deck
       if (this.gameStore.lastEventChange === 'sevenFaceCard') {
-        return this.$vuetify.display.xs ? Transitions.SLIDE_DOWN : Transitions.ENTER_FROM_LOWER_LEFT;
+        return this.$vuetify.display.xs ? Transitions.SLIDE_DOWN : Transitions.ENTER_FROM_LEFT;
       }
 
       // Otherwise in from opponent hand, out towards scrap

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -570,7 +570,7 @@ export default {
         case 'sevenJack':
           return Transitions.SLIDE_UP;
         case 'sevenPoints':
-          return Transitions.SLIDE_UP_LEFT;
+          return this.$vuetify.display.xs ? Transitions.SLIDE_DOWN : Transitions.ENTER_FROM_UPPER_LEFT;
         default:
           return Transitions.SLIDE_DOWN_LEFT;
       }
@@ -587,7 +587,7 @@ export default {
 
       // Playing from the deck
       if (this.gameStore.lastEventChange === 'sevenFaceCard') {
-        return Transitions.SLIDE_UP_LEFT;
+        return this.$vuetify.display.xs ? Transitions.SLIDE_DOWN : Transitions.ENTER_FROM_UPPER_LEFT;
       }
 
       // Defaults in below (from hand) out left (to scrap)
@@ -599,6 +599,8 @@ export default {
         case 'jack':
         case 'sevenJack':
           return Transitions.SLIDE_DOWN;
+        case 'sevenPoints':
+          return this.$vuetify.display.xs ? Transitions.SLIDE_DOWN : Transitions.ENTER_FROM_LOWER_LEFT;
         case 'resolve':
           // Different one-offs cause different direction transitions
           switch (this.gameStore.lastEventOneOffRank) {
@@ -633,6 +635,11 @@ export default {
       ) {
         return Transitions.SLIDE_UP;
       }
+      // Playing from the deck
+      if (this.gameStore.lastEventChange === 'sevenFaceCard') {
+        return this.$vuetify.display.xs ? Transitions.SLIDE_DOWN : Transitions.ENTER_FROM_LOWER_LEFT;
+      }
+
       // Otherwise in from opponent hand, out towards scrap
       return Transitions.SLIDE_UP_DOWN;
     },

--- a/src/routes/game/components/ScrapPile.vue
+++ b/src/routes/game/components/ScrapPile.vue
@@ -314,7 +314,7 @@ function openDialog(e) {
   }
 
   #scrap .scrap-card.scrap-enter-from {
-    transform: translateY(-200px);
+    transform: translateY(-80px);
     opacity: 0;
   }
 }

--- a/src/sass/transitions.scss
+++ b/src/sass/transitions.scss
@@ -16,10 +16,12 @@
 .slide-down-enter-active,
 .slide-up-enter-active,
 .slide-down-left-enter-active,
+.slide-up-left-enter-active,
 .slide-up-down-enter-active,
 .slide-down-leave-active,
 .slide-up-leave-active,
 .slide-down-left-leave-active,
+.slide-up-left-leave-active,
 .slide-up-down-leave-active {
   transition: opacity var(--duration-slow), transform var(--duration-slow);
 }
@@ -27,6 +29,7 @@
 .slide-down-leave-active,
 .slide-up-leave-active,
 .slide-down-left-leave-active,
+.slide-up-left-leave-active,
 .slide-up-down-leave-active {
   position: absolute;
 }
@@ -34,6 +37,7 @@
 .slide-down-move,
 .slide-up-move,
 .slide-down-left-move,
+.slide-up-left-move,
 .slide-up-down-move {
   transition: transform var(--duration-slow);
 }
@@ -56,6 +60,16 @@
 }
 
 .slide-down-left-leave-to {
+  opacity: 0;
+  transform: translateX(-32px);
+}
+
+.slide-up-left-enter-from {
+  opacity: 0;
+  transform: translate(-32px, -32px);
+}
+
+.slide-up-left-leave-to {
   opacity: 0;
   transform: translateX(-32px);
 }

--- a/src/sass/transitions.scss
+++ b/src/sass/transitions.scss
@@ -17,13 +17,13 @@
 .slide-up-enter-active,
 .slide-down-left-enter-active,
 .enter-from-upper-left-enter-active,
-.enter-from-lower-left-enter-active,
+.enter-from-left-enter-active,
 .slide-up-down-enter-active,
 .slide-down-leave-active,
 .slide-up-leave-active,
 .slide-down-left-leave-active,
 .enter-from-upper-left-leave-active,
-.enter-from-lower-left-leave-active,
+.enter-from-left-leave-active,
 .slide-up-down-leave-active {
   transition: opacity var(--duration-slow), transform var(--duration-slow);
 }
@@ -32,7 +32,7 @@
 .slide-up-leave-active,
 .slide-down-left-leave-active,
 .enter-from-upper-left-leave-active,
-.enter-from-lower-left-leave-active,
+.enter-from-left-leave-active,
 .slide-up-down-leave-active {
   position: absolute;
 }
@@ -41,7 +41,7 @@
 .slide-up-move,
 .slide-down-left-move,
 .enter-from-upper-left-move,
-.enter-from-lower-left-move,
+.enter-from-left-move,
 .slide-up-down-move {
   transition: transform var(--duration-slow);
 }
@@ -78,12 +78,12 @@
   transform: translateX(-32px);
 }
 
-.enter-from-lower-left-enter-from {
+.enter-from-left-enter-from {
   opacity: 0;
-  transform: translate(-32px, 32px);
+  transform: translateX(-32px);
 }
 
-.enter-from-lower-left-leave-to {
+.enter-from-left-leave-to {
   opacity: 0;
   transform: translateX(-32px);
 }

--- a/src/sass/transitions.scss
+++ b/src/sass/transitions.scss
@@ -101,10 +101,10 @@
 // with the wrapper's `translate` transition and the card's `transform` animation.
 @keyframes sevenWrapperRotateIn {
   from { rotate: 0deg; }
-  to { rotate: 12deg; }
+  to { rotate: 8deg; }
 }
 
 @keyframes sevenWrapperRotateOut {
-  from { rotate: 12deg; }
+  from { rotate: 8deg; }
   to { rotate: 0deg; }
 }

--- a/src/sass/transitions.scss
+++ b/src/sass/transitions.scss
@@ -83,15 +83,28 @@
 }
 
 // Per-card staggered slide-in for seven reveal.
-// Each card slides from left into its natural flex position, one at a time.
+// Card starts at deck center (wrapper's translate offset cancels the card start offset).
 // animation-fill-mode: both keeps card 2 invisible during its delay.
 @keyframes sevenCardSlideIn {
   from {
     opacity: 0;
-    transform: translateX(-64px);
+    transform: translateX(-72px);
   }
   to {
     opacity: 1;
     transform: translateX(0);
   }
+}
+
+// Wrapper rotation: builds up in sync with the card's slide-in, reverses on reveal.
+// Uses the CSS `rotate` property (separate from `transform`) so it composes cleanly
+// with the wrapper's `translate` transition and the card's `transform` animation.
+@keyframes sevenWrapperRotateIn {
+  from { rotate: 0deg; }
+  to { rotate: 12deg; }
+}
+
+@keyframes sevenWrapperRotateOut {
+  from { rotate: 12deg; }
+  to { rotate: 0deg; }
 }

--- a/src/sass/transitions.scss
+++ b/src/sass/transitions.scss
@@ -82,24 +82,16 @@
   transform: rotateY(0deg);
 }
 
-// Seven reveal: outer container slides in from the left when deck cards first appear
-.seven-reveal-enter-active {
-  transition: opacity var(--duration-normal), transform var(--duration-slow);
-}
-
-.seven-reveal-enter-from {
-  opacity: 0;
-  transform: translateX(0px);
-}
-.seven-reveal-enter-to {
-  transform: translateX(64px);
-}
-
-// Pre-flip offset: inner card row shifted right during face-down preview so the
-// cards sit visibly off-center to the right of the deck image.
-// Class is removed simultaneously with suit/rank props being set, so the
-// leftward slide and the CARD_FLIP transition inside each card fire together.
-.seven-pre-flip {
-  transform: translateX(64px);
-  transition: transform var(--duration-slow);
+// Per-card staggered slide-in for seven reveal.
+// Each card slides from left into its natural flex position, one at a time.
+// animation-fill-mode: both keeps card 2 invisible during its delay.
+@keyframes sevenCardSlideIn {
+  from {
+    opacity: 0;
+    transform: translateX(-64px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }

--- a/src/sass/transitions.scss
+++ b/src/sass/transitions.scss
@@ -16,12 +16,14 @@
 .slide-down-enter-active,
 .slide-up-enter-active,
 .slide-down-left-enter-active,
-.slide-up-left-enter-active,
+.enter-from-upper-left-enter-active,
+.enter-from-lower-left-enter-active,
 .slide-up-down-enter-active,
 .slide-down-leave-active,
 .slide-up-leave-active,
 .slide-down-left-leave-active,
-.slide-up-left-leave-active,
+.enter-from-upper-left-leave-active,
+.enter-from-lower-left-leave-active,
 .slide-up-down-leave-active {
   transition: opacity var(--duration-slow), transform var(--duration-slow);
 }
@@ -29,7 +31,8 @@
 .slide-down-leave-active,
 .slide-up-leave-active,
 .slide-down-left-leave-active,
-.slide-up-left-leave-active,
+.enter-from-upper-left-leave-active,
+.enter-from-lower-left-leave-active,
 .slide-up-down-leave-active {
   position: absolute;
 }
@@ -37,7 +40,8 @@
 .slide-down-move,
 .slide-up-move,
 .slide-down-left-move,
-.slide-up-left-move,
+.enter-from-upper-left-move,
+.enter-from-lower-left-move,
 .slide-up-down-move {
   transition: transform var(--duration-slow);
 }
@@ -64,12 +68,22 @@
   transform: translateX(-32px);
 }
 
-.slide-up-left-enter-from {
+.enter-from-upper-left-enter-from {
   opacity: 0;
   transform: translate(-32px, -32px);
 }
 
-.slide-up-left-leave-to {
+.enter-from-upper-left-leave-to {
+  opacity: 0;
+  transform: translateX(-32px);
+}
+
+.enter-from-lower-left-enter-from {
+  opacity: 0;
+  transform: translate(-32px, 32px);
+}
+
+.enter-from-lower-left-leave-to {
   opacity: 0;
   transform: translateX(-32px);
 }

--- a/src/sass/transitions.scss
+++ b/src/sass/transitions.scss
@@ -81,3 +81,25 @@
 .card-flip-enter-to {
   transform: rotateY(0deg);
 }
+
+// Seven reveal: outer container slides in from the left when deck cards first appear
+.seven-reveal-enter-active {
+  transition: opacity var(--duration-normal), transform var(--duration-slow);
+}
+
+.seven-reveal-enter-from {
+  opacity: 0;
+  transform: translateX(0px);
+}
+.seven-reveal-enter-to {
+  transform: translateX(64px);
+}
+
+// Pre-flip offset: inner card row shifted right during face-down preview so the
+// cards sit visibly off-center to the right of the deck image.
+// Class is removed simultaneously with suit/rank props being set, so the
+// leftward slide and the CARD_FLIP transition inside each card fire together.
+.seven-pre-flip {
+  transform: translateX(64px);
+  transition: transform var(--duration-slow);
+}

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -173,6 +173,8 @@ export const useGameStore = defineStore('game', () => {
   const playerWins = computed(() => gameIsOver.value && winnerPNum.value === myPNum.value);
   const resolvingSeven = computed(() => phase.value === GamePhase.RESOLVING_SEVEN);
   const showingSevenReveal = ref(false);
+  const firstCardRevealed = ref(true);
+  const secondCardRevealed = ref(true);
   const isPlayersTurn = computed(() => turn.value % 2 === myPNum.value);
   const hasGlassesEight = computed(() => {
     const faceCards = player.value?.faceCards ?? [];
@@ -406,9 +408,14 @@ export const useGameStore = defineStore('game', () => {
   }
   async function processResolveSeven(game) {
     showingSevenReveal.value = true;
-    await sleep(1000);
-    showingSevenReveal.value = false;
+    firstCardRevealed.value = false;
+    secondCardRevealed.value = false;
     updateGame(game);
+    await sleep(500); // card 1 entry animation
+    firstCardRevealed.value = true; // card 1 flips
+    await sleep(1500); // card 1 flip (1s) + card 2 entry (0.5s)
+    secondCardRevealed.value = true; // card 2 flips
+    showingSevenReveal.value = false;
   }
   function handleGameResponse(jwres, resolve, reject, returnFullResponse = false) {
     switch (jwres.statusCode) {
@@ -740,6 +747,8 @@ export const useGameStore = defineStore('game', () => {
     playerWins,
     resolvingSeven,
     showingSevenReveal,
+    firstCardRevealed,
+    secondCardRevealed,
     isPlayersTurn,
     hasGlassesEight,
     iWantRematch,

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -406,7 +406,7 @@ export const useGameStore = defineStore('game', () => {
     }
     updateGame(game);
   }
-  async function processSeven(game) {
+  async function processSevens(game) {
     showingSevenReveal.value = true;
     firstCardRevealed.value = false;
     secondCardRevealed.value = false;
@@ -781,7 +781,7 @@ export const useGameStore = defineStore('game', () => {
     processThrees,
     processFours,
     processFives,
-    processSeven,
+    processSevens,
     handleGameResponse,
     transformGameUrl,
     makeSocketRequest,

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -414,7 +414,8 @@ export const useGameStore = defineStore('game', () => {
     await sleep(500); // card 1 entry animation
     firstCardRevealed.value = true; // card 1 flips
     await sleep(1500); // card 1 flip (1s) + card 2 entry (0.5s)
-    secondCardRevealed.value = true; // card 2 flips
+    secondCardRevealed.value = true; // card 2 flips + rotates back
+    await sleep(1000); // wait for card 2's sevenWrapperRotateOut to finish before removing .seven-animating
     showingSevenReveal.value = false;
   }
   function handleGameResponse(jwres, resolve, reject, returnFullResponse = false) {

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -1,4 +1,4 @@
-import { ref, computed } from 'vue';
+import { ref, computed, nextTick } from 'vue';
 import { defineStore } from 'pinia';
 import { useAuthStore } from '@/stores/auth';
 import { useGameHistoryStore } from '@/stores/gameHistory';
@@ -411,7 +411,7 @@ export const useGameStore = defineStore('game', () => {
     firstCardRevealed.value = false;
     secondCardRevealed.value = false;
     updateGame(game);
-    await sleep(500); // card 1 entry animation
+    await nextTick(); // card 1 entry animation
     firstCardRevealed.value = true; // card 1 flips
     await sleep(1500); // card 1 flip (1s) + card 2 entry (0.5s)
     secondCardRevealed.value = true; // card 2 flips + rotates back

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -172,6 +172,7 @@ export const useGameStore = defineStore('game', () => {
   const opponentQueenCount = computed(() => queenCount(opponent.value));
   const playerWins = computed(() => gameIsOver.value && winnerPNum.value === myPNum.value);
   const resolvingSeven = computed(() => phase.value === GamePhase.RESOLVING_SEVEN);
+  const showingSevenReveal = ref(false);
   const isPlayersTurn = computed(() => turn.value % 2 === myPNum.value);
   const hasGlassesEight = computed(() => {
     const faceCards = player.value?.faceCards ?? [];
@@ -401,6 +402,12 @@ export const useGameStore = defineStore('game', () => {
       ];
       await sleep(1000);
     }
+    updateGame(game);
+  }
+  async function processResolveSeven(game) {
+    showingSevenReveal.value = true;
+    await sleep(1000);
+    showingSevenReveal.value = false;
     updateGame(game);
   }
   function handleGameResponse(jwres, resolve, reject, returnFullResponse = false) {
@@ -732,6 +739,7 @@ export const useGameStore = defineStore('game', () => {
     opponentQueenCount,
     playerWins,
     resolvingSeven,
+    showingSevenReveal,
     isPlayersTurn,
     hasGlassesEight,
     iWantRematch,
@@ -763,6 +771,7 @@ export const useGameStore = defineStore('game', () => {
     processThrees,
     processFours,
     processFives,
+    processResolveSeven,
     handleGameResponse,
     transformGameUrl,
     makeSocketRequest,

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -406,7 +406,7 @@ export const useGameStore = defineStore('game', () => {
     }
     updateGame(game);
   }
-  async function processResolveSeven(game) {
+  async function processSeven(game) {
     showingSevenReveal.value = true;
     firstCardRevealed.value = false;
     secondCardRevealed.value = false;
@@ -781,7 +781,7 @@ export const useGameStore = defineStore('game', () => {
     processThrees,
     processFours,
     processFives,
-    processResolveSeven,
+    processSeven,
     handleGameResponse,
     transformGameUrl,
     makeSocketRequest,

--- a/utils/Transitions.json
+++ b/utils/Transitions.json
@@ -2,7 +2,8 @@
   "SLIDE_DOWN": "slide-down",
   "SLIDE_UP": "slide-up",
   "SLIDE_DOWN_LEFT": "slide-down-left",
-  "SLIDE_UP_LEFT": "slide-up-left",
+  "ENTER_FROM_UPPER_LEFT": "enter-from-upper-left",
+  "ENTER_FROM_LEFT": "enter-from-left",
   "SLIDE_UP_DOWN": "slide-up-down",
   "CARD_FLIP": "card-flip"
 }

--- a/utils/Transitions.json
+++ b/utils/Transitions.json
@@ -2,6 +2,7 @@
   "SLIDE_DOWN": "slide-down",
   "SLIDE_UP": "slide-up",
   "SLIDE_DOWN_LEFT": "slide-down-left",
+  "SLIDE_UP_LEFT": "slide-up-left",
   "SLIDE_UP_DOWN": "slide-up-down",
   "CARD_FLIP": "card-flip"
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
WORK IN PROGRESS - opening PR to run tests

Adds animated transition when cards are revealed from top of deck with a 7

https://github.com/user-attachments/assets/88045019-1e3c-471a-8886-350eab1e8384


## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
