### PR TITLE
style(GameView): fix play from deck label responsiveness

### DIFF
--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -1248,8 +1248,10 @@ export default {
         left: 50%;
         transform: translateX(-50%);
         width: max-content;
+        max-width: 25vw;
+        text-align: center;
         color: rgba(var(--v-theme-base-light));
-        font-size: 32px;
+        font-size: min(32px, 2.3vw);
         font-weight: bold;
         font-family: Changa;
       }

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -1245,7 +1245,9 @@ export default {
       & .seven-reveal-label {
         position: absolute;
         top: -48px;
-        width: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        width: max-content;
         color: rgba(var(--v-theme-base-light));
         font-size: 32px;
         font-weight: bold;

--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -1207,8 +1207,8 @@ export default {
     align-items: center;
     background-color: transparent;
     margin: 10px;
-    height: 29vh;
-    width: calc(29vh / 1.3);
+    height: min(29vh, calc((25vw - 20px) * 1.3));
+    width: min(calc(29vh / 1.3), calc(25vw - 20px));
     isolation: isolate;
     transition: width var(--duration-fast) ease-in-out;
     contain: var(--contain-isolated);
@@ -1264,7 +1264,7 @@ export default {
       }
 
       & .resolving-seven-card {
-        width: 9.5rem;
+        width: min(9.5rem, 12vw);
       }
 
       // Rotation builds up in sync with each card's slide-in


### PR DESCRIPTION
<!-- Thanks for contributing to Cuttle! 🎉 -->
Fixes responsiveness issue where 'play from deck' label was spilling to multiple lines

Old
<img width="1263" height="653" alt="image" src="https://github.com/user-attachments/assets/04a372a6-fa81-4cd3-bdcd-c3f844368ee7" />


New
<img width="1139" height="673" alt="image" src="https://github.com/user-attachments/assets/cd4260b5-8b66-4b9c-bae0-53db4bdb31b6" />


## Issue number

Relevant [issue number](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- Resolves #

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
