### PR TITLE
fix(GameView): wrap top cards in v-if

### DIFF
--- a/src/routes/game/GameView.vue
+++ b/src/routes/game/GameView.vue
@@ -172,6 +172,7 @@
                   }"
                 >
                   <GameCard
+                    v-if="topCard"
                     :suit="gameStore.firstCardRevealed ? topCard?.suit : undefined"
                     :rank="gameStore.firstCardRevealed ? topCard?.rank : undefined"
                     :data-top-card="(gameStore.firstCardRevealed && topCard)
@@ -182,6 +183,7 @@
                   />
                 </div>
                 <div
+                  v-if="secondCard"
                   class="seven-card-wrapper"
                   :class="{
                     'seven-card-offset': !gameStore.secondCardRevealed,


### PR DESCRIPTION

Fixes issue where the second card will appear as a card back during initial seven reveal, then disappear if there is no second card (on last card of deck).

## Please check the following

- [ ] Do the tests still pass? (see [Run the Tests](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#run-the-tests))
- [ ] Is the code formatted properly? (see [Linting (Formatting)](https://github.com/cuttle-cards/cuttle/blob/main/docs/setup-development.md#linting-formatting))
- For New Features:
  - [ ] Have tests been added to cover any new features or fixes?
  - [ ] Has the documentation been updated accordingly?

## Please describe additional details for testing this change
